### PR TITLE
Add polars[rt64] support for large datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ pega_io = ['aioboto3', 'polars_hash']
 api = ['httpx', 'pydantic', 'anyio']
 healthcheck = ['pdstools[adm]', 'great_tables>=0.13', 'quarto', 'papermill', 'xlsxwriter>=3.0', 'pydot', 'ipykernel']
 explanations = ['duckdb', "plotly[express]", "pyarrow", "pyyaml", "ipywidgets"]
-app = ['pdstools[healthcheck]', 'streamlit>=1.45']
+app = ['pdstools[healthcheck]', 'streamlit>=1.45', 'polars[rt64]>=1.30,!=1.35.1,<=1.36.1']
 onnx = [
     'scikit-learn>=1.6.1',
     'skl2onnx>=1.19.1', # Updated to be compatible with onnx 1.19.0+

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -667,15 +667,23 @@ class DecisionAnalyzer:
 
         # Use hash-based sampling for efficiency - this is deterministic per interaction ID
         # but doesn't require collecting all unique IDs first, 15x faster than collecting 50k interactions first.
-        df = (
-            self.decision_data.select(columns_to_keep)
-            .with_columns([(pl.col("Interaction ID").hash() % 1000 < 1000 * sample_rate).alias("_sample")])
-            .filter(pl.col("_sample"))
-            .drop("_sample")
-            .collect()
-            .shrink_to_fit()  # reclaim unused memory (DataFrame-only method)
-            .lazy()  # re-wrap so downstream consumers stay lazy
-        )
+        try:
+            df = (
+                self.decision_data.select(columns_to_keep)
+                .with_columns([(pl.col("Interaction ID").hash() % 1000 < 1000 * sample_rate).alias("_sample")])
+                .filter(pl.col("_sample"))
+                .drop("_sample")
+                .collect()
+                .shrink_to_fit()  # reclaim unused memory (DataFrame-only method)
+                .lazy()  # re-wrap so downstream consumers stay lazy
+            )
+        except Exception as e:
+            if "maximum length reached" in str(e).lower():
+                raise RuntimeError(
+                    "Dataset exceeds Polars' 32-bit row limit (2^32 rows). "
+                    "Install the 64-bit runtime with: uv pip install 'polars[rt64]'"
+                ) from e
+            raise
 
         return df
 

--- a/uv.lock
+++ b/uv.lock
@@ -1107,6 +1107,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.15"
 source = { registry = "https://pypi.org/simple" }
@@ -2052,6 +2061,7 @@ wheels = [
 name = "pdstools"
 source = { editable = "." }
 dependencies = [
+    { name = "humanize" },
     { name = "polars" },
     { name = "typing-extensions" },
 ]
@@ -2201,6 +2211,7 @@ requires-dist = [
     { name = "great-tables", marker = "extra == 'healthcheck'", specifier = ">=0.13" },
     { name = "httpx", marker = "extra == 'api'" },
     { name = "httpx", marker = "extra == 'docs'" },
+    { name = "humanize", specifier = ">=4.0.0" },
     { name = "ipykernel", marker = "extra == 'healthcheck'" },
     { name = "ipywidgets", marker = "extra == 'explanations'" },
     { name = "itables", marker = "extra == 'tests'" },


### PR DESCRIPTION
## Summary

- Add `polars[rt64]` to the `app` optional dependency group to enable 64-bit row indexing by default for Decision Analysis Tool users
- Add error handling in `DecisionAnalyzer.sample()` to catch Polars row limit errors and provide actionable guidance
- Prevents cryptic `pyo3_runtime.PanicException` when loading datasets exceeding 2^32 rows

## Context

Users loading very large decision data files hit Polars' 32-bit row limit (4.3 billion rows) during the sampling phase, which manifested as a silent panic exception. The error message was not visible to users because it occurred inside a Streamlit spinner.

## Changes

**[pyproject.toml:53](pyproject.toml#L53)**: Added `polars[rt64]` to app dependencies with matching version constraints
**[DecisionAnalyzer.py:670-687](python/pdstools/decision_analyzer/DecisionAnalyzer.py#L670-L687)**: Wrapped sampling `.collect()` call in try-except to catch and explain the row limit error

## Test Plan

- [ ] Install fresh environment with `uv pip install -e '.[app]'` and verify `polars[rt64]` is installed
- [ ] Verify existing functionality works with smaller datasets
- [ ] Manually test error message by simulating row limit condition (if feasible)
- [ ] Confirm no breaking changes to existing Decision Analysis Tool workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)