### PR TITLE
Don't default `pdstools` CLI -> let user choose between health_check and decision_analyzer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ['pdstools*']
 exclude = ['/tests/*', '*.dist-info', '/docs/*']
 
 [tool.setuptools.package-data]
-"*" = ['*.qmd']
+"*" = ['*.qmd', 'py.typed']
 
 [project]
 name = "pdstools"
@@ -69,6 +69,3 @@ tests = ['testbook', 'pytest', 'pytest-cov', 'pytest-httpx', 'pytest-mock', 'mot
 
 [project.scripts]
 pdstools = 'pdstools.cli:main'
-
-[tool.mypy]
-mypy_path=['python/stubs']


### PR DESCRIPTION
@yusufuyanik1 , @operdeck, any concerns with this? I would like to ultimately be able to run `uvx pdstools` and have you choose between health check and decision analyzer -> then you don't even need to pre-install pdstools, just uv. Please test this out to see if it works like you would like.