### PR TITLE
Missing cast of by-period to date in summaries

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -1319,7 +1319,7 @@ Meaning in total, {self.model_stats['models_n_nonperforming']} ({round(self.mode
 
         if by_period is not None:
             period_expr = [
-                pl.col("SnapshotTime").dt.truncate(by_period).alias("Period")
+                pl.col("SnapshotTime").dt.truncate(by_period).cast(pl.Date).alias("Period")
             ]
         else:
             period_expr = []

--- a/python/pdstools/prediction/Prediction.py
+++ b/python/pdstools/prediction/Prediction.py
@@ -165,7 +165,7 @@ class Prediction:
 
         if by_period is not None:
             period_expr = [
-                pl.col("SnapshotTime").dt.truncate(by_period).alias("Period")
+                pl.col("SnapshotTime").dt.truncate(by_period).cast(pl.Date).alias("Period")
             ]
         else:
             period_expr = []


### PR DESCRIPTION
Prediction and ADM summaries did not always return the optional Period as the exact same date type, which causes problems with the new, stricter, polars