### PR TITLE
Give warnings on SSL errors

### DIFF
--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -105,7 +105,14 @@ def read_ds_export(
 
         except ImportError:
             warnings.warn(
-                "Unable to import `requests`, so not able to check for remote files. If you're trying to read in a file from the internet (or, for instance, using the built-in cdh_sample method), try installing the 'requests' package (`uv pip install requests`)"
+                "Unable to import `requests`, so not able to check for remote files. If you're trying to read in a file from the internet (or, for instance, using the built-in cdh_sample method), try installing the 'requests' package (`uv pip install requests`)",
+                ImportWarning,
+            )
+
+        except (urllib.error.URLError, requests.exceptions.SSLError):
+            warnings.warn(
+                "There was an error making a HTTP request call. This is likely due to your certificates not being installed correctly. Please follow these instructions: https://stackoverflow.com/a/70495761",
+                RuntimeWarning,
             )
 
         except Exception as e:

--- a/python/pdstools/utils/datasets.py
+++ b/python/pdstools/utils/datasets.py
@@ -33,7 +33,7 @@ def cdh_sample(query: Optional[QUERY] = None) -> ADMDatamart:
             )
         except Exception as e:
             raise RuntimeError(
-                f"Error importing CDH Sample. Warnings: {[str(i) for i in w] if len(w)>0 else "None"}, exceptions: {e}"
+                f"Error importing CDH Sample. Warnings: {[str(i) for i in w] if len(w)>0 else 'None'}, exceptions: {e}"
             )
 
 
@@ -45,7 +45,7 @@ def sample_trees():
             )
         except Exception as e:
             raise RuntimeError(
-                f"Error importing the Sample Trees dataset. Warnings: {[str(i) for i in w] if len(w)>0 else "None"}, exceptions: {e}"
+                f"Error importing the Sample Trees dataset. Warnings: {[str(i) for i in w] if len(w)>0 else 'None'}, exceptions: {e}"
             )
 
 
@@ -74,5 +74,5 @@ def sample_value_finder(threshold: Optional[float] = None) -> ValueFinder:
             )
         except Exception as e:
             raise RuntimeError(
-                f"Error importing the Value Finder dataset. Warnings: {[str(i) for i in w] if len(w)>0 else "None"}, exceptions: {e}"
+                f"Error importing the Value Finder dataset. Warnings: {[str(i) for i in w] if len(w)>0 else 'None'}, exceptions: {e}"
             )

--- a/python/pdstools/utils/datasets.py
+++ b/python/pdstools/utils/datasets.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 from ..adm.ADMDatamart import ADMDatamart
@@ -22,18 +23,30 @@ def cdh_sample(query: Optional[QUERY] = None) -> ADMDatamart:
     path = "https://raw.githubusercontent.com/pegasystems/pega-datascientist-tools/master/data"
     models = "Data-Decision-ADM-ModelSnapshot_pyModelSnapshots_20210526T131808_GMT.zip"
     predictors = "Data-Decision-ADM-PredictorBinningSnapshot_pyADMPredictorSnapshots_20210526T133622_GMT.zip"
-    return ADMDatamart.from_ds_export(
-        model_filename=models,
-        predictor_filename=predictors,
-        base_path=path,
-        query=query,
-    )
+    with warnings.catch_warnings(record=True) as w:
+        try:
+            return ADMDatamart.from_ds_export(
+                model_filename=models,
+                predictor_filename=predictors,
+                base_path=path,
+                query=query,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"Error importing CDH Sample. Warnings: {w}, exceptions: {e}"
+            )
 
 
 def sample_trees():
-    return ADMTrees(
-        "https://raw.githubusercontent.com/pegasystems/pega-datascientist-tools/master/data/agb/_974a7f9c-66a6-4f00-bf3e-3acf5f188b1d.txt"
-    )
+    with warnings.catch_warnings(record=True) as w:
+        try:
+            return ADMTrees(
+                "https://raw.githubusercontent.com/pegasystems/pega-datascientist-tools/master/data/agb/_974a7f9c-66a6-4f00-bf3e-3acf5f188b1d.txt"
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"Error importing the Sample Trees dataset. Warnings: {w}, exceptions: {e}"
+            )
 
 
 def sample_value_finder(threshold: Optional[float] = None) -> ValueFinder:
@@ -51,9 +64,15 @@ def sample_value_finder(threshold: Optional[float] = None) -> ValueFinder:
     ValueFinder
         The Value Finder class populated with the Value Finder simulation data
     """
-    return ValueFinder.from_ds_export(
-        base_path="https://raw.githubusercontent.com/pegasystems/pega-datascientist-tools/master/data",
-        filename="Data-Insights_pyValueFinder_20210824T112615_GMT.zip",
-        n_customers=10000,
-        threshold=threshold,
-    )
+    with warnings.catch_warnings(record=True) as w:
+        try:
+            return ValueFinder.from_ds_export(
+                base_path="https://raw.githubusercontent.com/pegasystems/pega-datascientist-tools/master/data",
+                filename="Data-Insights_pyValueFinder_20210824T112615_GMT.zip",
+                n_customers=10000,
+                threshold=threshold,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"Error importing the Value Finder dataset. Warnings: {w}, exceptions: {e}"
+            )

--- a/python/pdstools/utils/datasets.py
+++ b/python/pdstools/utils/datasets.py
@@ -33,7 +33,7 @@ def cdh_sample(query: Optional[QUERY] = None) -> ADMDatamart:
             )
         except Exception as e:
             raise RuntimeError(
-                f"Error importing CDH Sample. Warnings: {w}, exceptions: {e}"
+                f"Error importing CDH Sample. Warnings: {[str(i) for i in w] if len(w)>0 else "None"}, exceptions: {e}"
             )
 
 
@@ -45,7 +45,7 @@ def sample_trees():
             )
         except Exception as e:
             raise RuntimeError(
-                f"Error importing the Sample Trees dataset. Warnings: {w}, exceptions: {e}"
+                f"Error importing the Sample Trees dataset. Warnings: {[str(i) for i in w] if len(w)>0 else "None"}, exceptions: {e}"
             )
 
 
@@ -74,5 +74,5 @@ def sample_value_finder(threshold: Optional[float] = None) -> ValueFinder:
             )
         except Exception as e:
             raise RuntimeError(
-                f"Error importing the Value Finder dataset. Warnings: {w}, exceptions: {e}"
+                f"Error importing the Value Finder dataset. Warnings: {[str(i) for i in w] if len(w)>0 else "None"}, exceptions: {e}"
             )


### PR DESCRIPTION
Previously, we ignored ssl errors but kept them in the log. Now, I'm raising explicit warnings which we can capture in our dataset functions.

The goal here is to still fail gracefully in case we really can't find a file remotely (like in the case where we only have model data and not predictor data) but fail hard on these default functions - as we know that we can expect both files to be present and we don't expect any of these warnings. Not ready for merge yet, still needs to be tested a bit more thoroughly. 