### PR TITLE
fix: persist decision data and filters across page navigation

### DIFF
--- a/python/pdstools/app/decision_analyzer/pages/1_Global_Data_Filters.py
+++ b/python/pdstools/app/decision_analyzer/pages/1_Global_Data_Filters.py
@@ -1,3 +1,4 @@
+# python/pdstools/app/decision_analyzer/pages/1_Global_Data_Filters.py
 import io
 import json
 
@@ -5,18 +6,14 @@ import polars as pl
 import streamlit as st
 
 from da_streamlit_utils import (
+    deserialize_filters,
     get_data_filters,
     reset_filter_state,
+    serialize_filters,
     show_filtered_counts,
     ensure_data,
 )
 from pdstools.decision_analyzer.utils import get_first_level_stats
-
-# TODO Customize the filter dropdown, instead of using the one from PDS tools, so to focus on the more logical filter fields
-# TODO Audience selection would be a meaningful filter, but there is no such thing in the data NOTE: What is audience? A subset of customers?
-# TODO Lets see if we can make re-applying the filters more easy, do that by default, including configurations like the reference set NOTE: I didn't understand this comment, what reference set?
-# TODO Anonymization should perhaps be a check box?  Yusuf: You can now upload your own data. Sample data is the anonymized version
-# TODO Make rest of code robust against heavy filtering, e.g. dropping stages etc
 
 """# Global Data Filters"""
 
@@ -30,61 +27,80 @@ what values you want to use in the Decision Analyzer.
 
 ensure_data()
 
-# Handle pending filter reset at the top — before any widgets render — so
-# session state is clean when get_data_filters() builds the filter UI.
+# ── Handle pending filter reset (before any widgets render) ──────────
 if st.session_state.pop("_needs_filter_reset", False):
     reset_filter_state("global")
     st.session_state["filters"] = []
     st.session_state.decision_data.resetGlobalDataFilters()
     st.cache_data.clear()
 
-## Filtering UI
-expr_list = []
+# ── Uploaded filter file ─────────────────────────────────────────────
+expr_list: list[pl.Expr] = []
 with st.container(border=True):
     """
     You can (optionally) save and re-apply filters you defined earlier:
     """
-    uploaded_file = st.file_uploader("Use the same data filters you used in previous sessions:", type=["json"])
+    uploaded_file = st.file_uploader(
+        "Use the same data filters you used in previous sessions:",
+        type=["json"],
+    )
     if uploaded_file:
         imported_filters = json.load(uploaded_file)
-        for key, val in imported_filters.items():
+        for val in imported_filters.values():
             str_io = io.StringIO(json.dumps(val))
             expr_list.append(pl.Expr.deserialize(str_io, format="json"))
 
-st.session_state["filters"] = get_data_filters(
+# ── Build filters from widgets ───────────────────────────────────────
+widget_filters = get_data_filters(
     st.session_state.decision_data.unfiltered_raw_decision_data,
     columns=st.session_state.decision_data.getAvailableFieldsForFiltering(),
     queries=expr_list,
     filter_type="global",
 )
 
-# Allow for optional save
-# TODO: consider doing this by default
-if st.session_state["filters"] != []:
-    serialized_exprs = {}
-    for i, expr in enumerate(st.session_state["filters"]):
-        serialized = expr.meta.serialize(format="json")
-        serialized_exprs[i] = json.loads(serialized)
-    data = json.dumps(serialized_exprs)
-    st.download_button(
-        label="Save current filters",
-        data=data,
-        file_name="DecisionAnalyzerFilters.json",
-    )
+# ── Determine active filters ────────────────────────────────────────
+# Widget-derived filters are authoritative when present. When empty
+# (e.g. after page navigation destroyed widget state), fall back to
+# the persistent JSON store so filters survive navigation.  As a last
+# resort, reuse the live filter list from session state.
+if widget_filters:
+    active_filters = widget_filters
+    st.session_state["_applied_filters_json"] = serialize_filters(active_filters)
+elif "_applied_filters_json" in st.session_state:
+    active_filters = deserialize_filters(st.session_state["_applied_filters_json"])
+elif st.session_state.get("filters"):
+    active_filters = st.session_state["filters"]
+    st.session_state["_applied_filters_json"] = serialize_filters(active_filters)
+else:
+    active_filters = []
 
-if st.session_state["filters"] != []:
+st.session_state["filters"] = active_filters
+
+# ── Apply filters and show status ───────────────────────────────────
+if active_filters:
     st.session_state.decision_data.resetGlobalDataFilters()
-    statsBeforeFilter = get_first_level_stats(st.session_state.decision_data.sample)
+    stats_before = get_first_level_stats(st.session_state.decision_data.sample)
 
-    st.session_state.decision_data.applyGlobalDataFilters(st.session_state["filters"])
+    st.session_state.decision_data.applyGlobalDataFilters(active_filters)
 
-    statsAfterFilter = get_first_level_stats(st.session_state.decision_data.sample)
+    stats_after = get_first_level_stats(st.session_state.decision_data.sample)
     st.cache_data.clear()
-    show_filtered_counts(statsBeforeFilter, statsAfterFilter)
+    show_filtered_counts(stats_before, stats_after)
 
-    if st.button("Reset all filters", type="secondary"):
-        st.session_state["_needs_filter_reset"] = True
-        st.rerun()
+    col_download, col_reset = st.columns(2)
+    with col_download:
+        serialized_exprs = {}
+        for i, expr in enumerate(active_filters):
+            serialized_exprs[i] = json.loads(expr.meta.serialize(format="json"))
+        st.download_button(
+            label="Save current filters",
+            data=json.dumps(serialized_exprs),
+            file_name="DecisionAnalyzerFilters.json",
+        )
+    with col_reset:
+        if st.button("Reset all filters", type="secondary"):
+            st.session_state["_needs_filter_reset"] = True
+            st.rerun()
 else:
     st.session_state.decision_data.resetGlobalDataFilters()
     st.cache_data.clear()


### PR DESCRIPTION
## Problem

Navigating away from the Decision Analyzer Home page and returning would unconditionally delete `decision_data` from session state and reset filters to `[]`. This caused:

1. **Home page**: Sample data reloaded every time the user navigated back, even if they had uploaded their own data.
2. **Global Data Filters page**: Filters lost on navigation when all fallback tiers were exhausted.

## Solution

### Home.py
- Removed unconditional `del st.session_state["decision_data"]` and `st.session_state["filters"] = []`.
- Sample data only loads on first visit when no data exists in session state.
- Filters reset only when new data is actually ingested.
- Extracted `_show_data_summary()` helper to display existing data summary without re-processing.

### 1_Global_Data_Filters.py
- Added `st.session_state.get("filters")` as a third fallback tier for filter restoration, improving resilience when both widget state and JSON store are empty.

### da_streamlit_utils.py
- Added `serialize_filters` / `deserialize_filters` helpers and `reset_filter_state` for persistent filter management (from earlier work on this branch).

Closes #545