### PR TITLE
Make Quarto Render OS-Agnostic and Add Version Info to Health Check Logs

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -1933,28 +1933,21 @@ Meaning in total, {self.model_stats['models_n_nonperforming']} ({round(self.mode
         process = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,  # Redirect stderr to stdout
             cwd=temp_dir,
             text=True,
+            bufsize=1,  # Line buffered
         )
-        import select
 
-        while True:
-            reads = [process.stdout.fileno(), process.stderr.fileno()]
-            ret = select.select(reads, [], [])
-            for fd in ret[0]:
-                line = (
-                    process.stdout.readline()
-                    if fd == process.stdout.fileno()
-                    else process.stderr.readline()
-                )
-                if line:
-                    logger.info(line.strip())
-                    if verbose:
-                        print(line.strip())
-            if process.poll() is not None and not line:
-                break
-        return_code = process.returncode
+        verbose = kwargs.get("verbose", True)
+
+        for line in iter(process.stdout.readline, ""):
+            line = line.strip()
+            logger.info(line)
+            if verbose:
+                print(line)
+
+        return_code = process.wait()
         message = f"Quarto process exited with return code {return_code}"
         logger.info(message)
         if verbose:

--- a/python/pdstools/app/health_check/pages/3_Reports.py
+++ b/python/pdstools/app/health_check/pages/3_Reports.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import streamlit as st
 
 from pdstools.utils.streamlit_utils import model_selection_df
+from pdstools import show_versions
 
 if "dm" not in st.session_state:
     st.warning("Please configure your files in the `data import` tab.")
@@ -110,6 +111,8 @@ with health_check:
             )
             with open(log_file_path, "w") as log_file:
                 log_file.write(st.session_state.log_buffer.getvalue())
+                log_file.write("\n\n--- Version Information ---\n")
+                log_file.write(show_versions(print_output=False))
             with open(log_file_path, "rb") as f:
                 btn = st.download_button(
                     label="Download error log",
@@ -213,6 +216,8 @@ if st.session_state["dm"].predictorData is not None:
                 log_file_path = f"pdstools_error_log_{datetime.now().isoformat().replace(':', '_')}.txt"
                 with open(log_file_path, "w") as log_file:
                     log_file.write(st.session_state.log_buffer.getvalue())
+                    log_file.write("\n\n--- Version Information ---\n")
+                    log_file.write(show_versions(print_output=False))
                 with open(log_file_path, "rb") as f:
                     btn = st.download_button(
                         label="Download error log",

--- a/python/pdstools/utils/show_versions.py
+++ b/python/pdstools/utils/show_versions.py
@@ -1,16 +1,29 @@
 from __future__ import annotations
 
 import importlib
+import importlib.metadata
 import sys
+from typing import Optional
 
 from .. import __version__
 
 import importlib.metadata
 
 
-def show_versions() -> None:
+def show_versions(print_output: bool = True) -> Optional[str]:
     """
-    Print out version of pdstools and dependencies to stdout.
+    Print or return version of pdstools and dependencies.
+    Parameters
+    ----------
+    print_output : bool, optional
+        If True, print the version information to stdout.
+        If False, return the version information as a string.
+        Default is True.
+
+    Returns
+    -------
+    Optional[str]
+        Version information as a string if print_output is False, else None.
 
     Examples
     --------
@@ -20,6 +33,7 @@ def show_versions() -> None:
     pdstools: 3.1.0
     Platform: macOS-12.6.4-x86_64-i386-64bit
     Python: 3.11.0 (v3.11.0:deaf509e8f, Oct 24 2022, 14:43:23) [Clang 13.0.0 (clang-1300.0.29.30)]
+
     ---Dependencies---
     plotly: 5.13.1
     requests: 2.28.1
@@ -29,6 +43,7 @@ def show_versions() -> None:
     tqdm: 4.64.1
     pyyaml: <not installed>
     aioboto3: 11.0.1
+
     ---Streamlit app dependencies---
     streamlit: 1.20.0
     quarto: 0.1.0
@@ -42,20 +57,27 @@ def show_versions() -> None:
     # note: we import 'platform' here as a micro-optimisation for initial import
     import platform
 
-    print("---Version info---")
-    print(f"pdstools: {__version__}")
-    print(f"Platform: {platform.platform()}")
-    print(f"Python: {sys.version}")
+    info = []
+    info.append("---Version info---")
+    info.append(f"pdstools: {__version__}")
+    info.append(f"Platform: {platform.platform()}")
+    info.append(f"Python: {sys.version}")
 
-    print("\n---Dependencies---")
+    info.append("\n---Dependencies---")
     deps = _get_dependency_info()
     for name, v in deps.items():
-        print(f"{name}: {v}")
+        info.append(f"{name}: {v}")
 
-    print("\n---Streamlit app dependencies---")
+    info.append("\n---Streamlit app dependencies---")
     deps = _get_opt_dependency_info()
     for name, v in deps.items():
-        print(f"{name}: {v}")
+        info.append(f"{name}: {v}")
+    version_info = "\n".join(info)
+    if print_output:
+        print(version_info)
+        return None
+    else:
+        return version_info
 
 
 def _get_dependency_info() -> dict[str, str]:


### PR DESCRIPTION
- Simplified Quarto render subprocess to fix Windows failures and make it OS-agnostic.
- Added version info to Health Check error logs for improved debugging.