### PR TITLE
Add PredictorCategory to default columns

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
 
+import datetime
+import glob
 import logging
 import os
 import shutil
 import subprocess
+from collections import namedtuple
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Literal, NoReturn, Optional, Tuple, Union
-from collections import namedtuple
 
 import polars as pl
 import yaml
-import glob
 
+from .. import pega_io
 from ..plots.plot_base import Plots
 from ..plots.plots_plotly import ADMVisualisations as plotly_plot
 from ..utils import cdh_utils
 from ..utils.errors import NotEagerError
 from ..utils.types import any_frame
-from .. import pega_io
 from .ADMTrees import ADMTrees
 from .Tables import Tables
 
@@ -621,10 +622,11 @@ class ADMDatamart(Plots, Tables):
 
     @staticmethod
     def _last(df: any_frame) -> any_frame:
+        fill_date = datetime.datetime.fromtimestamp(0)
         """Method to retrieve only the last snapshot."""
         return df.filter(
-            pl.col("SnapshotTime").fill_null(1)
-            == pl.col("SnapshotTime").fill_null(1).max()
+            pl.col("SnapshotTime").fill_null(fill_date)
+            == pl.col("SnapshotTime").fill_null(fill_date).max()
         )
 
     @staticmethod

--- a/python/pdstools/adm/BinAggregator.py
+++ b/python/pdstools/adm/BinAggregator.py
@@ -719,7 +719,7 @@ class BinAggregator:
         )
 
         fig = px.line(
-            boundaries_data,
+            boundaries_data.to_pandas(),
             x="boundary",
             y="binning",
             markers="both",

--- a/python/pdstools/adm/BinAggregator.py
+++ b/python/pdstools/adm/BinAggregator.py
@@ -113,9 +113,13 @@ class BinAggregator:
                     predictor=predictor,
                     n=n,
                     distribution=distribution,
-                    boundaries=[]
-                    if boundaries is None
-                    else (boundaries if isinstance(boundaries, list) else [boundaries]),
+                    boundaries=(
+                        []
+                        if boundaries is None
+                        else (
+                            boundaries if isinstance(boundaries, list) else [boundaries]
+                        )
+                    ),
                     minimum=minimum,
                     maximum=maximum,
                 )
@@ -125,9 +129,11 @@ class BinAggregator:
                 symbol_list = self.create_symbol_list(
                     predictor=predictor,
                     n_symbols=n,
-                    musthave_symbols=[]
-                    if symbols is None
-                    else (symbols if isinstance(symbols, list) else [symbols]),
+                    musthave_symbols=(
+                        []
+                        if symbols is None
+                        else (symbols if isinstance(symbols, list) else [symbols])
+                    ),
                 )
 
             if aggregation is None:
@@ -225,7 +231,7 @@ class BinAggregator:
 
         if verbose:
             print(target_binning)
-            
+
             # fig = self.plot_lift_binning(target_binning)
             # fig.update_layout(
             #     width=800,
@@ -755,7 +761,7 @@ class BinAggregator:
         return fig.update_xaxes(title="")
 
     # "Philip Mann" plot with simple red/green lift bars relative to base propensity
