### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,4 +1,6 @@
 name: Python linter
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/pegasystems/pega-datascientist-tools/security/code-scanning/39](https://github.com/pegasystems/pega-datascientist-tools/security/code-scanning/39)

To fix the problem, add an explicit `permissions` block to the workflow to limit the default permissions granted to `GITHUB_TOKEN`. For workflows that only check out code and run tools (such as linters), the minimal permission required is usually `contents: read`. This permission ensures that the workflow can read the repository contents necessary for checkout and linting, but does not grant write access to code, metadata, or other resources. In this case, add the following lines after the `name:` block and before the `on:` trigger to set minimal root-level permissions for the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
