### PR TITLE
Streamlit

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -286,10 +286,20 @@ class ADMDatamart(Plots):
                 df2 = df2.join(df1.select(pl.col("ModelID").unique()), on="ModelID")
 
         if self.import_strategy == "eager":
-            if df1 is not None:
-                df1 = df1.collect().lazy()
-            if df2 is not None:
-                df2 = df2.collect().lazy()
+            try:
+                if df1 is not None:
+                    df1 = df1.collect().lazy()
+                if df2 is not None:
+                    df2 = df2.collect().lazy()
+            except pl.ComputeError as e:
+                raise Exception(
+                    """Unexpected Time format! 
+                        Please refer to :meth:`._set_types` to change datetime format \n
+                        If you are using HealthCheck app, use `Edit Parameters` button above
+                        and enter the date format in your files. \n
+                        You can check https://strftime.org/ for formatting options
+                        """
+                ) from e
         return df1, df2
 
     def _import_utils(

--- a/python/pdstools/app/HealthCheckModel.qmd
+++ b/python/pdstools/app/HealthCheckModel.qmd
@@ -1,0 +1,357 @@
+---
+title: "ADM Health Check"
+author: "Pega pdstools"
+format:
+  html:
+    code-fold: true
+    embed-resources: true
+    standalone: true
+    code-tools: true
+    toc: true
+    toc-title: Contents
+    theme:
+        light: flatly
+        dark: darkly
+jupyter: python3
+---
+```{python}
+#| label: Imports
+#| code-fold: true
+#| code-summary: Python imports
+#| output: false
+import logging, sys
+logging.disable()
+from IPython.display import display, Markdown
+def Text(d):
+   return display(Markdown(d))
+import sys
+sys.path.append('..')
+from pdstools import datasets, ADMDatamart
+from pdstools.utils import cdh_utils
+from pdstools.utils.cdh_utils import defaultPredictorCategorization
+from plotly.offline import iplot
+from itables import show
+import plotly.express as px
+import plotly.graph_objs as go
+import polars as pl
+import pandas as pd
+import numpy as np
+from pdstools.utils import pega_template 
+import math
+df_dict = {}
+
+
+```
+
+
+```{python}
+#| tags: [parameters]
+#| echo: false
+
+# These parameters are overwritten when called by the app function.
+# Though if running this healthcheck separately, you can populate this cell.
+
+name = 'CDH Sample'
+filters = dict()
+kwargs = dict()
+globalQuery = None
+
+```
+
+```{python}
+#| tags: [initialization]
+#| code-fold: true
+#| code-summary: Initialization of the datamart class.
+
+# Initialize the class after the parameters have been overwritten.
+
+#datamart = ADMDatamart(**kwargs)
+datamart = ADMDatamart(predictor_filename=None, **kwargs)
+
+modelData = datamart.modelData.with_columns(pl.col(pl.Null).fill_null("NA"))
+
+ 
+last_data = (
+    datamart.last(strategy='lazy')
+    .with_columns(pl.col(pl.Categorical).cast(pl.Utf8))
+    .with_columns(
+        [
+            pl.col(pl.Utf8).fill_null("NA"),
+            pl.col(pl.Null).fill_null("NA"),
+            pl.col("SuccessRate").fill_nan(0).fill_null(0),
+            pl.col("Performance").fill_nan(0).fill_null(0),
+            pl.col("ResponseCount").fill_null(0),
+            (pl.concat_str("Channel/Direction".split("/"), separator="/")).alias("Channel/Direction"),
+        ]
+    )
+).collect()
+datamart_all_columns = modelData.columns
+standardNBADNames = [
+    "Assisted_Click_Through_Rate",
+    "CallCenter_Click_Through_Rate",
+    "CallCenterAcceptRateOutbound",
+    "Default_Inbound_Model",
+    "Default_Outbound_Model",
+    "Email_Click_Through_Rate",
+    "Mobile_Click_Through_Rate",
+    "OmniAdaptiveModel",
+    "Other_Inbound_Click_Through_Rate",
+    "Push_Click_Through_Rate",
+    "Retail_Click_Through_Rate",
+    "Retail_Click_Through_Rate_Outbound",
+    "SMS_Click_Through_Rate",
+    "Web_Click_Through_Rate",
+]
+
+
+```
+
+This document gives a generic and global overview of the Adaptive models 
+and predictors. It is generated from a Python markdown file in the [Pega Data Scientist Tools](https://github.com/pegasystems/pega-datascientist-tools). That repository
+of tools and scripts also contains a notebook to generate stand-alone
+model reports for individual models, please refer 
+to the [Wiki](https://github.com/pegasystems/pega-datascientist-tools/wiki).
+
+This document provides a first-level scan of the models after which a 
+deeper and more customer specific deeper dive can be done.
+
+For best viewing results, open the 
+HTML document in a browser. Viewing it from platforms like e.g. Sharepoint or 
+Github will loose the interactive charts.
+
+Note that the notebook by default generates a single-page HTML, however you
+can also export to PDF as well as other formats supported by Pandoc (e.g. Word) 
+but you would loose interactivity.
+
+In the cell below, all data preprocessing is executed, such as importing the data and applying global filters. By default, the values are populated by environment variables supplied when running the file, but for customization purposes, you can edit this cell.
+
+# Overview of the Actions
+In a standard setup, the offers/conversations are presented as treatments for actions in a hierarchical structure setup in NBA Designer. The recommendation is to have multiple treatments for an action. Treatments are often channel specific and you would typically expect more unique treatments than there are actions.
+
+Adaptive Models are created per treatment (at least in the default setup) and the recommendation is to stick the default context keys of the models.
+```{python}
+datamart.context_keys
+context_keys= {'Channels':'Channel/Direction', 'Issues':'Issue', 'Groups':'Group','Actions':'Name', 'Treatments':'Treatment'}
+value_keys = ['Actions', 'Treatments','Issues', 'Groups', 'Channels']
+counts, values = dict(), dict()
+
+for label, column in context_keys.items():
+    if column in last_data.columns:
+        if label in value_keys:
+            datalist = ', '.join(filter(None, (last_data.select(context_keys[label]).to_series().unique().sort().to_list())[:5]))
+        else:
+            datalist = ''
+        n = last_data.select(column).to_series().n_unique()
+    else:
+        datalist, n = '', 0
+    counts[f'Number of {label}'] = [n, datalist]
+overview_of_adaptive_models = pd.DataFrame(counts, index=['Counts', 'Values']).T
+df_dict["overview_of_adaptive_models"] = overview_of_adaptive_models
+show(overview_of_adaptive_models, columnDefs=[{"className": "dt-left", "targets": "_all"}])
+```
+
+## Success Rates per Channel
+Showing the current success rate of the treatments. Different channels usually have very different success rates. Just showing the top 20 here and limiting to the propositions that have received at least 100 responses (the rates reported by the models are unreliable otherwise).
+
+### Guidance
+- Look out for propositions that stand out, having a far higher success rate than the rest. Check with business if that is expected.
+
+- Variation in the set of offered propositions across customers is also an important metric but not one that can be derived from the Adaptive Model data - this requires analysis of the actual interactions.
+```{python}
+facet = "Channel/Direction"
+hover_columns = ["Issue", "Group", "Name"]
+df = last_data.lazy().with_columns(pl.concat_str(facet.split("/"), separator="/").alias(facet)).with_columns(pl.col(pl.Categorical).cast(pl.Utf8))
+df = (
+    df
+    .filter(pl.col("ResponseCount") > 100)
+    .groupby(hover_columns + ["ModelID","Channel/Direction"])
+    .agg(
+        cdh_utils.weighed_average_polars("SuccessRate", "ResponseCount").alias(
+            "SuccessRate"
+        )
+    )
+    .with_columns(pl.col("SuccessRate").round(4))
+    .sort(["Channel/Direction", "SuccessRate"], descending=True)
+    .groupby(["Channel/Direction"])
+    .head(20)
+    .collect()
+).to_pandas(use_pyarrow_extension_array=True)
+
+hover_data = {
+    "SuccessRate": ":.2%",
+    "Issue": ":.d",
+    "Group": ":.d",
+    "Name": ":.d",
+}
+
+
+facet= "Channel/Direction"
+facet_col_wrap = 3
+fig = px.bar(
+    df.sort_values(["Channel/Direction", "SuccessRate"]),
+    x="SuccessRate",
+    y="ModelID",
+    color="SuccessRate",
+    facet_col=facet,
+    facet_col_wrap=facet_col_wrap,
+    template="pega",
+    text="Name",
+    title="Proposition success rates <br><sup>Issue/Group/Name/Treatment</sup>",
+    hover_data=hover_data,
+)
+fig.update_xaxes(tickformat=",.0%")
+fig.update_yaxes(matches=None, showticklabels=False, visible=False).update_xaxes(
+    matches=None,
+).update_traces(textposition="inside")
+fig.for_each_annotation(
+    lambda a: a.update(text=a.text.replace("Channel/Direction=", ""))
+)
+fig.update(layout_coloraxis_showscale=False)
+
+unique_count = datamart.last(strategy='lazy').with_columns(pl.concat_str(facet.split("/"), separator="/").alias(facet)).select(facet).collect().to_series().n_unique()
+
+height = 200 + (math.ceil( unique_count / facet_col_wrap) * 250)
+
+fig.update_layout(autosize=True, height=height)
+
+display(fig)
+```
+
+## All Success Rates
+Interactive chart with all success rates.
+
+```{python}
+fig = datamart.plotTreeMap(color_var="SuccessRate",
+                     groupby_col= None,
+                     levels=['Channel', 'Direction', 'Issue', 'Group', "Name"], 
+                     colorscale=pega_template.success)
+fig
+```
+
+## Success Rates over Time
+Showing how the overall channel success rates evolved over the time that the data export covers. Split by Channel and model configuration. Usually there are separate model configurations for different channels but sometimes there are also additional model configurations for different outcomes (e.g. conversion) or different customers (e.g. anonymous).
+
+### Guidance
+- There shouldn’t be too sudden changes over time
+```{python}
+by = "Channel/Direction"
+facet = "Configuration"
+fig = datamart.plotOverTime('SuccessRate', by=by, facets=facet, facet_col_wrap=2, query=pl.col("ResponseCount") > 100)
+fig.update_yaxes(matches=None)
+fig.for_each_yaxis(lambda yaxis: yaxis.update(showticklabels=True, rangemode="tozero"))
+unique_count = modelData.with_columns(pl.concat_str(facet.split("/"), separator="/").alias(facet)).select(facet).collect().unique().shape[0]
+height = 200 + (math.ceil( unique_count / 2) * 250)
+fig.update_layout(autosize=True, height=height)
+fig.for_each_annotation(
+    lambda a: a.update(text=a.text.replace(f"{facet}=", ""))
+)
+fig.for_each_xaxis(lambda xaxis: xaxis.update(showticklabels=True))
+fig.show()
+```
+
+# Overview of Adaptive Models
+The standard configuration is to have one model per treatment.
+
+```{python}
+model_overview = last_data.groupby(["Configuration", "Channel", "Direction"]).agg(
+    [
+        pl.col("Name").unique().count().alias("Number of Actions"),
+        pl.col("ModelID").unique().count().alias("Number of Models"),
+    ]
+).with_columns(
+    [
+    pl.col("Configuration").is_in(standardNBADNames).alias("Standard in NBAD Framework"),
+    (pl.col("Number of Models") / pl.col("Number of Actions")).round(2).alias("Average number of Treatments per Action")
+    ]
+).sort("Configuration").to_pandas(use_pyarrow_extension_array=True)
+show(model_overview)
+print(f"There are a total of {len(last_data.select('ModelID').unique())} unique models in the latest snapshot. \n " )
+```
+## Model Performance 
+ Recommended best practice is to have multiple treatments for an action. Too few gives less opportunity for personalization of the interactions.
+
+### Model Performance vs Action Success Rates (the Bubble Chart)
+This “Bubble Chart” - similar to the standard plot in the ADM reports in Pega - shows the relation between model performance and proposition success rates. In addition, the size of the bubbles indicates the number of responses.
+
+#### Guidance
+- If all the bubbles clutter too much on the left-hand side of the charts, this means the models are not predictive. These models may be still be ramping up, or they may not have predictive enough features to work with: consider if new/better predictors can be added.
+
+- Bubbles at the bottom of the charts represent propositions with very low success rates - they may not be compelling enough.
+
+- In an ideal scenario you will see the larger bubbles more on the top-right, so more volume for propositions with higher success rates and better models.
+
+- There should be a positive correlation between success rate and performance - per channel.
+
+- There should be a positive correlation between responses and performance - also per channel.
+
+- There should be variation in response counts (not all dots of equal size)
+
+- For small volumes of good models, see if the engagement rules in the Decision Strategy are overly restrictive or reconsider the arbitration of the propositions so they get more (or less) exposure.
+```{python}
+facet_col_wrap=2
+facet = 'Configuration/Channel/Direction'
+fig = datamart.plotPerformanceSuccessRateBubbleChart(facets=facet,facet_col_wrap=facet_col_wrap)
+fig.layout.coloraxis.colorscale = pega_template.success
+fig.for_each_xaxis(lambda xaxis: xaxis.update(showticklabels=True, visible=True))
+fig.for_each_xaxis(lambda xaxis: xaxis.update(dict(
+        tickmode = 'array',
+        tickvals = [50, 60, 70, 80, 90,100],
+    )))
+height = 250 + (math.ceil( len(fig.layout.annotations) / facet_col_wrap) * 270)
+fig.update_layout(autosize=True, height=height, title=None)
+
+fig.for_each_annotation(
+    lambda a: a.update(text=a.text.replace(f"{facet}=", ""))
+)
+fig.update_layout(font=dict(size=10))
+
+fig.for_each_annotation(lambda a: a.update(text="<br> ".join(a.text.split("/", 1))))
+fig.update_coloraxes(colorbar_len= 1 / math.ceil( len(fig.layout.annotations) / facet_col_wrap))
+
+fig.show()
+```
+
+### Model Performance over Time
+Showing how the model performance evolves over time. Note that ADM is by default configured to track performance over all time. You can configure a window for monitoring but this is not commonly done.
+
+Aggregating up to Channel and splitting by model configuration.
+
+#### Guidance
+- No abrupt changes but gradual upward trend is good
+```{python}
+facet = "Configuration"
+modelperformance = datamart.plotOverTime('weighted_performance', by="Channel/Direction", facets=facet, facet_col_wrap=2)
+
+unique_count = modelData.with_columns(pl.concat_str(facet.split("/"), separator="/").alias(facet)).select(facet).collect().unique().shape[0]
+height = 200 + (math.ceil( unique_count / 2) * 250)
+modelperformance.update_layout(autosize=True, height=height)
+modelperformance.for_each_annotation(
+    lambda a: a.update(text=a.text.replace(f"{facet}=", ""))
+)
+
+modelperformance.for_each_xaxis(lambda xaxis: xaxis.update(showticklabels=True))
+
+modelperformance.show()
+```
+
+### Model performance of all the actions (interactive Treemap)
+Using an interactive treemap to visualize the performance. Lighter is better, darker is low performance.
+
+It can be interesting to see which issues, groups or channels can be better predicted than others. Identifying categories of items for which the predictions are poor can help to drive the search for better predictors, for example.
+
+```{python}
+fig = datamart.plotTreeMap(color_var="performance_weighted", groupby_col= None, levels=['Channel', 'Direction', 'Issue', 'Group', "Name"])
+
+fig.show()
+```
+
+### Response counts for all the actions
+Using an interactive treemap to visualize the response counts.
+Different channels will have very different numbers but within one channel the relative differences in response counts give an indication how skewed the distribution is.
+
+Warning : Currently treemap calculates mean response count moving upwards in the hierarchy. 
+```{python}
+fig = datamart.plotTreeMap(color_var="responsecount", levels=['Channel', 'Direction', 'Issue', 'Group', "Name"], colorscale=pega_template.negative_positive)
+fig
+
+```

--- a/python/pdstools/app/HealthCheckModel.qmd
+++ b/python/pdstools/app/HealthCheckModel.qmd
@@ -65,7 +65,6 @@ globalQuery = None
 
 # Initialize the class after the parameters have been overwritten.
 
-#datamart = ADMDatamart(**kwargs)
 datamart = ADMDatamart(predictor_filename=None, **kwargs)
 
 modelData = datamart.modelData.with_columns(pl.col(pl.Null).fill_null("NA"))

--- a/python/pdstools/app/pds_app.py
+++ b/python/pdstools/app/pds_app.py
@@ -22,6 +22,8 @@ def run(*args):
     sys.argv = ["streamlit", "run", filename]
     if len(args) > 1:
         sys.argv.extend(args[1:])
+    if "--server.maxUploadSize" not in sys.argv:
+        sys.argv.extend(["--server.maxUploadSize", "2000"])
     sys.exit(stcli.main())
 
 

--- a/python/pdstools/app/streamlit_app.py
+++ b/python/pdstools/app/streamlit_app.py
@@ -54,13 +54,11 @@ def run(**kwargs):
         """<hr style="height:1px;border:none;color:#333;background-color:#333;" /> """,
         unsafe_allow_html=True,
     )
-    with st.expander("Export options", expanded=False):
-        output_type = st.selectbox("Export format", ["pdf", "html", "docx"], index=1)
+    with st.expander("Cache Location", expanded=False):
         cache_location = file_loc
-        st.write("Cache location")
         st.code(cache_location)
         params["name"] = params["name"].replace(" ", "_")
-        output_filename = f'HealthCheck_{params["name"]}.{output_type}'
+        output_filename = f'HealthCheck_{params["name"]}.html'
         cwd = os.getcwd()
         quarto_file_name = "HealthCheck.qmd"
         param_file = f"{cache_location}/params.yaml"
@@ -94,7 +92,7 @@ def run(**kwargs):
             )
         except shutil.SameFileError:
             pass
-        bashCommand = f"quarto render {f'{cwd}/{quarto_file_name}'} --to {output_type} --output {output_filename} --execute-params {param_file}"
+        bashCommand = f"quarto render {f'{cwd}/{quarto_file_name}'} --to html --output {output_filename} --execute-params {param_file}"
         params["Command"] = {
             "quarto_file_name": quarto_file_name,
             "bashCommand": bashCommand,

--- a/python/pdstools/app/streamlit_app.py
+++ b/python/pdstools/app/streamlit_app.py
@@ -17,7 +17,20 @@ else:
 def run(**kwargs):
     import os
 
-    st.title("Generate a health check :male-doctor:")
+    st.title("Generate a Health Check :male-doctor:")
+    st.write(
+        """
+             This application generates a Health Check that provides an overview of the Adaptive models and predictors. 
+             
+             You can simply run it by uploading your ADM data (see [pdstools wiki](https://github.com/pegasystems/pega-datascientist-tools/wiki/How-to-export-and-use-the-ADM-Datamart)
+             to learn about ADM tables and how export them) and clicking on **Generate healthcheck** button.
+             
+             If you want to focus only on a subset of models/predictors, you can add filters and preview the filtered data.
+             If you want to change model context keys, use edit parameters button.
+             
+             Before clicking on **Generate healthcheck** button, you can preview the data that will be used for creating the document.
+            """
+    )
     file_loc = os.path.dirname(__file__)
     params = dict()
     params["name"] = st.text_input("Customer name", "Sample")
@@ -29,7 +42,8 @@ def run(**kwargs):
     if data is None:
         return None
     data.modelData = data.modelData.lazy()
-    data.predictorData = data.predictorData.lazy()
+    if data.predictorData is not None:
+        data.predictorData = data.predictorData.lazy()
 
     filtereddf, params = generate_modeldata_filters(data, params)
 
@@ -38,9 +52,7 @@ def run(**kwargs):
     )
     if data.predictorData is not None:
         filteredpreds = data.predictorData.join(
-            filtereddf.select(pl.col("ModelID").unique()),
-            on="ModelID",
-            how="inner",
+            filtereddf.select(pl.col("ModelID").unique()), on="ModelID", how="inner"
         )
         st.write(
             f"Shape of predictor file: {filteredpreds.select(pl.count()).collect().item(), len(filteredpreds.columns)}"
@@ -60,7 +72,11 @@ def run(**kwargs):
         params["name"] = params["name"].replace(" ", "_")
         output_filename = f'HealthCheck_{params["name"]}.html'
         cwd = os.getcwd()
-        quarto_file_name = "HealthCheck.qmd"
+        quarto_file_name = (
+            "HealthCheck.qmd"
+            if data.predictorData is not None
+            else "HealthCheckModel.qmd"
+        )
         param_file = f"{cache_location}/params.yaml"
         persist_cache = st.checkbox("Keep cached files", value=False)
 

--- a/python/pdstools/utils/cdh_utils.py
+++ b/python/pdstools/utils/cdh_utils.py
@@ -341,11 +341,12 @@ def getMatches(files_dir, target):
     if len(matches) == 0:
         raise FileNotFoundError(
             """Couldn't find a compatible file name. Please try feeding model and predictor filenames seperatly.
-        See https://github.com/pegasystems/pega-datascientist-tools/blob/master/python/pdstools/adm/ADMDatamart.py#L87
+        See https://github.com/pegasystems/pega-datascientist-tools/blob/master/python/pdstools/adm/ADMDatamart docstring
         for usage.
         
-        Or check out https://github.com/pegasystems/pega-datascientist-tools/blob/master/python/pdstools/utils/cdh_utils.py#L299
-        to see default model and predictor file names that pdstools can find.
+        Or check out https://github.com/pegasystems/pega-datascientist-tools/blob/master/python/pdstools/utils/cdh_utils/
+        get_latest function to see default model and predictor file names that pdstools 
+        can find.
         """
         )
     return matches

--- a/python/pdstools/utils/cdh_utils.py
+++ b/python/pdstools/utils/cdh_utils.py
@@ -102,9 +102,11 @@ def readDSExport(
         logging.debug("File found in directory")
         file = os.path.join(path, filename)
     # If we can't find the file locally, we can try
-    # if the file's a URL. If it is, we need to wrap
+    # if the file is a URL. If it is, we need to wrap
     # the file in a BytesIO object, and read the file
-    # fully to disk for pyarrow to read it.
+    # fully to disk for pyarrow to read it. Else we search
+    # the path to see if there is a file named as one
+    # of the default names in getMatches function
     elif _is_url(path, filename):
         logging.debug("File found online, importing and parsing to BytesIO")
         try:
@@ -122,11 +124,6 @@ def readDSExport(
     else:
         logging.debug("File not found in directory, scanning for latest file")
         file = get_latest_file(path, filename)
-
-    # If we can't find the file locally, we can try
-    # if the file's a URL. If it is, we need to wrap
-    # the file in a BytesIO object, and read the file
-    # fully to disk for pyarrow to read it.
 
     if "extension" not in vars():
         name, extension = os.path.splitext(file)

--- a/python/pdstools/utils/cdh_utils.py
+++ b/python/pdstools/utils/cdh_utils.py
@@ -123,9 +123,6 @@ def readDSExport(
             return None
 
     elif filename is not None:
-        import streamlit as st
-
-        st.write(f"filename: {filename}")
         logging.debug("File not found in directory, scanning for latest file")
         file = get_latest_file(path, filename)
 

--- a/python/pdstools/utils/cdh_utils.py
+++ b/python/pdstools/utils/cdh_utils.py
@@ -101,26 +101,16 @@ def readDSExport(
     if os.path.isfile(os.path.join(path, filename)):
         logging.debug("File found in directory")
         file = os.path.join(path, filename)
-    else:
-        logging.debug("File not found in directory, scanning for latest file")
-        file = get_latest_file(path, filename)
-
     # If we can't find the file locally, we can try
     # if the file's a URL. If it is, we need to wrap
     # the file in a BytesIO object, and read the file
     # fully to disk for pyarrow to read it.
-    if file == "Target not found" or file is None:
-        logging.debug("Could not find file in directory, checking if URL")
-        import requests
-
+    elif _is_url(path, filename):
+        logging.debug("File found online, importing and parsing to BytesIO")
         try:
-            response = requests.get(f"{path}/{filename}")
-            logging.info(f"Response: {response}")
-            if response.status_code == 200:
-                logging.debug("File found online, importing and parsing to BytesIO")
-                file = f"{path}/{filename}"
-                file = BytesIO(urllib.request.urlopen(file).read())
-                name, extension = os.path.splitext(filename)
+            file = f"{path}/{filename}"
+            file = BytesIO(urllib.request.urlopen(file).read())
+            name, extension = os.path.splitext(filename)
 
         except Exception as e:
             logging.info(e)
@@ -129,12 +119,45 @@ def readDSExport(
             logging.info(f"File not found: {path}/{filename}")
             return None
 
+    else:
+        logging.debug("File not found in directory, scanning for latest file")
+        file = get_latest_file(path, filename)
+
+    # If we can't find the file locally, we can try
+    # if the file's a URL. If it is, we need to wrap
+    # the file in a BytesIO object, and read the file
+    # fully to disk for pyarrow to read it.
+
     if "extension" not in vars():
         name, extension = os.path.splitext(file)
 
     # Now we should either have a full path to a file, or a
     # BytesIO wrapper around the file. Polars can read those both.
     return import_file(file, extension, **reading_opts)
+
+
+def _is_url(path: str, filename: str):
+    """Checks whether the given path/filename is a url
+
+    Parameters
+    ----------
+    path : str
+        The location of the file
+    filename : str
+        The name of the file
+    
+    Returns
+    -------
+    Union[bool, Response]
+    """
+    import requests
+
+    try:
+        response = requests.get(f"{path}/{filename}")
+        logging.info(f"Response: {response}")
+        return response
+    except:
+        return False
 
 
 def import_file(file: str, extension: str, **reading_opts) -> pl.LazyFrame:
@@ -273,13 +296,6 @@ def get_latest_file(path: str, target: str, verbose: bool = False) -> str:
         print(files_dir)  # pragma: no cover
     matches = getMatches(files_dir, target)
 
-    if len(matches) == 0:  # pragma: no cover
-        if verbose:
-            print(
-                f"Unable to find data for {target}. Please check if the data is available."
-            )
-        return None
-
     paths = [os.path.join(path, name) for name in matches]
 
     def f(x):
@@ -325,6 +341,16 @@ def getMatches(files_dir, target):
         match = [file for name in names if re.findall(name.casefold(), file.casefold())]
         if len(match) > 0:
             matches.append(match[0])
+    if len(matches) == 0:
+        raise FileNotFoundError(
+            """Couldn't find a compatible file name. Please try feeding model and predictor filenames seperatly.
+        See https://github.com/pegasystems/pega-datascientist-tools/blob/master/python/pdstools/adm/ADMDatamart.py#L87
+        for usage.
+        
+        Or check out https://github.com/pegasystems/pega-datascientist-tools/blob/master/python/pdstools/utils/cdh_utils.py#L299
+        to see default model and predictor file names that pdstools can find.
+        """
+        )
     return matches
 
 

--- a/python/tests/test_cdh_utils.py
+++ b/python/tests/test_cdh_utils.py
@@ -58,7 +58,7 @@ def test_find_default_predictors():
 
 
 def test_file_not_found():
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(Exception):
         cdh_utils.get_latest_file(path="data1", target="predictorData")
 
 
@@ -101,10 +101,7 @@ def test_import_produces_bytes():
 def test_read_json(test_data):
     temp_filename = "data.json"
     test_data.collect().write_ndjson(temp_filename)
-    assert cdh_utils.readDSExport(
-        "data.json",
-        ".",
-    ).shape == (20, 23)
+    assert cdh_utils.readDSExport("data.json", ".").shape == (20, 23)
     os.remove(temp_filename)
 
 
@@ -128,10 +125,7 @@ def test_polars_zip_from_url():
         "https://raw.githubusercontent.com/pegasystems/cdh-datascientist-tools/master/data",
     )
 
-    assert isinstance(
-        df,
-        pl.LazyFrame,
-    )
+    assert isinstance(df, pl.LazyFrame)
     assert df.shape == (20, 23)
 
 
@@ -201,7 +195,7 @@ def test_file_not_found_in_good_dir():
 
 
 def test_file_not_found_in_bad_dir():
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(Exception):
         cdh_utils.readDSExport(path="data1", filename="modelData")
 
 
@@ -403,7 +397,9 @@ def test_toPRPCDateTime():
         == "20180316T134127.847 GMT-0456"
     )
     assert (
-        cdh_utils.toPRPCDateTime(datetime.datetime(2018, 3, 16, 13, 41, 27, 847000))[:-3]
+        cdh_utils.toPRPCDateTime(datetime.datetime(2018, 3, 16, 13, 41, 27, 847000))[
+            :-3
+        ]
         == "20180316T134127.847 GMT+0000"[:-3]
     )
 
@@ -421,7 +417,7 @@ def test_weighted_average_polars():
         .agg(
             cdh_utils.weighed_average_polars("SuccessRate", "ResponseCount").alias(
                 "SuccessRate_weighted"
-            ),
+            )
         )
         .sort("Channel")
     )

--- a/python/tests/test_cdh_utils.py
+++ b/python/tests/test_cdh_utils.py
@@ -196,7 +196,8 @@ def test_cdh_sample_autodiscovered_locally():
 
 
 def test_file_not_found_in_good_dir():
-    assert cdh_utils.readDSExport(path="data", filename="models") == None
+    with pytest.raises(ValueError):
+        cdh_utils.readDSExport(path="data", filename="models")
 
 
 def test_file_not_found_in_bad_dir():


### PR DESCRIPTION
- Removed pdf and word export options from streamlit app. I believe they are not useful (you can't see the plots appropriately) and if we want to keep them, we have to make sure they work properly (Ex. pdf export doesn't have the _download file_ option and it generates the pds file it in wherever you run the app.)

- If the user feeds a directory path with non-standard file names to ADMDatamart, it would return a NONE object and result in an error like (Nonetype object has no modeldata ...). But I think it should raise a more verbose error. To achieve that:
added _is_url function to test if the given path is a URL. To make sure before raising errors such as: Not a directory or this directory doesn't have files with standard standard file names(see admdatamart changes)

- Added HealthCheckModel.qmd to create a healthcheck in case only the modeldata is uploaded (currently if filepath option is used, it wouldnt work), only works with upload file.

- updated the extract_keys argument, it was depriciated in the app.

- --server.maxUploadSize default is set to 2GB

Some controversial changes with removing pds, word options and I am not sure if we should change the error messages of ADM. Maybe sticking to st.warning() messages in streamlit is a better idea, waiting for your comments
 