### PR TITLE
Hc fixes

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -127,14 +127,17 @@ class ADMDatamart:
         self.model_data = self._validate_model_data(
             model_df, query=query, extract_pyname_keys=extract_pyname_keys
         )
+        predictor_df = self._validate_predictor_data(predictor_df)
 
-        # TODO shouldnt we subset the predictor data to the model IDs also in the model data - if that is present
-        self.predictor_data = self._validate_predictor_data(predictor_df)
+        if predictor_df is not None and self.model_data is not None:
+            model_ids = self.model_data.select("ModelID").unique()
+            self.predictor_data = predictor_df.join(model_ids, on="ModelID", how="semi")
+        else:
+            self.predictor_data = None
 
         self.combined_data = self.aggregates._combine_data(
             self.model_data, self.predictor_data
         )
-
         self.bin_aggregator = BinAggregator(dm=self)  # attach after model_data
 
     @classmethod

--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -127,13 +127,8 @@ class ADMDatamart:
         self.model_data = self._validate_model_data(
             model_df, query=query, extract_pyname_keys=extract_pyname_keys
         )
-        predictor_df = self._validate_predictor_data(predictor_df)
 
-        if predictor_df is not None and self.model_data is not None:
-            model_ids = self.model_data.select("ModelID").unique()
-            self.predictor_data = predictor_df.join(model_ids, on="ModelID", how="semi")
-        else:
-            self.predictor_data = None
+        self.predictor_data = self._validate_predictor_data(predictor_df)
 
         self.combined_data = self.aggregates._combine_data(
             self.model_data, self.predictor_data

--- a/python/pdstools/reports/HealthCheck.qmd
+++ b/python/pdstools/reports/HealthCheck.qmd
@@ -1480,7 +1480,7 @@ maturity_criteria = [
     pl.col("Name")
     .filter(
         (pl.col("Performance") > 0.5)
-        & (pl.col("Performance") < cdh_guidelines.min("Model Performance"))
+        & (pl.col("Performance") < (cdh_guidelines.min("Model Performance") / 100))
         & (
             pl.col("Positives") >= cdh_guidelines.best_practice_min("Positive Responses")
         )
@@ -1492,7 +1492,7 @@ maturity_criteria = [
 
     pl.col("Name")
     .filter(
-        (pl.col("Performance") >= cdh_guidelines.min("Model Performance"))
+        (pl.col("Performance") >= (cdh_guidelines.min("Model Performance") / 100))
         & (
             pl.col("Positives")
             >= cdh_guidelines.best_practice_min("Positive Responses")

--- a/python/tests/test_healthcheck.py
+++ b/python/tests/test_healthcheck.py
@@ -32,7 +32,7 @@ def test_GenerateHealthCheck(sample: ADMDatamart):
 
 
 def test_ExportTables(sample: ADMDatamart):
-    excel = sample.generate.excel_report(predictor_binning=True)
+    excel, warning_messages = sample.generate.excel_report(predictor_binning=True)
     assert excel == pathlib.Path("./Tables.xlsx")
     assert excel.exists()
     spreadsheet = ExcelFile(excel)
@@ -48,7 +48,7 @@ def test_ExportTables(sample: ADMDatamart):
 
 
 def test_ExportTables_NoBinning(sample: ADMDatamart):
-    excel = sample.generate.excel_report(predictor_binning=False)
+    excel, warining_messages = sample.generate.excel_report(predictor_binning=False)
     assert excel == pathlib.Path("./Tables.xlsx")
     assert pathlib.Path(excel).exists()
     spreadsheet = ExcelFile(excel)
@@ -73,7 +73,7 @@ def test_GenerateHealthCheck_ModelDataOnly(
 
 
 def test_ExportTables_ModelDataOnly(sample_without_predictor_binning: ADMDatamart):
-    excel = sample_without_predictor_binning.generate.excel_report(
+    excel, warning_messages = sample_without_predictor_binning.generate.excel_report(
         name="ModelTables.xlsx", predictor_binning=True
     )
     assert excel == pathlib.Path("ModelTables.xlsx")


### PR DESCRIPTION
- Fixed predictor_data in Datamart init. It used to not filter out models which are not in model_data @StijnKas any problems with that?
- Added active/inactive info to excel report
- Added warning to excel when the data exceed excel row limit
- Fixed predictors_overview function, used to have a query parameter but the parameter wasn't used. Now the function doesn't have query parameter, instead i filter datamart itself before calling this function
- In Health Check some maturity_criteria filters were wrong because in cdh_limits performance is in 50-100 range and we were using that to filter Performance in datamart which is in 0.5-1.0 range.