### PR TITLE
Make regex strings raw strings

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -1298,7 +1298,7 @@ Meaning in total, {self.model_stats['models_n_nonperforming']} ({round(self.mode
 
         # Removes whitespace and capitalizes names for matching
         def name_normalizer(x):
-            return pl.col(x).str.replace_all("[ \-_]", "").str.to_uppercase()
+            return pl.col(x).str.replace_all(r"[ \-_]", "").str.to_uppercase()
 
         directionMapping = pl.DataFrame(
             # Standard directions have a 1:1 mapping to channel groups

--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -336,7 +336,7 @@ def get_latest_file(path: str, target: str, verbose: bool = False) -> str:
 
     def f(x):
         try:
-            return fromPRPCDateTime(re.search("\d.*GMT", x)[0].replace("_", " "))
+            return fromPRPCDateTime(re.search(r"\d.*GMT", x)[0].replace("_", " "))
         except:
             return pytz.timezone("GMT").localize(
                 datetime.datetime.fromtimestamp(os.path.getctime(x))


### PR DESCRIPTION
I was running into warnings on our regexes:

```python
[/Users/kass1/Documents/pdstools/.venv/lib/python3.12/site-packages/pdstools/adm/ADMDatamart.py:1301](https://file+.vscode-resource.vscode-cdn.net/Users/kass1/Documents/pdstools/.venv/lib/python3.12/site-packages/pdstools/adm/ADMDatamart.py:1301): SyntaxWarning: invalid escape sequence '\-'
  return pl.col(x).str.replace_all("[ \-_]", "").str.to_uppercase()
[/Users/kass1/Documents/pdstools/.venv/lib/python3.12/site-packages/pdstools/pega_io/File.py:339](https://file+.vscode-resource.vscode-cdn.net/Users/kass1/Documents/pdstools/.venv/lib/python3.12/site-packages/pdstools/pega_io/File.py:339): SyntaxWarning: invalid escape sequence '\d'
  return fromPRPCDateTime(re.search("\d.*GMT", x)[0].replace("_", " "))
```
  
Fixed this by turning these strings into raw strings