### PR TITLE
Add devcontainer in support for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,10 @@
     "portsAttributes": {
         "8501": {
             "label": "Pdstools App",
-            "onAutoForward": "notify"
+            "onAutoForward": "openBrowser"
         }
-    }
+	},
+	"features": {
+		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {}
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,5 +10,11 @@
             ]
         }
     },
-    "postCreateCommand": "pip3 install ."
+    "postCreateCommand": "pip3 install .['app'] & pdstools run",
+    "portsAttributes": {
+        "8501": {
+            "label": "Pdstools App",
+            "onAutoForward": "notify"
+        }
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
             ]
         }
     },
-    "postCreateCommand": "pip3 install .['app'] & pdstools run",
+    "postCreateCommand": "pip3 install .['app'] && pdstools run",
     "portsAttributes": {
         "8501": {
             "label": "Pdstools App",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,10 +16,10 @@
     "portsAttributes": {
         "8501": {
             "label": "Pdstools App",
-            "onAutoForward": "openBrowser"
+            "onAutoForward": "openBrowserOnce"
         }
-	},
-	"features": {
-		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {}
-	}
+    },
+    "features": {
+        "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {}
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
         "vscode": {
             "extensions": [
                 "ms-python.black-formatter",
-                "charliermarsh.ruff"
+                "charliermarsh.ruff",
+                "ms-python.python",
+                "ms-toolsai.jupyter"
             ]
         }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "name": "Python 3",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.black-formatter",
+                "charliermarsh.ruff"
+            ]
+        }
+    },
+    "postCreateCommand": "pip3 install ."
+}


### PR DESCRIPTION
This one supersedes #130 - adding devcontainer with proper configuration makes 1) codespaces work, 2) docker creation seamless and 3) environments consistent.

Building the environment takes quite a while, because we don't just install a pretty sizable python image but also install all app dependencies & quarto. Let's see if we can improve this after.