### PR TITLE
Automate pypi release

### DIFF
--- a/.github/workflows/Python release.yml
+++ b/.github/workflows/Python release.yml
@@ -1,0 +1,38 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on: 
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/python/tests/test_docScenarios.py
+++ b/python/tests/test_docScenarios.py
@@ -36,7 +36,7 @@ def test_all_notebooks():
             tb.inject(
                 f"""
             import sys
-            sys.path.append(f"{str(basePath/'python')}")"""
+            sys.path.append("{f"{str(basePath)}/python"}")"""
             )
             tb.execute()
         return True


### PR DESCRIPTION
With this PR, releases will automatically be pushed to PyPi whenever a new tag gets pushed. In practice, this means: for patch releases, we'll create `tags` only, not full releases. Every once in a while, we can create a new `release`: this creates a tag as well, but here we also provide changelogs. 
