### PR TITLE
polars expression serialization

### DIFF
--- a/python/pdstools/adm/Plots.py
+++ b/python/pdstools/adm/Plots.py
@@ -137,7 +137,7 @@ def add_bottom_left_text_to_bubble_plot(
                 else:
                     print(fig.data, i)
         return fig
-    num_models = df.select(pl.first().count()).collect().item()
+    num_models = df.select(pl.first().len()).collect().item()
     bottomleft = get_nonperforming_models(df)
     newtext = f"{num_models} models: {bottomleft} ({round(bottomleft/num_models*100, 2)}%) at (50,0)"
     fig.layout.title.text += f"<br><sup>{newtext}</sup>"
@@ -486,7 +486,7 @@ class Plots(LazyNamespace):
             )
         ).sort("BinIndex")
 
-        if df.select(pl.first().count()).collect().item() == 0:
+        if df.select(pl.first().len()).collect().item() == 0:
             raise ValueError(f"There is no data for the provided modelid {model_id}")
 
         if return_df:
@@ -578,7 +578,7 @@ class Plots(LazyNamespace):
             )
         ).sort("BinIndex")
 
-        if df.select(pl.first().count()).collect().item() == 0:
+        if df.select(pl.first().len()).collect().item() == 0:
             raise ValueError(
                 f"There is no data for the provided modelid {model_id} and predictor {predictor_name}"
             )
