### PR TITLE
 refactor DA col resolution to ColumnResolver

### DIFF
--- a/python/pdstools/decision_analyzer/table_definition.py
+++ b/python/pdstools/decision_analyzer/table_definition.py
@@ -169,12 +169,12 @@ DecisionAnalyzer: Dict[str, TableConfig] = {
     "pyApplication": {
         "label": "pyApplication",
         "default": False,
-        "type": pl.Float64,
+        "type": pl.Utf8,
     },
     "pyApplicationVersion": {
         "label": "pyApplicationVersion",
         "default": False,
-        "type": pl.Float64,
+        "type": pl.Utf8,
     },
 }
 


### PR DESCRIPTION
Extract column renaming, type mapping, and conflict resolution logic from the inline get_schema helper into a dedicated ColumnResolver class.
Only cast columns marked as default to avoid errors from unreliable type definitions on non-default columns, so we are going to include unexpected columns in the processed data, in case someone wants to do custom analysis but we are not casting them as we don't know the format
