### PR TITLE
fix: improve compatibility with isolated Python environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ adm = [
 ]
 pega_io = ['aioboto3', 'polars_hash']
 api = ['httpx', 'pydantic', 'anyio']
-healthcheck = ['pdstools[adm]', 'great_tables>=0.13', 'quarto', 'papermill', 'xlsxwriter>=3.0', 'pydot']
+healthcheck = ['pdstools[adm]', 'great_tables>=0.13', 'quarto', 'papermill', 'xlsxwriter>=3.0', 'pydot', 'ipykernel']
 explanations = ['duckdb', "plotly[express]", "pyarrow", "pyyaml", "ipywidgets"]
 app = ['pdstools[healthcheck]', 'streamlit>=1.45']
 onnx = [

--- a/python/pdstools/cli.py
+++ b/python/pdstools/cli.py
@@ -63,10 +63,10 @@ def run(args, unknown):
     # If no app is specified, prompt the user to choose
     if args.app is None:
         app_list = list(APPS.keys())
-        print("Available pdstools apps:")
+        print("Available pdstools apps:", flush=True)
         for i, app_key in enumerate(app_list, 1):
             display_name = APPS[app_key]["display_name"]
-            print(f"  {i}. {display_name}")
+            print(f"  {i}. {display_name}", flush=True)
 
         while True:
             try:

--- a/python/pdstools/utils/report_utils.py
+++ b/python/pdstools/utils/report_utils.py
@@ -218,11 +218,21 @@ def run_quarto(
     if verbose:
         print(f"Executing: {' '.join(command)} in temp directory {temp_dir}")
 
+    # Set QUARTO_PYTHON to ensure Quarto uses the same Python that's running pdstools.
+    # This is critical for isolated environments (uv tool, pipx) where the default
+    # system Python may not have the required dependencies like ipykernel.
+    import sys
+
+    env = os.environ.copy()
+    env["QUARTO_PYTHON"] = sys.executable
+    logger.info(f"Setting QUARTO_PYTHON to: {sys.executable}")
+
     process = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,  # Redirect stderr to stdout
         cwd=temp_dir,
+        env=env,
         text=True,
         bufsize=1,  # Line buffered
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2291,6 +2291,7 @@ all = [
     { name = "duckdb" },
     { name = "great-tables" },
     { name = "httpx" },
+    { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "onnx" },
     { name = "onnxruntime", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -2317,6 +2318,7 @@ api = [
 ]
 app = [
     { name = "great-tables" },
+    { name = "ipykernel" },
     { name = "papermill" },
     { name = "plotly", extra = ["express"] },
     { name = "pydot" },
@@ -2353,6 +2355,7 @@ explanations = [
 ]
 healthcheck = [
     { name = "great-tables" },
+    { name = "ipykernel" },
     { name = "papermill" },
     { name = "plotly", extra = ["express"] },
     { name = "pydot" },
@@ -2382,6 +2385,7 @@ tests = [
     { name = "duckdb" },
     { name = "great-tables" },
     { name = "httpx" },
+    { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "itables" },
     { name = "moto" },
@@ -2428,6 +2432,7 @@ requires-dist = [
     { name = "great-tables", marker = "extra == 'healthcheck'", specifier = ">=0.13" },
     { name = "httpx", marker = "extra == 'api'" },
     { name = "httpx", marker = "extra == 'docs'" },
+    { name = "ipykernel", marker = "extra == 'healthcheck'" },
     { name = "ipywidgets", marker = "extra == 'explanations'" },
     { name = "itables", marker = "extra == 'tests'" },
     { name = "moto", marker = "extra == 'tests'" },


### PR DESCRIPTION
__Problem__

When running pdstools via isolated package managers like `uvx`, `uv tool`, or `pipx`:

1. CLI output wasn't appearing immediately due to stdout buffering, causing the interactive app selection menu to not display properly
2. Quarto report generation failed because Quarto defaulted to the system Python, which doesn't have the required dependencies (like `ipykernel`) installed in the isolated environment

__Solution__

- __CLI (`cli.py`)__: Added `flush=True` to print statements to ensure output is displayed immediately, even in buffered contexts
- __Report utils (`report_utils.py`)__: Set `QUARTO_PYTHON` environment variable to `sys.executable`, ensuring Quarto uses the same Python interpreter that's running pdstools