@@ -1194,7 +1194,7 @@ class Plots(LazyNamespace):
             return plot_df
 
         fig = px.bar(
-            plot_df.collect(), #.to_pandas(use_pyarrow_extension_array=False),
+            plot_df.collect(),  # .to_pandas(use_pyarrow_extension_array=False),
             x="Lift",
             y="BinSymbolAbbreviated",
             color="Direction",
@@ -1260,8 +1260,7 @@ class Plots(LazyNamespace):
                 fig.show()
         return figs
 
-
-    # TODO I took the propensity distrib plot out of the HC as 
+    # TODO I took the propensity distrib plot out of the HC as
     # it wasn't very clear, also didn't look great visually.
 
     @requires(

--- a/python/pdstools/adm/Reports.py
+++ b/python/pdstools/adm/Reports.py
@@ -1,20 +1,18 @@
 __all__ = ["Reports"]
 import logging
 import os
-import re
 import shutil
 import subprocess
-import sys
 from os import PathLike
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import polars as pl
 
 from ..utils import cdh_utils
 from ..utils.namespaces import LazyNamespace
 from ..utils.types import QUERY
-from ..prediction import Prediction
+from ..utils.report_utils import _serialize_query, get_quarto_with_version
 
 if TYPE_CHECKING:
     from .ADMDatamart import ADMDatamart
@@ -257,7 +255,7 @@ class Reports(LazyNamespace):
                 and (self.datamart.predictor_data is not None)
             ):
                 model_file_path, predictor_file_path = self.datamart.save_data(temp_dir)
-
+            serialized_query = _serialize_query(query)
             self.run_quarto(
                 qmd_file=qmd_file,
                 output_filename=output_filename,
@@ -267,7 +265,7 @@ class Reports(LazyNamespace):
                     "model_file_path": str(model_file_path),
                     "predictor_file_path": str(predictor_file_path),
                     "prediction_file_path": str(prediction_file_path),
-                    "query": query,
+                    "query": serialized_query,
                     "title": title,
                     "subtitle": subtitle,
                 },
@@ -331,17 +329,6 @@ class Reports(LazyNamespace):
 
         shutil.copy(__reports__ / qmd_file, temp_dir)
 
-    # Never used?
-    # def _verify_cached_files(self, temp_dir: Path) -> None:
-    #     """Verify that cached data files exist."""
-    #     modeldata_files = list(temp_dir.glob("cached_modelData*"))
-    #     predictordata_files = list(temp_dir.glob("cached_predictorData*"))
-
-    #     if not modeldata_files:
-    #         raise FileNotFoundError("No cached model data found.")
-    #     if not predictordata_files:
-    #         logger.warning("No cached predictor data found.")
-
     @staticmethod
     def _write_params_files(
         temp_dir: Path,
@@ -353,7 +340,6 @@ class Reports(LazyNamespace):
         import yaml
 
         # Parameters to python code
-
         with open(temp_dir / "params.yml", "w") as f:
             yaml.dump(
                 params,
@@ -361,7 +347,6 @@ class Reports(LazyNamespace):
             )
 
         # Project/rendering options to quarto
-
         with open(temp_dir / "_quarto.yml", "w") as f:
             yaml.dump(
                 {
@@ -370,103 +355,6 @@ class Reports(LazyNamespace):
                 },
                 f,
             )
-
-    @staticmethod
-    def _find_executable(exec_name: str) -> Path:
-        """Find the executable on the system."""
-
-        # First find in path
-        exec_in_path = shutil.which(exec_name)  # pragma: no cover
-        if exec_in_path:  # pragma: no cover
-            return Path(exec_in_path)
-
-        # If not in path try find explicitly. TODO not sure this is wise
-        # maybe we should not try be smart and assume quarto/pandoc are
-        # properly installed.
-
-        if sys.platform == "win32":  # pragma: no cover
-            possible_paths = [
-                Path(
-                    os.environ.get("USERPROFILE", ""),
-                    "AppData",
-                    "Local",
-                    "Programs",
-                    f"{exec_name}",  # assume windows is still case insensitive (NTFS changes this...)
-                    "bin",
-                    f"{exec_name}.cmd",
-                ),
-                Path(
-                    os.environ.get("PROGRAMFILES", ""),
-                    f"{exec_name}",
-                    "bin",
-                    f"{exec_name}.cmd",
-                ),
-            ]
-        else:  # pragma: no cover
-            possible_paths = [
-                Path(f"/usr/local/bin/{exec_name}"),
-                Path(f"/opt/{exec_name}/bin/{exec_name}"),
-                Path(os.environ.get("HOME", ""), ".local", "bin", exec_name),
-            ]
-
-        for path in possible_paths:
-            if path.exists():
-                return path
-
-        raise FileNotFoundError(
-            "Quarto executable not found. Please ensure Quarto is installed and in the system PATH."
-        )  # pragma: no cover
-
-    # TODO not conviced about below. This isn't necessarily the same path resolution
-    # as the os does. What's wrong with just assuming quarto is in the path so we can
-    # just test for version w code like
-    # def get_cmd_output(args):
-    # result = (
-    #     subprocess.run(args, stdout=subprocess.PIPE).stdout.decode("utf-8").split("\n")
-    # )
-    # return result
-    # get_version_only(get_cmd_output(["quarto", "--version"])[0])
-
-    @staticmethod
-    def _get_executable_with_version(
-        exec_name: str, verbose: bool = False
-    ) -> Tuple[Path, str]:
-        def get_version_only(versionstr):
-            return re.sub("[^.0-9]", "", versionstr)
-
-        try:
-            executable = Reports._find_executable(exec_name=exec_name)
-        except FileNotFoundError as e:  # pragma: no cover
-            logger.error(e)
-            raise
-
-        # Check version
-        try:
-            version_result = subprocess.run(
-                [str(executable), "--version"],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            version_string = get_version_only(
-                version_result.stdout.split("\n")[0].strip()
-            )
-            message = f"{exec_name} version: {version_string}"
-            logger.info(message)
-            if verbose:
-                print(message)
-        except subprocess.CalledProcessError as e:  # pragma: no cover
-            logger.warning(f"Failed to check {exec_name} version: {e}")
-
-        return (executable, version_string)
-
-    @staticmethod
-    def get_quarto_with_version(verbose: bool = True) -> Tuple[Path, str]:
-        return Reports._get_executable_with_version("quarto", verbose=verbose)
-
-    @staticmethod
-    def get_pandoc_with_version(verbose: bool = True) -> Tuple[Path, str]:
-        return Reports._get_executable_with_version("pandoc", verbose=verbose)
 
     @staticmethod
     def run_quarto(
@@ -488,7 +376,7 @@ class Reports(LazyNamespace):
             analysis=analysis,
         )
 
-        quarto_exec, _ = Reports.get_quarto_with_version(verbose)
+        quarto_exec, _ = get_quarto_with_version(verbose)
 
         command = [
             str(quarto_exec),
@@ -565,9 +453,7 @@ class Reports(LazyNamespace):
         }
 
         if self.datamart.predictor_data is not None:
-            tabs["predictors_overview"] = (
-                self.datamart.aggregates.predictors_overview()
-            )
+            tabs["predictors_overview"] = self.datamart.aggregates.predictors_overview()
 
         if predictor_binning and self.datamart.predictor_data is not None:
             tabs["predictor_binning"] = self.datamart.aggregates.last(

--- a/python/pdstools/reports/HealthCheck.qmd
+++ b/python/pdstools/reports/HealthCheck.qmd
@@ -48,6 +48,8 @@ import polars as pl
 
 import numpy as np
 import math
+import json
+import io
 
 cdh_guidelines = CDHGuidelines()
 
@@ -73,6 +75,22 @@ def fig_set_xaxis_modelperformance(fig, label="Model Performance"):
         .update_xaxes(title=label, showticklabels=True, visible=True)
     )
     return fig
+def _deserialize_query(serialized_query):
+    if serialized_query is None:
+        return None
+
+    if serialized_query["type"] == "expr_list":
+        expr_list = []
+        for _, val in serialized_query["expressions"].items():
+            json_str = json.dumps(val)
+            str_io = io.StringIO(json_str)
+            expr_list.append(pl.Expr.deserialize(str_io, format="json"))
+        return expr_list
+
+    elif serialized_query["type"] == "dict":
+        return serialized_query["data"]
+
+    raise ValueError(f"Unknown query type: {serialized_query['type']}")
 ```
 
 ```{python}
@@ -84,7 +102,7 @@ def fig_set_xaxis_modelperformance(fig, label="Model Performance"):
 title = "ADM Model Overview"
 subtitle = "Sample data"
 
-# Insert the paths to your data files here to run the notebook from your IDE. 
+# Insert the paths to your data files here to run the notebook from your IDE.
 # Edit the _quarto.yml to enable/disable specific sections of the quarto output.
 # Parameters will be overriden by quarto when a parameters yaml is provided
 
@@ -116,6 +134,7 @@ if query and query == "None":
     query = None
 
 
+query = _deserialize_query(query)
 responsecount_analysis_query = (
     pl.col("ResponseCount") > responsecount_analysis_threshold
 )
@@ -1390,7 +1409,7 @@ if datamart.predictor_data is not None:
         # The default of observed=False is deprecated...
 
         fig = px.treemap(
-            missing, 
+            missing,
             path=path,
             color="Percentage without responses",
             template="pega",

--- a/python/pdstools/utils/polars_ext.py
+++ b/python/pdstools/utils/polars_ext.py
@@ -29,7 +29,7 @@ class Sample:
         )
 
     def height(self):
-        return self._ldf.select(pl.first().count()).collect().item()
+        return self._ldf.select(pl.first().len()).collect().item()
 
     def shape(self):
         return (self.height(), len(self._ldf.columns))

--- a/python/pdstools/utils/report_utils.py
+++ b/python/pdstools/utils/report_utils.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 import logging
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Union, Tuple
+from typing import Dict, List, Optional, Union, Tuple
 from IPython.display import display, Markdown
 from great_tables import GT, style, loc
 from ..adm.CDH_Guidelines import CDHGuidelines
@@ -131,52 +131,46 @@ def polars_subset_to_existing_cols(all_columns, cols):
     return [col for col in cols if col in all_columns]
 
 
-def rag_background_styler(
-    rag: Optional[Literal["Red", "Amber", "Yellow", "Green"]] = None,
-):
-    match rag[0].upper() if len(rag) > 0 else None:
-        case "R":
+def rag_background_styler(rag: Optional[str] = None):
+    if rag is not None and len(rag) > 0:
+        rag_upper = rag[0].upper()
+        if rag_upper == "R":
             return style.fill(color="orangered")
-        case "A":
+        elif rag_upper == "A":
             return style.fill(color="orange")
-        case "Y":
+        elif rag_upper == "Y":
             return style.fill(color="yellow")
-        case "G":
+        elif rag_upper == "G":
             return None  # no green background to keep it light
-        case _:
-            raise ValueError(f"Not a supported RAG value: {rag}")
+    raise ValueError(f"Not a supported RAG value: {rag}")
 
 
-def rag_background_styler_dense(
-    rag: Optional[Literal["Red", "Amber", "Yellow", "Green"]] = None,
-):
-    match rag[0].upper() if len(rag) > 0 else None:
-        case "R":
+def rag_background_styler_dense(rag: Optional[str] = None):
+    if rag is not None and len(rag) > 0:
+        rag_upper = rag[0].upper()
+        if rag_upper == "R":
             return style.fill(color="orangered")
-        case "A":
+        elif rag_upper == "A":
             return style.fill(color="orange")
-        case "Y":
+        elif rag_upper == "Y":
             return style.fill(color="yellow")
-        case "G":
+        elif rag_upper == "G":
             return style.fill(color="green")
-        case _:
-            raise ValueError(f"Not a supported RAG value: {rag}")
+    raise ValueError(f"Not a supported RAG value: {rag}")
 
 
-def rag_textcolor_styler(
-    rag: Optional[Literal["Red", "Amber", "Yellow", "Green"]] = None,
-):
-    match rag[0].upper() if len(rag) > 0 else None:
-        case "R":
+def rag_textcolor_styler(rag: Optional[str] = None):
+    if rag is not None and len(rag) > 0:
+        rag_upper = rag[0].upper()
+        if rag_upper == "R":
             return style.text(color="orangered")
-        case "A":
+        elif rag_upper == "A":
             return style.text(color="orange")
-        case "Y":
+        elif rag_upper == "Y":
             return style.text(color="yellow")
-        case "G":
+        elif rag_upper == "G":
             return style.text(color="green")
-        case _:
-            raise ValueError(f"Not a supported RAG value: {rag}")
+    raise ValueError(f"Not a supported RAG value: {rag}")
 
 
 def table_standard_formatting(

--- a/python/pdstools/utils/report_utils.py
+++ b/python/pdstools/utils/report_utils.py
@@ -1,13 +1,79 @@
 import re
 import traceback
-from typing import Dict, List, Literal, Optional, Union
+import shutil
+import subprocess
+import logging
+from pathlib import Path
+from typing import Dict, List, Literal, Optional, Union, Tuple
 from IPython.display import display, Markdown
 from great_tables import GT, style, loc
 from ..adm.CDH_Guidelines import CDHGuidelines
 from ..utils.show_versions import show_versions
-from ..adm.Reports import Reports
+from ..utils.types import QUERY
 import polars as pl
 import datetime
+import json
+
+logger = logging.getLogger(__name__)
+
+
+def _get_cmd_output(args: List[str]) -> List[str]:
+    """Get command output in an OS-agnostic way."""
+    try:
+        result = subprocess.run(
+            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
+        )
+        return result.stdout.split("\n")
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to run command {' '.join(args)}: {e}")
+        raise FileNotFoundError(
+            f"Command failed. Make sure {args[0]} is installed and in the system PATH."
+        )
+
+
+def _get_version_only(versionstr: str) -> str:
+    """Extract version number from version string."""
+    return re.sub("[^.0-9]", "", versionstr)
+
+
+def get_quarto_with_version(verbose: bool = True) -> Tuple[Path, str]:
+    """Get Quarto executable path and version."""
+    try:
+        executable = Path(shutil.which("quarto"))
+        if not executable:
+            raise FileNotFoundError(
+                "Quarto executable not found. Please ensure Quarto is installed and in the system PATH."
+            )
+
+        version_string = _get_version_only(_get_cmd_output(["quarto", "--version"])[0])
+        message = f"quarto version: {version_string}"
+        logger.info(message)
+        if verbose:
+            print(message)
+        return executable, version_string
+    except Exception as e:
+        logger.error(f"Error getting quarto version: {e}")
+        raise
+
+
+def get_pandoc_with_version(verbose: bool = True) -> Tuple[Path, str]:
+    """Get Pandoc executable path and version."""
+    try:
+        executable = Path(shutil.which("pandoc"))
+        if not executable:
+            raise FileNotFoundError(
+                "Pandoc executable not found. Please ensure Pandoc is installed and in the system PATH."
+            )
+
+        version_string = _get_version_only(_get_cmd_output(["pandoc", "--version"])[0])
+        message = f"pandoc version: {version_string}"
+        logger.info(message)
+        if verbose:
+            print(message)
+        return executable, version_string
+    except Exception as e:
+        logger.error(f"Error getting pandoc version: {e}")
+        raise
 
 
 def quarto_print(text):
@@ -66,7 +132,7 @@ def polars_subset_to_existing_cols(all_columns, cols):
 
 
 def rag_background_styler(
-    rag: Optional[Literal["Red", "Amber", "Yellow", "Green"]] = None
+    rag: Optional[Literal["Red", "Amber", "Yellow", "Green"]] = None,
 ):
     match rag[0].upper() if len(rag) > 0 else None:
         case "R":
@@ -82,7 +148,7 @@ def rag_background_styler(
 
 
 def rag_background_styler_dense(
-    rag: Optional[Literal["Red", "Amber", "Yellow", "Green"]] = None
+    rag: Optional[Literal["Red", "Amber", "Yellow", "Green"]] = None,
 ):
     match rag[0].upper() if len(rag) > 0 else None:
         case "R":
@@ -98,7 +164,7 @@ def rag_background_styler_dense(
 
 
 def rag_textcolor_styler(
-    rag: Optional[Literal["Red", "Amber", "Yellow", "Green"]] = None
+    rag: Optional[Literal["Red", "Amber", "Yellow", "Green"]] = None,
 ):
     match rag[0].upper() if len(rag) > 0 else None:
         case "R":
@@ -177,7 +243,6 @@ def table_standard_formatting(
                 and (best_practice_min is None or v >= best_practice_min)
                 and (best_practice_max is None or v <= best_practice_max)
             ]
-            # TODO consider that bad / warning rows are exclusive
 
             gt = apply_style(gt, "green", good_rows)
             gt = apply_style(gt, "amber", warning_rows)
@@ -232,7 +297,7 @@ def table_standard_formatting(
 
     # Highlight columns with non-standard values
     def simplify_name(x: str) -> str:
-        if x is None: 
+        if x is None:
             return x
         return re.sub("\\W", "", x, flags=re.IGNORECASE).upper()
 
@@ -346,8 +411,8 @@ def sample_values(dm, all_dm_cols, fld, n=6):
 
 
 def show_credits(quarto_source: str):
-    _, quarto_version = Reports.get_quarto_with_version(verbose=False)
-    _, pandoc_version = Reports.get_pandoc_with_version(verbose=False)
+    _, quarto_version = get_quarto_with_version(verbose=False)
+    _, pandoc_version = get_pandoc_with_version(verbose=False)
 
     timestamp_str = datetime.datetime.now().strftime("%d %b %Y %H:%M:%S")
 
@@ -357,10 +422,10 @@ def show_credits(quarto_source: str):
     Document created at: {timestamp_str}
 
     This notebook: {quarto_source}
-    
+
     Quarto runtime: {quarto_version}
     Pandoc: {pandoc_version}
-    
+
     Additional details from 'pdstools.show_versions()':
 
     """
@@ -371,3 +436,24 @@ def show_credits(quarto_source: str):
     quarto_print(
         "For more information please see the [Pega Data Scientist Tools](https://github.com/pegasystems/pega-datascientist-tools)."
     )
+
+
+def _serialize_query(query: Optional[QUERY]) -> Optional[Dict]:
+    if query is None:
+        return None
+
+    if isinstance(query, pl.Expr):
+        query = [query]
+
+    if isinstance(query, (list, tuple)):
+        serialized_exprs = {}
+        for i, expr in enumerate(query):
+            if not isinstance(expr, pl.Expr):
+                raise ValueError("All items in query list must be Expressions")
+            serialized_exprs[str(i)] = json.loads(expr.meta.serialize(format="json"))
+        return {"type": "expr_list", "expressions": serialized_exprs}
+
+    elif isinstance(query, dict):
+        return {"type": "dict", "data": query}
+
+    raise ValueError(f"Unsupported query type: {type(query)}")

--- a/python/pdstools/utils/report_utils.py
+++ b/python/pdstools/utils/report_utils.py
@@ -261,33 +261,32 @@ def table_standard_formatting(
             gt = apply_rag_styling(gt, col_name=col_name, metric=metric)
 
         # Value formatting
-        match metric:
-            case "Model Performance":
-                gt = gt.fmt_number(
-                    decimals=2,
-                    columns=cols,
-                )
-            case "Engagement Lift":
-                gt = gt.fmt_percent(
-                    decimals=0,
-                    columns=cols,
-                )
-            case "OmniChannel":
-                gt = gt.fmt_percent(
-                    decimals=0,
-                    columns=cols,
-                )
-            case "CTR":
-                gt = gt.fmt_percent(
-                    decimals=3,
-                    columns=cols,
-                )
-            case _:
-                gt = gt.fmt_number(
-                    decimals=0,
-                    compact=True,
-                    columns=cols,
-                )
+        if metric == "Model Performance":
+            gt = gt.fmt_number(
+                decimals=2,
+                columns=cols,
+            )
+        elif metric == "Engagement Lift":
+            gt = gt.fmt_percent(
+                decimals=0,
+                columns=cols,
+            )
+        elif metric == "OmniChannel":
+            gt = gt.fmt_percent(
+                decimals=0,
+                columns=cols,
+            )
+        elif metric == "CTR":
+            gt = gt.fmt_percent(
+                decimals=3,
+                columns=cols,
+            )
+        else:
+            gt = gt.fmt_number(
+                decimals=0,
+                compact=True,
+                columns=cols,
+            )
 
     # Highlight columns with non-standard values
     def simplify_name(x: str) -> str:

--- a/python/tests/test_ValueFinder.py
+++ b/python/tests/test_ValueFinder.py
@@ -70,8 +70,8 @@ def test_query(vf: ValueFinder):
         query=pl.col("Stage") != "Arbitration",
     )
     assert (
-        _vf.df.select(pl.first().count()).collect().item()
-        != vf.df.select(pl.first().count()).collect().item()
+        _vf.df.select(pl.first().len()).collect().item()
+        != vf.df.select(pl.first().len()).collect().item()
     )
 
 


### PR DESCRIPTION
## Changes
1. Fixed Polars expression serialization for healthcheck filters. 
   - Previously: Polars automatically converted expressions to JSON format
   - Now: Explicitly serialize expressions before writing to params.yml
   - Why: Newer Polars versions default to binary format which can't be safely stored in YAML
   - Solution: Added proper serialization/deserialization handling for expressions. Serialize just before creating YAML and deserialize in heatlhcheck.qmd

2. Code Organization Improvements
   - Simplified executable version handling as per @operdeck's TODO suggestion
   - Moved utility functions (find_quarto_executable) from Reports.py to report_utils.py
   - Resolved circular import issue where Reports class was being imported in its util file

