### PR TITLE
Use local path in docs workflow

### DIFF
--- a/.github/workflows/Docs deploy.yml
+++ b/.github/workflows/Docs deploy.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Commit documentation changes
         run: |
-          git clone https://github.com/${{github.repository}}.git --branch gh-pages --single-branch gh-pages
+          git clone https://github.com/${{ github.repository }}.git --branch gh-pages --single-branch gh-pages
           cp -r python/docs/build/html/* gh-pages/Python/
           cp -r r/docs/* gh-pages/R/
           cd gh-pages

--- a/.github/workflows/Docs deploy.yml
+++ b/.github/workflows/Docs deploy.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Commit documentation changes
         run: |
-          git clone https://github.com/pegasystems/pega-datascientist-tools.git --branch gh-pages --single-branch gh-pages
+          git clone https://github.com/${{github.repository}}.git --branch gh-pages --single-branch gh-pages
           cp -r python/docs/build/html/* gh-pages/Python/
           cp -r r/docs/* gh-pages/R/
           cd gh-pages

--- a/.github/workflows/R docs.yml
+++ b/.github/workflows/R docs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Commit documentation changes
         run: |
-          git clone https://github.com/pegasystems/pega-datascientist-tools.git --branch gh-pages --single-branch gh-pages
+          git clone https://github.com/${{ github.repository }}.git --branch gh-pages --single-branch gh-pages
           cp -r r/docs/* gh-pages/R/
           cd gh-pages
           git config --local user.email "action@github.com"


### PR DESCRIPTION
Rather than hardcode the URL for cloning, we can use the ${{github.repository}} variable to point to the repository. This means, if you fork the repository and setup your workflows correctly, you can get a local copy of the docs. 

To generate local docs in your fork:
1. Click on 'actions' in the top bar and enable the workflows
2. Under settings -> actions -> general -> workflow permissions, set the permission to read and write
3. Under settings -> pages, set the branch to 'gh-pages', and click save

This should automatically generate the docs and put them in your local branch - and should update on any commits in your repo.