### PR TITLE
feat(decision_analyzer): support human-readable notation in --sample flag

### DIFF
--- a/python/pdstools/cli.py
+++ b/python/pdstools/cli.py
@@ -78,7 +78,7 @@ def create_parser():
         default=None,
         help=(
             "Pre-ingestion interaction sampling for large datasets. "
-            "Specify an absolute count (e.g. '100000') or a percentage "
+            "Specify an absolute count (e.g. '100000', '100k', '1M') or a percentage "
             "(e.g. '10%%'). All rows for each sampled interaction are kept. "
             "Exposed to the app as the PDSTOOLS_SAMPLE_LIMIT env var."
         ),

--- a/python/pdstools/decision_analyzer/utils.py
+++ b/python/pdstools/decision_analyzer/utils.py
@@ -759,7 +759,8 @@ def prepare_and_save(
 def parse_sample_flag(value: str) -> dict[str, int | float]:
     """Parse the ``--sample`` CLI flag value into keyword arguments.
 
-    Supports absolute counts (``"100000"``) and percentages (``"10%"``).
+    Supports absolute counts (``"100000"``), percentages (``"10%"``),
+    and human-readable notation (``"100k"``, ``"1M"``).
 
     Returns
     -------
@@ -772,11 +773,22 @@ def parse_sample_flag(value: str) -> dict[str, int | float]:
         if not 0 < pct <= 100:
             raise ValueError(f"Percentage must be in (0, 100], got {pct}")
         return {"fraction": pct / 100.0}
+
+    # Parse human-readable notation (k/K for thousands, m/M for millions)
+    multiplier = None
+    if value.lower().endswith("k"):
+        multiplier = 1000
+    elif value.lower().endswith("m"):
+        multiplier = 1000000
+
+    if multiplier:
+        count = int(float(value[:-1]) * multiplier)
     else:
         count = int(value)
-        if count <= 0:
-            raise ValueError(f"Sample count must be positive, got {count}")
-        return {"n": count}
+
+    if count <= 0:
+        raise ValueError(f"Sample count must be positive, got {count}")
+    return {"n": count}
 
 
 def format_count_for_filename(count: int) -> str:

--- a/python/tests/test_da_utils.py
+++ b/python/tests/test_da_utils.py
@@ -83,6 +83,34 @@ class TestParseSampleFlag:
         result = parse_sample_flag("1")
         assert result == {"n": 1}
 
+    def test_thousands_notation_lowercase_k(self):
+        result = parse_sample_flag("100k")
+        assert result == {"n": 100000}
+
+    def test_thousands_notation_uppercase_k(self):
+        result = parse_sample_flag("100K")
+        assert result == {"n": 100000}
+
+    def test_millions_notation_lowercase_m(self):
+        result = parse_sample_flag("1M")
+        assert result == {"n": 1000000}
+
+    def test_millions_notation_uppercase_m(self):
+        result = parse_sample_flag("1m")
+        assert result == {"n": 1000000}
+
+    def test_decimal_thousands(self):
+        result = parse_sample_flag("1.5k")
+        assert result == {"n": 1500}
+
+    def test_decimal_millions(self):
+        result = parse_sample_flag("2.5M")
+        assert result == {"n": 2500000}
+
+    def test_thousands_with_whitespace(self):
+        result = parse_sample_flag("  50k  ")
+        assert result == {"n": 50000}
+
 
 # ---------------------------------------------------------------------------
 # format_count_for_filename


### PR DESCRIPTION
## Summary

Add support for human-readable size notation (k/K for thousands, m/M for millions) in the `--sample` CLI flag to make it easier to specify large sample sizes.

## Changes

- **Enhanced `parse_sample_flag()`** to parse human-readable notation:
  - "100k" or "100K" → 100,000
  - "1M" or "1m" → 1,000,000
  - "1.5k" → 1,500
  - "2.5M" → 2,500,000
  - Case-insensitive, supports decimal values

- **Updated CLI help text** to document the new formats

- **Added comprehensive test coverage** with 7 new tests covering:
  - Lowercase and uppercase notation (k, K, m, M)
  - Decimal values (1.5k, 2.5M)
  - Whitespace handling

## Examples

```bash
# Before - only absolute counts or percentages
pdstools decision_analyzer --sample 100000
pdstools decision_analyzer --sample 10%

# After - also supports human-readable notation
pdstools decision_analyzer --sample 100k
pdstools decision_analyzer --sample 1M
pdstools decision_analyzer --sample 1.5M
```

## Testing

All tests pass:
- ✅ 17 tests in `TestParseSampleFlag` (10 existing + 7 new)
- ✅ 108 tests in decision_analyzer and CLI modules
- ✅ All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)