### PR TITLE
feat: Add infer_schema_length parameter for large dataset support (#506)

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -158,6 +158,7 @@ class ADMDatamart:
         *,
         query: Optional[QUERY] = None,
         extract_pyname_keys: bool = True,
+        infer_schema_length: int = 10000,
     ):
         """Import the ADMDatamart class from a Pega Dataset Export
 
@@ -177,6 +178,11 @@ class ADMDatamart:
             An optional argument to filter out selected data, by default None
         extract_pyname_keys : bool, optional
             Whether to extract additional keys from the `pyName` column, by default True
+        infer_schema_length : int, optional
+            Number of rows to scan when inferring the schema for CSV/JSON files.
+            For large production datasets, increase this value (e.g., 200000) if columns
+            are not being detected correctly. Higher values use more memory but provide
+            more accurate schema detection. By default 10000
 
         Returns
         -------
@@ -196,6 +202,12 @@ class ADMDatamart:
                 predictor_df = '/Downloads/predictor_snapshots.parquet'
                 )
 
+        >>> # To use a higher schema inference length for large datasets:
+        >>> dm = ADMDatamart.from_ds_export(
+                base_path='/my_export_folder',
+                infer_schema_length=200000
+                )
+
         Note
         ----
         By default, the dataset export in Infinity returns a zip file per table.
@@ -209,8 +221,16 @@ class ADMDatamart:
         """
         # "model_data"/"predictor_data" are magic keywords
         # to automatically find data files in base_path
-        model_df = read_ds_export(model_filename or "model_data", base_path)
-        predictor_df = read_ds_export(predictor_filename or "predictor_data", base_path)
+        model_df = read_ds_export(
+            model_filename or "model_data",
+            base_path,
+            infer_schema_length=infer_schema_length,
+        )
+        predictor_df = read_ds_export(
+            predictor_filename or "predictor_data",
+            base_path,
+            infer_schema_length=infer_schema_length,
+        )
         return cls(
             model_df, predictor_df, query=query, extract_pyname_keys=extract_pyname_keys
         )

