### PR TITLE
Polars `0.17` compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
         "plotly>=5.5.0",
         "requests",
         "pydot",
-        "polars>=0.16.8",
+        "polars>=0.17.0",
         "pyarrow",
         "tqdm",
         "pyyaml",

--- a/python/pdstools/__init__.py
+++ b/python/pdstools/__init__.py
@@ -2,9 +2,8 @@
 
 __version__ = "3.0.1"
 
-from polars.polars import toggle_string_cache
-
-toggle_string_cache(True)
+from polars import enable_string_cache
+enable_string_cache(True)
 
 import sys
 from pathlib import Path

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,7 +3,7 @@ plotly>=5.5.0
 requests
 pydot
 tqdm
-polars>=0.16.8
+polars>=0.17.0
 pyarrow
 pyyaml
 aioboto3>=11.0

--- a/python/tests/test_docScenarios.py
+++ b/python/tests/test_docScenarios.py
@@ -36,7 +36,7 @@ def test_all_notebooks():
             tb.inject(
                 f"""
             import sys
-            sys.path.append(f"{str(basePath/'python')}")"""
+            sys.path.append("{f"{str(basePath)}/python"}")"""
             )
             tb.execute()
         return True


### PR DESCRIPTION
Polars 0.17 has some breaking changes, in our case mainly the change of `toggle_string_cache` -> `enable_string_cache` which we use in the `__init__.py`. This pr fixes those.
