### PR TITLE
docs: fix install commands in streamlit app getting-started guides

### DIFF
--- a/python/docs/source/GettingStartedWithDecisionAnalyzer.rst
+++ b/python/docs/source/GettingStartedWithDecisionAnalyzer.rst
@@ -258,11 +258,11 @@ Upgrading pdstools
 If you already had an older version of pdstools, make sure to upgrade to the latest version:
 
 .. tabs::
-   .. tab:: uv + tool (recommended)
+   .. tab:: uv tool (recommended)
 
       .. code-block:: bash
 
-         uv tool update pdstools
+         uv tool upgrade pdstools
 
    .. tab:: uv + venv
 

--- a/python/docs/source/GettingStartedWithTheStandAloneApplication.rst
+++ b/python/docs/source/GettingStartedWithTheStandAloneApplication.rst
@@ -108,13 +108,13 @@ To use the stand-alone health check application, you need to install several Pyt
 
       .. code-block:: bash
 
-         python -m pip install pip
+         python -m pip install --upgrade pip
 
       **Step 4:** Install pdstools with app dependencies
 
       .. code-block:: bash
 
-         pip install 'pdstools[app]'
+         pip install --upgrade 'pdstools[app]'
 
       **Remember:** Always activate your virtual environment before working with the application:
 
@@ -129,13 +129,13 @@ To use the stand-alone health check application, you need to install several Pyt
 
       .. code-block:: bash
 
-         python -m pip install pip
+         python -m pip install --upgrade pip
 
       **Step 2:** Install pdstools with app dependencies globally
 
       .. code-block:: bash
 
-         pip install 'pdstools[app]'
+         pip install --upgrade 'pdstools[app]'
 
       **Consider using virtual environments:** Global installations can cause conflicts with other Python projects. Consider switching to the "uv" or "pip + venv" methods for better project isolation.
 
@@ -217,7 +217,7 @@ If you already had an older version of pdstools, make sure to upgrade to the lat
 
       .. code-block:: bash
 
-         uv tool update pdstools
+         uv tool upgrade pdstools
 
    .. group-tab:: uv + venv
 


### PR DESCRIPTION
## Summary

Fix incorrect commands in the Health Check and Decision Analyzer install docs.

### Changes

- **`uv tool update` → `uv tool upgrade`**: The correct uv subcommand is `upgrade`, not `update` (both docs)
- **Tab label `uv + tool` → `uv tool`**: Inconsistent label in the Decision Analyzer upgrade section
- **Missing `--upgrade` flag**: `pip install pip` and `pip install 'pdstools[app]'` in the Health Check pip tabs were missing `--upgrade`

All commands verified on macOS with `uv tool --help` and `uv tool upgrade --help`.