### PR TITLE
Default pdstools run to HC app

### DIFF
--- a/python/pdstools/app/cli.py
+++ b/python/pdstools/app/cli.py
@@ -2,7 +2,7 @@ def main():
     import sys
 
     if len(sys.argv) == 1:
-        print("No arguments provided. Please see `pdstools help`.")
+        run()
     elif sys.argv[1] == "run":
         run(*sys.argv[1:])
     elif sys.argv[1] == "help":


### PR DESCRIPTION
This PR defaults the `pdstools` CLI command to `pdstools run`. `run` is the namespace for all other apps today anyway, so if you don't supply it, there's a very high chance you actually want to go there. `pdstools help` is still there if you need it, which is a fairly standard syntax so chances are if someone is looking for help, that's what they'll try.