-    # TODO currently shared between ModelReport.qmd and BinAggregator.py and 
+    # TODO currently shared between ModelReport.qmd and BinAggregator.py and
     # copied into plot_base - move over to that version once PDS tools version got bumped
     def plotBinningLift(
         self,
@@ -817,7 +823,7 @@ class BinAggregator:
         )
 
         fig = px.bar(
-            data_frame=pm_plot_binning_table,
+            data_frame=pm_plot_binning_table.to_pandas(),
             x="Lift",
             y="BinSymbolAbbreviated",
             color="Direction",
@@ -906,10 +912,17 @@ class BinAggregator:
         )
 
         fig = self.plotBinningLift(
-            binning.with_columns((pl.col("BinCoverage") / pl.col("Models")).alias("RelativeBinCoverage")),
+            binning.with_columns(
+                (pl.col("BinCoverage") / pl.col("Models")).alias("RelativeBinCoverage")
+            ),
             col_facet=model_facet,
             row_facet=predictor_facet,
-            custom_data=["PredictorName", "BinSymbol", "RelativeBinCoverage", "BinResponses"],
+            custom_data=[
+                "PredictorName",
+                "BinSymbol",
+                "RelativeBinCoverage",
+                "BinResponses",
+            ],
         )
         fig.update_traces(
             hovertemplate="<br>".join(

--- a/python/pdstools/plots/plot_base.py
+++ b/python/pdstools/plots/plot_base.py
@@ -1592,7 +1592,7 @@ def plotBinningLift(
     )
 
     fig = px.bar(
-        data_frame=pm_plot_binning_table,
+        data_frame=pm_plot_binning_table.to_pandas(use_pyarrow_extension_array=True),
         x="Lift",
         y="BinSymbolAbbreviated",
         color="Direction",

--- a/python/pdstools/plots/plots_plotly.py
+++ b/python/pdstools/plots/plots_plotly.py
@@ -191,7 +191,7 @@ class ADMVisualisations:
             color = by
             hover_data = {by: ":.d", metric: metric_hovers[metric]}
         elif mode == "Cumulative":
-            df = df.sort("SnapshotTime")
+            df = df.sort("SnapshotTime").to_pandas(use_pyarrow_extension_array=False)
             x = "SnapshotTime"
             y = metric
             color = by

--- a/python/pdstools/reports/HealthCheck.qmd
+++ b/python/pdstools/reports/HealthCheck.qmd
@@ -640,7 +640,7 @@ for col in hover_columns:
 facet = "Channel/Direction"
 facet_cols = 3
 fig = px.bar(
-    df,
+    df.to_pandas(use_pyarrow_extension_array=True),
     x="SuccessRate",
     y="ModelID",
     color="SuccessRate",
@@ -1775,7 +1775,7 @@ def plot_gains(df, value: str, index=None, by=None):
     else:
         by_as_list = by if isinstance(by, list) else [by]
         fig = px.line(
-            gains_data,
+            gains_data.to_pandas(use_pyarrow_extension_array=True),
             x="cum_x",
             y="cum_y",
             color=gains_data.select(
@@ -1985,7 +1985,7 @@ out = (
 )
 
 fig = px.bar(
-    out,
+    out.to_pandas(use_pyarrow_extension_array=True),
     x="PerformanceBin",
     y="Volume",
     color="Channel",
@@ -2172,7 +2172,7 @@ if datamart.predictorData is not None:
 
     out = out.sort(["Channel", "break_label"])
     fig = px.bar(
-        out,
+        out.to_pandas(use_pyarrow_extension_array=True),
         x=f"{to_plot}_range",
         y="Responses",
         color=color_col,

--- a/python/pdstools/reports/ModelReport.qmd
+++ b/python/pdstools/reports/ModelReport.qmd
@@ -490,7 +490,7 @@ predictors. This can be configured via a parameter to this report.
 
 ```{python}
 # "Philip Mann" plot with simple red/green lift bars relative to base propensity
-# TODO currently shared between ModelReport.qmd and BinAggregator.py and 
+# TODO currently shared between ModelReport.qmd and BinAggregator.py and
 # copied into plot_base - move over to that version once PDS tools version got bumped
 def plotBinningLift(
     binning,
@@ -505,9 +505,7 @@ def plotBinningLift(
     # Add Lift column if not present
     if "Lift" not in binning.columns:
         binning = binning.with_columns(
-            (lift(pl.col("BinPositives"), pl.col("BinNegatives")) - 1.0).alias(
-                "Lift"
-            )
+            (lift(pl.col("BinPositives"), pl.col("BinNegatives")) - 1.0).alias("Lift")
         )
 
     # Optionally a shading expression
@@ -551,7 +549,7 @@ def plotBinningLift(
     )
 
     fig = px.bar(
-        data_frame=pm_plot_binning_table,
+        data_frame=pm_plot_binning_table.to_pandas(use_pyarrow_extension_array=True),
         x="Lift",
         y="BinSymbolAbbreviated",
         color="Direction",

--- a/python/tests/test_ADMDatamart.py
+++ b/python/tests/test_ADMDatamart.py
@@ -91,7 +91,7 @@ def test_import_utils_with_importing(test):
     )
     assert isinstance(output, pl.LazyFrame)
     assert len(output.columns) == 10
-    assert output.select(pl.count()).collect().item() == 20
+    assert output.select(pl.len()).collect().item() == 20
     assert renamed == {
         "Channel",
         "Configuration",
@@ -115,6 +115,7 @@ def test_import_utils_with_importing(test):
         "Direction",
         "EntryType",
         "PredictorName",
+        "PredictorCategory",
         "Treatment",
         "Type",
         "GroupIndex",
@@ -148,7 +149,7 @@ def test_import_utils(test, data):
         timestamp_fmt="%Y-%m-%d %H:%M:%S",
         typesetting_table="ADMModelSnapshot",
     )
-    assert len(missing) == 20
+    assert len(missing) == 21
     assert isinstance(output, pl.LazyFrame)
     output = output.collect()
     assert output.shape == (3, 3)

--- a/python/tests/test_end_to_end.py
+++ b/python/tests/test_end_to_end.py
@@ -53,6 +53,7 @@ def test_end_to_end():
         "ResponseCount",
         "SnapshotTime",
         "PredictorName",
+        "PredictorCategory",
         "Performance",
         "EntryType",
         "BinSymbol",
@@ -84,6 +85,7 @@ def test_end_to_end():
         "BinIndex",
         "Type",
         "PredictorName",
+        "PredictorCategory",
         "BinSymbol",
         "BinType",
         "BinPositives",
@@ -102,6 +104,7 @@ def test_end_to_end():
         "Name",
         "Configuration",
         "Treatment",
+        "PredictorCategory",
     }
 
     assert datamart.renamed_model == {


### PR DESCRIPTION
Checking if _PredictorCategory_ column already exists in the data. If not, we create it with the function provided as _predictorCategorization_ parameter to the _ADMDatamart_ class