### PR TITLE
fix safeName function

### DIFF
--- a/python/tests/test_ADMDatamart.py
+++ b/python/tests/test_ADMDatamart.py
@@ -2,19 +2,19 @@
 Testing the functionality of the ADMDatamart functions
 """
 
-import sys
-import pytest
-import zipfile
-import polars as pl
-from polars.testing import assert_frame_equal
 import itertools
-from pandas.errors import UndefinedVariableError
 import pathlib
+import sys
+import zipfile
+
+import polars as pl
+import pytest
+from pandas.errors import UndefinedVariableError
+from polars.testing import assert_frame_equal
 
 basePath = pathlib.Path(__file__).parent.parent.parent
 sys.path.append(f"{str(basePath)}/python")
-from pdstools import ADMDatamart, cdh_utils
-from pdstools import errors
+from pdstools import ADMDatamart, cdh_utils, errors
 
 
 @pl.api.register_lazyframe_namespace("shape")
@@ -175,7 +175,7 @@ def test_extract_treatment(test, data):
     mapping = {"pyname": "Name"}
     output = cdh_utils._extract_keys(data.rename(mapping).lazy()).collect()
     assert output.shape == (3, 6)
-    assert list(output["Treatment"]) == ["XYZ", "xyz", None]
+    assert list(output["Treatment"]) == ["XYZ", "xyz", ""]
     assert list(output["Name"]) == ["ABC", "abc", "NormalName"]
     jsonnames = pl.LazyFrame(
         {


### PR DESCRIPTION

There was a bug with the safeName function when we had both json and string in pyName column. When pyName column looks like this:

1. '{"pyName":"CreditCard","pyTreatment":"Gold"}'
2. 'Iphone'

`df.select(safeName().str.json_decode()).unnest("tempName")`
This returns only pyName  I assume because of this conflict where the pyTreatment column has both a string from first row ("Gold") and a None type from second row. 

Now i am filling pyTreatment with an empty string if it does not exist and this fixes the issue.

@StijnKas please review this.
@operdeck fyi this is why we didn't get the pyTreatment column.