--- a/python/pdstools/app/health_check/pages/1_Data_Import.py
+++ b/python/pdstools/app/health_check/pages/1_Data_Import.py
@@ -5,14 +5,28 @@ from pdstools.utils import streamlit_utils
 st.write(
     """We currently support three ways to upload your own data,
 and one convenient way to test out the Health Check using a CDH Sample dataset.
-Select an option below to get started, or first configure some advanded options
-in the expanding section below."""
+Select an option below to get started. Advanced options can be configured at the
+bottom of this page."""
 )
 
-with st.expander("Configure advanced options", expanded=True):
-    extract_pyname_keys = st.checkbox(
+# Initialize session state for import options if not already set
+if "extract_pyname_keys" not in st.session_state:
+    st.session_state["extract_pyname_keys"] = True
+if "infer_schema_length" not in st.session_state:
+    st.session_state["infer_schema_length"] = 10000
+
+# Data import section using current session state values
+streamlit_utils.import_datamart(
+    extract_pyname_keys=st.session_state["extract_pyname_keys"],
+    infer_schema_length=st.session_state["infer_schema_length"],
+)
+
+# Advanced options at the bottom
+st.write("### Advanced options")
+with st.expander("Configure import settings"):
+    st.session_state["extract_pyname_keys"] = st.checkbox(
         "Extract Treatments",
-        True,
+        value=st.session_state["extract_pyname_keys"],
         help="""By default, ADM has a few "Context Keys" it uses to
         distinguish between models, such as Issue, Group, Channel, or Name.
         However, if you've setup custom context keys that are not part of a regular
@@ -20,10 +34,30 @@ with st.expander("Configure advanced options", expanded=True):
         tells us to try to extract these keys into separate columns.""",
     )
 
-streamlit_utils.import_datamart(extract_pyname_keys=extract_pyname_keys)
+    st.session_state["infer_schema_length"] = st.number_input(
+        "Schema inference length",
+        min_value=1000,
+        value=st.session_state["infer_schema_length"],
+        step=10000,
+        help="""Number of rows to scan when inferring the schema for CSV/JSON files.
+        For large production datasets, you may need to increase this value (e.g., 200000)
+        if columns are not being detected correctly. Higher values use more memory but
+        provide more accurate schema detection.""",
+    )
+
+    st.info("💡 Changes to these options will take effect when you re-import the data.")
 
 # Keep only essential session state keys
-essential_keys = ["dm", "params", "logger", "log_buffer", "data_source", "prediction"]
+essential_keys = [
+    "dm",
+    "params",
+    "logger",
+    "log_buffer",
+    "data_source",
+    "prediction",
+    "extract_pyname_keys",
+    "infer_schema_length",
+]
 for key in list(st.session_state.keys()):
     if key not in essential_keys and not key.startswith("_"):
         del st.session_state[key]

--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -48,23 +48,29 @@ def read_ds_export(
         - A BytesIO object containing the file data (e.g., from an uploaded file in a webapp)
     path : Union[str, os.PathLike], default = '.'
         The location of the file
-    verbose : bool, default = True
+    verbose : bool, default = False
         Whether to print out which file will be imported
-
-    Keyword arguments
-    -----------------
-    Any:
-        Any arguments to plug into the scan_* function from Polars.
+    infer_schema_length : int, default = 10000
+        Number of rows to scan when inferring the schema for CSV/JSON files.
+        For large production datasets, increase this value (e.g., 200000) if columns
+        are not being detected correctly. Higher values use more memory but provide
+        more accurate schema detection.
+    **reading_opts
+        Additional arguments passed to the Polars scan_* functions.
 
     Returns
     -------
     pl.LazyFrame
         The (lazy) dataframe
 
-    Examples:
-        >>> df = read_ds_export(filename='full/path/to/ModelSnapshot.json')
-        >>> df = read_ds_export(filename='ModelSnapshot.json', path='data/ADMData')
-        >>> df = read_ds_export(filename=uploaded_file)  # Where uploaded_file is a BytesIO object
+    Examples
+    --------
+    >>> df = read_ds_export(filename='full/path/to/ModelSnapshot.json')
+    >>> df = read_ds_export(filename='ModelSnapshot.json', path='data/ADMData')
+    >>> df = read_ds_export(filename=uploaded_file)  # Where uploaded_file is a BytesIO object
+
+    >>> # For large datasets with schema detection issues:
+    >>> df = read_ds_export(filename='large_export.csv', infer_schema_length=200000)
 
     """
     file: Union[str, BytesIO]

--- a/python/pdstools/prediction/Prediction.py
+++ b/python/pdstools/prediction/Prediction.py
@@ -693,6 +693,7 @@ class Prediction:
         base_path: Union[os.PathLike, str] = ".",
         *,
         query: Optional[QUERY] = None,
+        infer_schema_length: int = 10000,
     ):
         """Import from a Pega Dataset Export of the PR_DATA_DM_SNAPSHOTS table.
 
@@ -704,6 +705,11 @@ class Prediction:
             A base path to provide if predictions_filename is not given as a full path, by default "."
         query : Optional[QUERY], optional
             An optional argument to filter out selected data, by default None
+        infer_schema_length : int, optional
+            Number of rows to scan when inferring the schema for CSV/JSON files.
+            For large production datasets, increase this value (e.g., 200000) if columns
+            are not being detected correctly. Higher values use more memory but provide
+            more accurate schema detection. By default 10000
 
         Returns
         -------
@@ -714,6 +720,13 @@ class Prediction:
         --------
         >>> from pdstools import Prediction
         >>> pred = Prediction.from_ds_export('predictions.zip', '/my_export_folder')
+
+        >>> # For large datasets with schema detection issues:
+        >>> pred = Prediction.from_ds_export(
+                'predictions.zip',
+                '/my_export_folder',
+                infer_schema_length=200000
+                )
 
         Note
         ----
@@ -726,7 +739,9 @@ class Prediction:
         pdstools.pega_io.File.read_ds_export : More information on file compatibility
         pdstools.utils.cdh_utils._apply_query : How to query the Prediction class and methods
         """
-        predictions_raw_data = read_ds_export(predictions_filename, base_path)
+        predictions_raw_data = read_ds_export(
+            predictions_filename, base_path, infer_schema_length=infer_schema_length
+        )
         if predictions_raw_data is None:
             raise ValueError(
                 f"Unable to read prediction data from {predictions_filename}. "


### PR DESCRIPTION
- Add infer_schema_length parameter to ADMDatamart.from_ds_export()
- Add infer_schema_length parameter to Prediction.from_ds_export()
- Add UI control in Health Check app Data Import page
- Add unit tests for infer_schema_length parameter
- Update documentation

Closes #506