### PR TITLE
fix caching to arrow

### DIFF
--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Iterable, List, Literal, Optional, Tuple, Union, overload
 
 import polars as pl
+import polars.selectors as cs
 
 from ..utils.cdh_utils import from_prpc_date_time
 
@@ -476,6 +477,8 @@ def cache_to_file(
         df = df.collect()
     if cache_type == "ipc":
         outpath = outpath.with_suffix(".arrow")
+        # Cast categorical to string since Arrow IPC doesn't support dictionary replacement across batches
+        df = df.with_columns(cs.categorical().cast(pl.Utf8))
         df.write_ipc(outpath, compression=compression)
     if cache_type == "parquet":
         outpath = outpath.with_suffix(".parquet")


### PR DESCRIPTION
Avoids this error during caching of model and predictor df in ADMDatamart:

`InvalidOperationError: Dictionary replacement detected when writing IPC file format. Arrow IPC files only support a single dictionary for a given field across all batches.`
