### PR TITLE
Restore auc formatting in individual model reports

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -445,7 +445,6 @@ class ADMDatamart:
         df = cdh_utils._apply_schema_types(df, Schema.ADMModelSnapshot)
 
         # Normalize Performance from Pega's 50-100 scale to 0.5-1.0 scale
-        # This aligns with MetricLimits.csv thresholds for RAG evaluation
         perf_max = df.select(pl.col("Performance").max()).collect().item()
         if perf_max is not None and perf_max > 1.0:
             df = df.with_columns(
@@ -485,8 +484,6 @@ class ADMDatamart:
         df = cdh_utils._apply_schema_types(df, Schema.ADMPredictorBinningSnapshot)
 
         # Normalize Performance from Pega's 50-100 scale to 0.5-1.0 scale
-        # Only normalize if data appears to be in 50-100 scale (max > 1)
-        # Must happen after schema types are applied (Performance cast to Float64)
         if "Performance" in df.collect_schema().names():
             perf_max = df.select(pl.col("Performance").max()).collect().item()
             if perf_max is not None and perf_max > 1.0:

--- a/python/pdstools/prediction/Prediction.py
+++ b/python/pdstools/prediction/Prediction.py
@@ -599,7 +599,6 @@ class Prediction:
             .lazy()
         )
         # Normalize Performance from Pega's 50-100 scale to 0.5-1.0 scale
-        # This aligns with MetricLimits.csv thresholds for RAG evaluation
         perf_max = (
             predictions_raw_data_prepped.select(pl.col("Performance").max())
             .collect()

--- a/python/pdstools/reports/ModelReport.qmd
+++ b/python/pdstools/reports/ModelReport.qmd
@@ -212,10 +212,10 @@ try:
 
     active_range_info = datamart.active_ranges(model_id).collect().to_dicts()[0]
 
-    auc_roc = round(active_range_info['AUC_ActiveRange'], 4)
+    auc_roc = active_range_info['AUC_ActiveRange']
 
     report_utils.quarto_print(
-        f"The model performance is **{auc_roc}** measured as AUC-ROC. This number is calculated from the 'active' bins of the Classifier. In Pega, AUC is always scaled to a number 50-100."
+        f"The model performance is **{round(auc_roc*100, 2)}** measured as AUC-ROC. This number is calculated from the 'active' bins of the Classifier. In Pega, AUC is always scaled to a number 50-100."
     )
 except Exception as e:
     report_utils.quarto_plot_exception("Model Performance", e)
@@ -234,7 +234,7 @@ gt = (
             (pl.last("Positives") / pl.last("ResponseCount")).alias(
                 "Base Propensity"
             ),
-            (pl.lit(auc_roc) * 100).alias("Performance"),
+            (pl.lit(auc_roc)).alias("Performance"),
         ),
         column_to_metric={
             "ResponseCount": "TotalResponseCount",


### PR DESCRIPTION
followup on #508 to restore the original formatting in the individual model reports, given that AUC is stored as fraction and formatted as whole number.

Note that we can remove the *100 in the table, since this formatting rule is in MetricFormats class and always applied to tables. We do add the formatting manually in the text.