### PR TITLE
Including global predictor overview (372) and added average performan…

### DIFF
--- a/python/pdstools/adm/CDH_Guidelines.py
+++ b/python/pdstools/adm/CDH_Guidelines.py
@@ -11,6 +11,11 @@ import polars as pl
 # boundaries and descriptions should be in sync with that one
 # https://pegasystems.sharepoint.com/:x:/s/SP-1-1CustomerEngagement/EZRI5aEOxMlMiieFQL6HysEBheX1S96zmy-t4HROK3tG7w?e=NaLYUD
 
+# TODO: future proof the list of models/predictions with the upcoming support for AGB
+# https://git.pega.io/projects/PEGAMKTNG/repos/pega-marketing/pull-requests/23314/overview
+# and also with multi-level models with certain suffices. Double check with AB. For example,
+# Mobile_Click_Through_Rate_Customer should be ok. For some customers, this is currently flagged.
+
 _data = {
     "Issues": [1, 5, 25, None],
     "Groups per Issue": [1, 5, 25, None],

--- a/python/pdstools/adm/Reports.py
+++ b/python/pdstools/adm/Reports.py
@@ -424,10 +424,13 @@ class Reports(LazyNamespace):
         predictor_binning: bool = False,
     ) -> tuple[Optional[Path], list[str]]:
         """
-        Export aggregated data to an Excel file.
+        Export raw data to an Excel file.
+
         This method exports the last snapshots of model_data, predictor summary,
         and optionally predictor_binning data to separate sheets in an Excel file.
-        If a specific table is not available, it will be skipped without causing the export to fail.
+
+        If a specific table is not available or too large, it will be skipped without 
+        causing the export to fail.
 
         Parameters
         ----------
@@ -455,7 +458,7 @@ class Reports(LazyNamespace):
 
         name = Path(name)
         tabs = {
-            "modeldata_last_snapshot": self.datamart.aggregates.last(
+            "adm_models": self.datamart.aggregates.last(
                 table="model_data"
             ).with_columns(
                 pl.col("ResponseCount").cast(pl.Int64),
@@ -465,7 +468,10 @@ class Reports(LazyNamespace):
         }
 
         if self.datamart.predictor_data is not None:
-            tabs["predictors_overview"] = self.datamart.aggregates.predictors_overview()
+            tabs["predictors_detail"] = self.datamart.aggregates.predictors_overview()
+
+        if self.datamart.predictor_data is not None:
+            tabs["predictors_overview"] = self.datamart.aggregates.predictors_global_overview()
 
         if predictor_binning and self.datamart.predictor_data is not None:
             columns = [

--- a/python/pdstools/reports/HealthCheck.qmd
+++ b/python/pdstools/reports/HealthCheck.qmd
@@ -1288,25 +1288,12 @@ If predictors perform poorly across all models, that may be because of data sour
 :::
 
 ```{python}
-# weighted performance
-
-
 if datamart.predictor_data is not None:
     bad_predictors = (
-        datamart.predictor_data.filter(pl.col("PredictorName") != "Classifier")
-        .group_by("PredictorName")
-        .agg(
-            [
-                pl.sum("BinResponseCount").alias("Response Count"),
-                (pl.min("Performance") * 100).alias("Min"),
-                (pl.mean("Performance") * 100).alias("Mean"),
-                (pl.median("Performance") * 100).alias("Median"),
-                (pl.max("Performance") * 100).alias("Max"),
-            ]
-        )
+        datamart.aggregates.predictors_global_overview()
         .filter(pl.col("Mean") < cdh_guidelines.min("Model Performance"))
-        .sort(["Mean", "PredictorName"], descending=False)
-    ).collect()
+        .collect()
+    )
     # responses_column_index = bad_predictors.columns.index("Response Count")
 
     display(
@@ -1316,7 +1303,7 @@ if datamart.predictor_data is not None:
             # .with_columns(MeanPlotData=pl.col("Mean")),
             rowname_col="PredictorName",
             cdh_guidelines=cdh_guidelines,
-            highlight_limits = {"Responses" : "Response Count"}
+            highlight_limits={"Responses": "Response Count"},
         )
         .tab_options(container_height="400px", container_overflow_y=True)
         .tab_spanner(
@@ -1487,74 +1474,60 @@ For the full list of models, export the data into an Excel sheet from Pega or fr
 All below lists are guidance. With new treatments/actions being introduced regularly, you would expect a small percentage of the models to be at their initial stages, but that percentage should be small.
 
 ```{python}
-
-maturity_criteria = [
-    pl.len().alias("Number of models in last snapshot"),
-
-    pl.col("Name")
-    .filter(pl.col("ResponseCount") < cdh_guidelines.min("Responses"))
-    .len()
-    .alias("Models that have never been used"),
-
-    pl.col("Name")
-    .filter(
+maturity_criteria = {
+    "Number of models in last snapshot": True,
+    f"Models that have never been used (responses = 0)": (
+        pl.col("ResponseCount") < cdh_guidelines.min("Responses")
+    ),
+    f"Models that have been used (responses > 0) but never received a positive response": (
         (pl.col("Positives") < cdh_guidelines.min("Positive Responses"))
         & (pl.col("ResponseCount") >= cdh_guidelines.min("Responses"))
-    )
-    .count()
-    .alias("Models that have been used but never received a positive response"),
-
-    pl.col("Name")
-    .filter(
-        (
-            pl.col("Positives") < cdh_guidelines.best_practice_min("Positive Responses")
-        )
+    ),
+    f"Models that are still in an immature phase of learning (positives < {int(cdh_guidelines.best_practice_min('Positive Responses'))})": (
+        (pl.col("Positives") < cdh_guidelines.best_practice_min("Positive Responses"))
         & (pl.col("Positives") >= cdh_guidelines.min("Positive Responses"))
-    )
-    .count()
-    .alias("Models that are still in an immature phase of learning"),
-
-    pl.col("Name")
-    .filter(
+    ),
+    "Models that have received sufficient responses but are still at their minimum performance (AUC = 50)": (
         (pl.col("Performance") == 0.5)
         & (
-            pl.col("Positives") >= cdh_guidelines.best_practice_min("Positive Responses")
+            pl.col("Positives")
+            >= cdh_guidelines.best_practice_min("Positive Responses")
         )
-    )
-    .count()
-    .alias(
-        "Models that have received sufficient responses but are still at their minimum performance"
     ),
-
-    pl.col("Name")
-    .filter(
+    f"Models that have received sufficient responses but still have a low performance (AUC < {cdh_guidelines.min('Model Performance')})": (
         (pl.col("Performance") > 0.5)
         & (pl.col("Performance") < (cdh_guidelines.min("Model Performance") / 100))
         & (
-            pl.col("Positives") >= cdh_guidelines.best_practice_min("Positive Responses")
+            pl.col("Positives")
+            >= cdh_guidelines.best_practice_min("Positive Responses")
         )
-    )
-    .count()
-    .alias(
-        "Models that have received sufficient responses but still have a low performance"
     ),
-
-    pl.col("Name")
-    .filter(
+    f"Models with sufficient positive responses (≥ {int(cdh_guidelines.best_practice_min('Positive Responses'))}) and a decent performance (≥ {cdh_guidelines.min('Model Performance')})": (
         (pl.col("Performance") >= (cdh_guidelines.min("Model Performance") / 100))
         & (
             pl.col("Positives")
             >= cdh_guidelines.best_practice_min("Positive Responses")
         )
-    )
-    .count()
-    .alias("Models with sufficient responses and a decent performance"),
-]
+    ),
+}
 
-maturity_overview = (
-    last_data.select([pl.lit(1).alias("Dummy")] + maturity_criteria)
-    .unpivot(index="Dummy", variable_name="Category", value_name="Number of Models")
-    .drop("Dummy")
+maturity_overview = pl.concat(
+    [
+        last_data.group_by(None)
+        .agg(
+            pl.lit(name).alias("Category"),
+            pl.col("Name").filter(filter_expression).len().alias("Number of Models"),
+            (
+                cdh_utils.weighted_average_polars(
+                    pl.col("Performance").filter(filter_expression),
+                    pl.col("ResponseCount").filter(filter_expression),
+                )
+                * 100.0
+            ).alias("Average Performance"),
+        )
+        .drop("literal")
+        for name, filter_expression in maturity_criteria.items()
+    ]
 )
 
 display(
@@ -1562,11 +1535,11 @@ display(
         maturity_overview,
         title="Model Maturity Overview",
         cdh_guidelines=cdh_guidelines,
+    ).fmt_number(
+        decimals=2,
+        columns=["Average Performance"],
     )
 )
-
-# TODO: see if we can just combine the long descriptions below into one nice table view
-
 ```
 
 ### Models that have never been used
@@ -1613,25 +1586,31 @@ In the analysis below we count the number of models in each of the groups analys
 by = ["SnapshotTime", "Channel", "Direction"]
 facet = "Channel/Direction"
 
-df = (
-    datamart.model_data.with_columns(pl.col(pl.Categorical).cast(pl.Utf8))
-    .with_columns(pl.col(pl.Utf8).fill_null("Missing"))
-    .group_by(by)
-    .agg(
-        maturity_criteria
+maturity_trend = (
+    pl.concat(
+        [
+            datamart.model_data.group_by(by).agg(
+                pl.lit(name).alias("Category"),
+                pl.col("Name").filter(filter_expression).len().alias("Number of Models"),
+                (
+                    cdh_utils.weighted_average_polars(
+                        pl.col("Performance").filter(filter_expression),
+                        pl.col("ResponseCount").filter(filter_expression),
+                    )
+                    * 100.0
+                ).alias("Average Performance"),
+            )
+            for name, filter_expression in maturity_criteria.items()
+        ]
     )
-    .sort(["Channel", "Direction", "SnapshotTime"], descending=True)
-)
-
-df = df.with_columns(
-    pl.concat_str(facet.split("/"), separator="/").alias(facet)
-).with_columns(pl.col(facet).cast(pl.Utf8).fill_null("NA"))
-
-# df.collect()
+    .with_columns(pl.concat_str(facet.split("/"), separator="/").alias(facet))
+    .with_columns(pl.col(facet).cast(pl.Utf8).fill_null("NA"))
+    .sort(["SnapshotTime"])
+).collect()
 
 try:
     fig = px.line(
-        df.unpivot(index=by+[facet], variable_name="Category", value_name="Number of Models").sort(["SnapshotTime"]).collect(),
+        maturity_trend,
         x="SnapshotTime",
         y="Number of Models",
         color="Category",
@@ -1644,12 +1623,7 @@ try:
     fig.update_layout(legend_title_text="Model Maturity")
     fig = fig_update_facet_height(fig, 3, 200, 250)
 
-    fig.update_layout(legend=dict(
-        yanchor="bottom",
-        y=-400,
-        xanchor="left",
-        x=0
-    ))
+    fig.update_layout(legend=dict(yanchor="bottom", y=-400, xanchor="left", x=0))
 
     fig.show()
 except Exception as e:

--- a/python/tests/test_Aggregates.py
+++ b/python/tests/test_Aggregates.py
@@ -106,6 +106,13 @@ def test_predictor_counts(dm_aggregates):
     assert dm_aggregates.predictor_counts().collect().shape[0] == 78
     assert dm_aggregates.predictor_counts().collect().shape[1] == 5
 
+def test_predictors_overview(dm_aggregates):
+    assert dm_aggregates.predictors_overview().collect().height == 1800
+    assert dm_aggregates.predictors_overview().collect().width == 12
+
+def test_predictors_global_overview(dm_aggregates):
+    assert dm_aggregates.predictors_global_overview().collect().height == 89
+    assert dm_aggregates.predictors_global_overview().collect().width == 7
 
 def test_summary_by_channel(dm_aggregates):
     summary_by_channel = dm_aggregates.summary_by_channel().collect()

--- a/python/tests/test_healthcheck.py
+++ b/python/tests/test_healthcheck.py
@@ -37,7 +37,8 @@ def test_ExportTables(sample: ADMDatamart):
     assert excel.exists()
     spreadsheet = load_workbook(excel)
     assert spreadsheet.sheetnames == [
-        "modeldata_last_snapshot",
+        "adm_models",
+        "predictors_detail",
         "predictors_overview",
         "predictor_binning",
     ]
@@ -53,7 +54,8 @@ def test_ExportTables_NoBinning(sample: ADMDatamart):
     assert pathlib.Path(excel).exists()
     spreadsheet = load_workbook(excel)
     assert spreadsheet.sheetnames == [
-        "modeldata_last_snapshot",
+        "adm_models",
+        "predictors_detail",
         "predictors_overview",
     ]
     # TODO we could go further and check the size of the sheets
@@ -80,7 +82,7 @@ def test_ExportTables_ModelDataOnly(sample_without_predictor_binning: ADMDatamar
     assert pathlib.Path(excel).exists()
     spreadsheet = load_workbook(excel)
     assert spreadsheet.sheetnames == [
-        "modeldata_last_snapshot",
+        "adm_models",
     ]
     # TODO we could go further and check the size of the sheets
     # spreadsheet = read_excel(excel, sheet_name=None)

--- a/python/tests/test_plots.py
+++ b/python/tests/test_plots.py
@@ -220,7 +220,7 @@ def test_predictor_performance(sample: ADMDatamart):
     assert "PredictorPerformance" in df.collect_schema().names()
     assert (
         round(df.select(pl.col("PredictorPerformance").top_k(1)).collect().item(), 2)
-        == 0.86
+        == 86.38
     )
 
     plot = sample.plot.predictor_performance()
@@ -232,7 +232,7 @@ def test_predictor_category_performance(sample: ADMDatamart):
     assert df.shape == (60, 3)
     assert "PredictorCategory" in df.columns
     assert "PredictorPerformance" in df.columns
-    assert round(df.select(pl.col("PredictorPerformance").top_k(1)).item(), 2) == 0.62
+    assert round(df.select(pl.col("PredictorPerformance").top_k(1)).item(), 2) == 62.49
 
     plot = sample.plot.predictor_category_performance()
     assert isinstance(plot, Figure)


### PR DESCRIPTION
Issue 372: adding a global predictor list with min/max/mean/median performance to the Excel export
Issue 368: adding average model performance to the model maturity count list
Also fixed scaling performance to 50-100 in some of the predictor plots