### PR TITLE
limit the model contexts to process

### DIFF
--- a/python/pdstools/explanations/Preprocess.py
+++ b/python/pdstools/explanations/Preprocess.py
@@ -44,6 +44,8 @@ class Preprocess(LazyNamespace):
         self.to_date = explanations.to_date
         self.model_name = explanations.model_name
 
+        # set duckdb query parameters
+        self.model_context_limit = int(os.getenv("MODEL_CONTEXT_LIMIT", "2500"))
         self.query_batch_limit = int(os.getenv("QUERY_BATCH_LIMIT", "10"))
         self.file_batch_limit = int(os.getenv("FILE_BATCH_LIMIT", "10"))
         self.memory_limit = int(os.getenv("MEMORY_LIMIT", "2"))
@@ -51,12 +53,13 @@ class Preprocess(LazyNamespace):
         self.progress_bar = os.getenv("PROGRESS_BAR", "0") == "1"
 
         logger.debug(
-            "Using \nQUERY_BATCH_LIMIT=%s, \nFILE_BATCH_LIMIT=%s, \nMEMORY_LIMIT=%sGB, \nTHREAD_COUNT=%s, \nPROGRESS_BAR=%s",
+            "Using QUERY_BATCH_LIMIT=%s, FILE_BATCH_LIMIT=%s, MEMORY_LIMIT=%sGB, THREAD_COUNT=%s, PROGRESS_BAR=%s, MODEL_CONTEXT_LIMIT=%s",
             self.query_batch_limit,
             self.file_batch_limit,
             self.memory_limit,
             self.thread_count,
             self.progress_bar,
+            self.model_context_limit,
         )
 
         self._conn = None
@@ -272,6 +275,7 @@ class Preprocess(LazyNamespace):
                 TABLE_NAME=tbl_name.value,
                 SELECTED_FILES=self._get_selected_files(),
                 PREDICTOR_TYPE=predictor_type.value,
+                MODEL_CONTEXT_LIMIT=self.model_context_limit,
             )
         }"""
 

--- a/python/pdstools/explanations/resources/queries/create.sql
+++ b/python/pdstools/explanations/resources/queries/create.sql
@@ -1,7 +1,20 @@
 SET memory_limit='{MEMORY_LIMIT}GB';
 SET enable_progress_bar = {ENABLE_PROGRESS_BAR};
 
-CREATE TABLE {TABLE_NAME} as
-SELECT *
-FROM read_parquet([{SELECTED_FILES}])
-WHERE predictor_type = '{PREDICTOR_TYPE}';
+CREATE TABLE {TABLE_NAME} AS
+WITH data AS (
+    SELECT * FROM read_parquet([{SELECTED_FILES}])
+    WHERE predictor_type = '{PREDICTOR_TYPE}'
+),
+selected_partitions AS (
+    SELECT 
+        partition, 
+        COUNT(DISTINCT pySubjectID || '-' || pyInteractionID) AS nb_samples
+    FROM data
+    GROUP BY partition
+    ORDER BY nb_samples DESC, partition
+    LIMIT {MODEL_CONTEXT_LIMIT}
+)
+SELECT main.*
+FROM data AS main
+JOIN selected_partitions AS partitions ON main.partition = partitions.partition;


### PR DESCRIPTION
added an env variable to limit the model contexts we process during the duckdb explanations file processing. This will limit it on overview as well as on each context report page.

Added as env variable so that the djs input parameters do not need to be changed but allows to change it during djs pod creation if passed in the env variables. Open to suggestions