### PR TITLE
Update import logic to use `polars` instead of `pyarrow`, added logging

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -485,7 +485,8 @@ class ADMDatamart(Plots):
 
         for col in {"Performance"} & set(df.columns):
             df[col] = df[col].astype(float)
-
+        if 'SnapshotTime' not in df.columns:
+            df['SnapshotTime'] = np.nan
         try:
             df["SnapshotTime"] = pd.to_datetime(df["SnapshotTime"])
         except Exception:

--- a/python/pdstools/valuefinder/ValueFinder.py
+++ b/python/pdstools/valuefinder/ValueFinder.py
@@ -73,10 +73,8 @@ class ValueFinder:
             start = time.time()
             filename = kwargs.pop("filename", "ValueFinder")
             self.df = cdh_utils.readDSExport(
-                filename, path, return_pa=True, verbose=verbose
+                filename, path, return_pl=True, verbose=verbose
             )
-            if kwargs.get("subset", True):
-                self.df = self.df.select(keep_cols)
             if verbose:
                 print(f"Data import took {round(time.time() - start,2)} seconds")
 


### PR DESCRIPTION
With https://github.com/pola-rs/polars/issues/5687 closed, I've updated all import logic for pdstools to use polars over pyarrow. Since we make heavy use of ndjson, this issue was a blocker. All imports should now be much faster. 

Additionally, I've added some basic logging to the file import logic.