### PR TITLE
remove and replace wiki links

### DIFF
--- a/examples/adm/ADMBinningInsights.ipynb
+++ b/examples/adm/ADMBinningInsights.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "The predictor binning for Baysian ADM models is available in Pega Prediction Studio and also in the downloadable, off-line model reports you can create with PDS tools. These reports are available for both the legacy R and the new Python versions of the toolkit.\n",
     "\n",
-    "You can create these reports directly from the PDS tools app, or work in an IDE, for more information see [the PDS Tools Documentation](https://github.com/pegasystems/pega-datascientist-tools/wiki).\n",
+    "You can create these reports directly from the PDS tools app, or work in an IDE, for more information see [the PDS Tools Documentation](https://pegasystems.github.io/pega-datascientist-tools/index.html).\n",
     "\n",
     "You can easily recreate all or parts of this in code. For example, to recreate the binning reports use code like shown below. You'll need the model ID that you can pick up from Prediction Studio or from a quick analysis with PDS tools functions."
    ]

--- a/examples/datamart/Example_ADM_Analysis.ipynb
+++ b/examples/datamart/Example_ADM_Analysis.ipynb
@@ -17,9 +17,7 @@
    "metadata": {},
    "source": [
     "# Example ADM analysis\n",
-    "See this notebook for an introduction to the ADMDatamart class to get an overview of the currently implemented features in the Python version of CDH Tools. If you have any suggestions for new features, please do not hesitate to raise an issue in Git, or even better: create a pull request yourself!\n",
-    "\n",
-    "This notebook builds upon the [Getting Started guide](https://github.com/pegasystems/pega-datascientist-tools/wiki#using-the-python-tools). "
+    "See this notebook for an introduction to the ADMDatamart class to get an overview of the currently implemented features in the Python version of CDH Tools. If you have any suggestions for new features, please do not hesitate to raise an issue in Git, or even better: create a pull request yourself!"
    ]
   },
   {

--- a/python/docs/source/GettingStartedWithDecisionAnalyzer.rst
+++ b/python/docs/source/GettingStartedWithDecisionAnalyzer.rst
@@ -217,4 +217,4 @@ Troubleshooting
 
 - Review the `DecisionAnalyzer class documentation <https://pegasystems.github.io/pega-datascientist-tools/autoapi/pdstools/decision_analyzer/decision_data/index.html>`_
 - Check the `Decision Analyzer example <https://pegasystems.github.io/pega-datascientist-tools/articles/decision_analyzer.html>`_
-- Visit the main `pdstools documentation <https://pegasystems.github.io/pega-datascientist-tools/>`_
+- Raise an issue on `GitHub <https://github.com/pegasystems/pega-datascientist-tools>`_

--- a/python/docs/source/GettingStartedWithTheStandAloneApplication.rst
+++ b/python/docs/source/GettingStartedWithTheStandAloneApplication.rst
@@ -154,7 +154,7 @@ In the app, navigate to the Health Check tab (in the left pane). This shows inst
 Click the "Data Import" tab in the main screen to load your data. You have several options:
 
 .. note:: 
-   If you haven't downloaded the ADM Datamart yet, see `How to export the ADM Datamart <https://github.com/pegasystems/pega-datascientist-tools/wiki/Exporting-the-ADM-Datamart>`_ for instructions.
+   If you haven't downloaded the ADM Datamart yet, see `How to export the ADM Datamart <https://docs.pega.com/bundle/platform/page/platform/decision-management/enabling-monitoring-database-export.html>`_ for instructions.
 
 - **Direct file path**: Provide the folder path where the ADM files are located (e.g., ``/User/Downloads/``). The tool will automatically find the relevant files in that directory.
 - **Direct file upload**: Browse and upload your local files through the web interface.
@@ -214,7 +214,5 @@ Troubleshooting
 - Check the application logs in the terminal for specific error messages
 
 **For more help:**
-
-- Review the `ADM Health Check documentation <https://pegasystems.github.io/pega-datascientist-tools/articles/healthcheck.html>`_
-- Check the `ADM Datamart export instructions <https://github.com/pegasystems/pega-datascientist-tools/wiki/Exporting-the-ADM-Datamart>`_
-- Visit the main `pdstools documentation <https://pegasystems.github.io/pega-datascientist-tools/>`_
+- Check the `example ADM analysis <https://pegasystems.github.io/pega-datascientist-tools/articles/Example_ADM_Analysis.html>`_
+- Raise an issue on `GitHub <https://github.com/pegasystems/pega-datascientist-tools>`_.

--- a/python/pdstools/reports/HealthCheck.qmd
+++ b/python/pdstools/reports/HealthCheck.qmd
@@ -189,7 +189,7 @@ active_models_threshold_date_string = datamart.model_data.select(
 ).collect().item().strip()
 ```
 
-This document gives a global overview of the Adaptive models and (if available) the predictors of the models. It is generated from a Python markdown (Quarto) file in the [Pega Data Scientist Tools](https://github.com/pegasystems/pega-datascientist-tools). PDS Tools is open-source software and comes without guarantees. Off-line reports for Naive Bayes Adaptive models can be created as well, see [Wiki](https://github.com/pegasystems/pega-datascientist-tools/wiki).
+This document gives a global overview of the Adaptive models and (if available) the predictors of the models. It is generated from a Python markdown (Quarto) file in the [Pega Data Scientist Tools](https://github.com/pegasystems/pega-datascientist-tools). PDS Tools is open-source software and comes without guarantees.
 
 We provide guidance and best practices as much as possible. However these guidelines are generic and may or may not be applicable to a specific use case or implementation. The recommendations are strongly geared towards Customer Decision Hub (CDH) and may not apply to, for example, Process AI.
 

--- a/python/pdstools/utils/streamlit_utils.py
+++ b/python/pdstools/utils/streamlit_utils.py
@@ -116,7 +116,7 @@ def from_uploaded_file(extract_pyname_keys, codespaces):
         st.warning(
             """ Github Codespaces has a file size limit of 50MB for 'Direct Upload'.
             If you're using Github Codespaces and your files exceed this size limit, kindly opt for the 'Direct file path' method.
-            Detailed instructions can be found [here](https://github.com/pegasystems/pega-datascientist-tools/wiki/ADM-Health-Check#what-are-the-steps-to-use-it)
+            Detailed instructions can be found [here](https://pegasystems.github.io/pega-datascientist-tools/GettingStartedWithTheStandAloneApplication.html)
             """
         )
     if model_file and predictor_file:


### PR DESCRIPTION
Wiki has been deprecated, but some pages were still linking to it. These links are now replaced with appropriate docs or removed.
