### PR TITLE
fix: weighted average report corrected

### DIFF
--- a/python/pdstools/explanations/Aggregate.py
+++ b/python/pdstools/explanations/Aggregate.py
@@ -55,6 +55,7 @@ class Aggregate(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
+        include_numeric_single_bin: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
     ):
         """Get the top-n predictor contributions for a given context or overall.
@@ -71,6 +72,9 @@ class Aggregate(LazyNamespace):
                 Whether to include contributions for missing predictor values.
             remaining (bool):
                 Whether to include contributions for remaining predictors outside the top-n.
+            include_numeric_single_bin (bool):
+                Whether to include numeric predictors that have only a single
+                non-missing bin. Default is False (exclude them).
             sort_by (str):
                 Method to sort/select top contributions. Options include
                 `contribution`, `contribution_abs`, `contribution_weighted`.
@@ -93,6 +97,7 @@ class Aggregate(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
+            include_numeric_single_bin=include_numeric_single_bin,
             sort_by=validated_sort_by.value,
         )
 
@@ -104,6 +109,7 @@ class Aggregate(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
+        include_numeric_single_bin: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
     ):
         """Get the top-k predictor value contributions for a given context or overall.
@@ -122,6 +128,9 @@ class Aggregate(LazyNamespace):
                 Whether to include contributions for missing predictor values.
             remaining (bool):
                 Whether to include contributions for remaining predictors outside the top-n.
+            include_numeric_single_bin (bool):
+                Whether to include numeric predictors that have only a single
+                non-missing bin. Default is False (exclude them).
             sort_by (str):
                 Method to sort/select top contributions. Options include
                 `contribution`, `contribution_abs`, `contribution_weighted`.
@@ -145,6 +154,7 @@ class Aggregate(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
+            include_numeric_single_bin=include_numeric_single_bin,
             sort_by=validated_sort_by.value,
         )
 
@@ -206,15 +216,12 @@ class Aggregate(LazyNamespace):
             .filter(pl.col(_COL.CONTRIBUTION.value) != 0.0)
             .sort(by=_COL.PREDICTOR_NAME.value)
         )
-        self.df_contextual = self._filter_single_bin_numeric_predictors(self.df_contextual)
-
         self.df_overall = (
             pl.scan_parquet(f"{self.data_folderpath}/*_OVERALL.parquet")
             .select(selected_columns)
             .filter(pl.col(_COL.CONTRIBUTION.value) != 0.0)
             .sort(by=_COL.PREDICTOR_NAME.value)
         )
-        self.df_overall = self._filter_single_bin_numeric_predictors(self.df_overall)
 
         self.initialized = True
 
@@ -226,6 +233,7 @@ class Aggregate(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
+        include_numeric_single_bin: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
     ) -> pl.DataFrame:
         contexts = contexts or []
@@ -236,6 +244,9 @@ class Aggregate(LazyNamespace):
         # and load the data for those contexts
         df = self._get_df(contexts)
 
+        if not include_numeric_single_bin:
+            df = self._filter_single_bin_numeric_predictors(df)
+
         # If predictors are specified we filter the dataframe for those predictors
         if len(predictors) > 0:
             df = self._filter_for_predictors(df, predictors)
@@ -245,10 +256,15 @@ class Aggregate(LazyNamespace):
             df = df.filter(_COL.BIN_CONTENTS.value != _SPECIAL.MISSING.name)
 
         # Aggregate all the different types of contributions
-        # note: we need to aggregate frequency over partition to calculate weighted contributions
+        # note: total_frequency is computed per predictor so the weighted average
+        # divides by that predictor's own bin frequencies, not the entire partition.
         df = self._calculate_aggregates(
             df,
-            frequency_over=[_COL.PARTITON.value],
+            frequency_over=[
+                _COL.PARTITON.value,
+                _COL.PREDICTOR_NAME.value,
+                _COL.PREDICTOR_TYPE.value,
+            ],
             aggregate_over=[
                 _COL.PARTITON.value,
                 _COL.PREDICTOR_NAME.value,
@@ -300,12 +316,16 @@ class Aggregate(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
+        include_numeric_single_bin: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
     ) -> pl.DataFrame:
         # if no contexts are provided, then we return the overall data
         # if contexts are provided, then we generate the context filters
         # and load the data for those contexts
         df = self._get_df(contexts)
+
+        if not include_numeric_single_bin:
+            df = self._filter_single_bin_numeric_predictors(df)
 
         # If predictors are specified we filter the dataframe for those predictors
         predictors = predictors or []
@@ -590,7 +610,7 @@ class Aggregate(LazyNamespace):
 
         def _apply(col, alias):
             return (
-                (pl.col(col) * pl.col(_COL.FREQUENCY.value)).mean() / pl.col(_SPECIAL.TOTAL_FREQUENCY.value).first()
+                (pl.col(col) * pl.col(_COL.FREQUENCY.value)).sum() / pl.col(_SPECIAL.TOTAL_FREQUENCY.value).first()
             ).alias(alias)
 
         return [

--- a/python/pdstools/explanations/ExplanationsUtils.py
+++ b/python/pdstools/explanations/ExplanationsUtils.py
@@ -118,6 +118,7 @@ class _Defaults:
     descending: bool = True
     missing: bool = True
     remaining: bool = True
+    include_numeric_single_bin: bool = False
     sort_by: _CONTRIBUTION_TYPE = _CONTRIBUTION_TYPE.CONTRIBUTION_ABS
     display_by: _CONTRIBUTION_TYPE = _CONTRIBUTION_TYPE.CONTRIBUTION
 

--- a/python/pdstools/explanations/Plots.py
+++ b/python/pdstools/explanations/Plots.py
@@ -38,6 +38,7 @@ class Plots(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
+        single_bin_numeric: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
         display_by: str = defaults.display_by.value,
     ):
@@ -78,6 +79,7 @@ class Plots(LazyNamespace):
                 descending=descending,
                 missing=missing,
                 remaining=remaining,
+                single_bin_numeric=single_bin_numeric,
                 sort_by=validated_sort_by.value,
                 display_by=validated_display_by.value,
             )
@@ -98,6 +100,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
+            single_bin_numeric=single_bin_numeric,
             sort_by=validated_sort_by.value,
             display_by=validated_display_by.value,
         )
@@ -115,6 +118,7 @@ class Plots(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
+        single_bin_numeric: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
         display_by: str = defaults.display_by.value,
     ) -> tuple[go.Figure, list[go.Figure]]:
@@ -126,6 +130,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
+            include_numeric_single_bin=single_bin_numeric,
             sort_by=validated_sort_by.value,
         )
 
@@ -143,6 +148,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
+            include_numeric_single_bin=single_bin_numeric,
             sort_by=validated_sort_by.value,
         )
 
@@ -169,6 +175,7 @@ class Plots(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
+        single_bin_numeric: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
         display_by: str = defaults.display_by.value,
     ) -> tuple[go.Figure, go.Figure, list[go.Figure]]:
@@ -181,6 +188,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
+            include_numeric_single_bin=single_bin_numeric,
             sort_by=validated_sort_by.value,
         )
 
@@ -207,6 +215,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
+            include_numeric_single_bin=single_bin_numeric,
             sort_by=validated_sort_by.value,
         )
 

--- a/python/pdstools/explanations/Plots.py
+++ b/python/pdstools/explanations/Plots.py
@@ -38,7 +38,7 @@ class Plots(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
-        single_bin_numeric: bool = defaults.include_numeric_single_bin,
+        include_numeric_single_bin: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
         display_by: str = defaults.display_by.value,
     ):
@@ -79,7 +79,7 @@ class Plots(LazyNamespace):
                 descending=descending,
                 missing=missing,
                 remaining=remaining,
-                single_bin_numeric=single_bin_numeric,
+                include_numeric_single_bin=include_numeric_single_bin,
                 sort_by=validated_sort_by.value,
                 display_by=validated_display_by.value,
             )
@@ -100,7 +100,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
-            single_bin_numeric=single_bin_numeric,
+            include_numeric_single_bin=include_numeric_single_bin,
             sort_by=validated_sort_by.value,
             display_by=validated_display_by.value,
         )
@@ -118,7 +118,7 @@ class Plots(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
-        single_bin_numeric: bool = defaults.include_numeric_single_bin,
+        include_numeric_single_bin: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
         display_by: str = defaults.display_by.value,
     ) -> tuple[go.Figure, list[go.Figure]]:
@@ -130,7 +130,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
-            include_numeric_single_bin=single_bin_numeric,
+            include_numeric_single_bin=include_numeric_single_bin,
             sort_by=validated_sort_by.value,
         )
 
@@ -148,7 +148,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
-            include_numeric_single_bin=single_bin_numeric,
+            include_numeric_single_bin=include_numeric_single_bin,
             sort_by=validated_sort_by.value,
         )
 
@@ -175,7 +175,7 @@ class Plots(LazyNamespace):
         descending: bool = defaults.descending,
         missing: bool = defaults.missing,
         remaining: bool = defaults.remaining,
-        single_bin_numeric: bool = defaults.include_numeric_single_bin,
+        include_numeric_single_bin: bool = defaults.include_numeric_single_bin,
         sort_by: str = defaults.sort_by.value,
         display_by: str = defaults.display_by.value,
     ) -> tuple[go.Figure, go.Figure, list[go.Figure]]:
@@ -188,7 +188,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
-            include_numeric_single_bin=single_bin_numeric,
+            include_numeric_single_bin=include_numeric_single_bin,
             sort_by=validated_sort_by.value,
         )
 
@@ -215,7 +215,7 @@ class Plots(LazyNamespace):
             descending=descending,
             missing=missing,
             remaining=remaining,
-            include_numeric_single_bin=single_bin_numeric,
+            include_numeric_single_bin=include_numeric_single_bin,
             sort_by=validated_sort_by.value,
         )
 

--- a/python/tests/explanations/test_ExplanationsAggregate.py
+++ b/python/tests/explanations/test_ExplanationsAggregate.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import polars as pl
 import pytest
 from pdstools.explanations import Explanations
+from pdstools.explanations.ExplanationsUtils import _COL, _SPECIAL
 
 basePath = Path(__file__).parent.parent.parent.parent
 
@@ -303,6 +304,369 @@ class TestAggregateFrequencyPct:
         result = aggregate.add_frequency_pct_to_df(df, group_by=["partition"]).collect()
         assert (result["frequency_pct"] >= 0.0).all()
         assert (result["frequency_pct"] <= 100.0).all()
+
+
+class TestWeightedAverageComputation:
+    """Unit tests for the weighted average contribution calculation.
+
+    These tests exercise _calculate_aggregates, _add_total_frequency_to_df,
+    _get_weighted_aggregates, and _filter_single_bin_numeric_predictors using
+    minimal in-memory DataFrames — no parquet files required.
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_df(rows: list[dict]) -> pl.LazyFrame:
+        """Build a LazyFrame from a list of dicts matching the Aggregate schema."""
+
+        schema = {
+            _COL.PARTITON.value: pl.Utf8,
+            _COL.PREDICTOR_NAME.value: pl.Utf8,
+            _COL.PREDICTOR_TYPE.value: pl.Utf8,
+            _COL.BIN_CONTENTS.value: pl.Utf8,
+            _COL.BIN_ORDER.value: pl.Int64,
+            _COL.CONTRIBUTION.value: pl.Float64,
+            _COL.CONTRIBUTION_ABS.value: pl.Float64,
+            _COL.CONTRIBUTION_MIN.value: pl.Float64,
+            _COL.CONTRIBUTION_MAX.value: pl.Float64,
+            _COL.FREQUENCY.value: pl.Int64,
+        }
+        return pl.DataFrame(rows, schema=schema).lazy()
+
+    # ------------------------------------------------------------------
+    # _add_total_frequency_to_df
+    # ------------------------------------------------------------------
+
+    def test_total_frequency_per_predictor(self, aggregate):
+        """total_frequency equals the sum of all bin frequencies for the group."""
+
+        df = self._make_df(
+            [
+                {
+                    "partition": "p1",
+                    "predictor_name": "Age",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[0:30]",
+                    "bin_order": 1,
+                    "contribution": 0.2,
+                    "contribution_abs": 0.2,
+                    "contribution_min": 0.1,
+                    "contribution_max": 0.3,
+                    "frequency": 100,
+                },
+                {
+                    "partition": "p1",
+                    "predictor_name": "Age",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[30:60]",
+                    "bin_order": 2,
+                    "contribution": 0.8,
+                    "contribution_abs": 0.8,
+                    "contribution_min": 0.6,
+                    "contribution_max": 0.9,
+                    "frequency": 50,
+                },
+            ]
+        )
+        result = aggregate._add_total_frequency_to_df(
+            df, group_by=[_COL.PARTITON.value, _COL.PREDICTOR_NAME.value, _COL.PREDICTOR_TYPE.value]
+        ).collect()
+
+        assert (result[_SPECIAL.TOTAL_FREQUENCY.value] == 150).all()
+
+    # ------------------------------------------------------------------
+    # _get_weighted_aggregates (formula: sum(c*f) / total_f)
+    # ------------------------------------------------------------------
+
+    def test_weighted_average_formula_correctness(self, aggregate):
+        """contribution_weighted = sum(contribution * frequency) / total_frequency.
+
+        With bin A (contribution=0.2, frequency=100) and bin B (contribution=0.8,
+        frequency=50), total=150:
+          correct  = (0.2*100 + 0.8*50) / 150 = 60/150 = 0.4
+          wrong    = mean(0.2*100, 0.8*50) / 150 = 30/150 = 0.2
+        """
+
+        df = self._make_df(
+            [
+                {
+                    "partition": "p1",
+                    "predictor_name": "Age",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[0:30]",
+                    "bin_order": 1,
+                    "contribution": 0.2,
+                    "contribution_abs": 0.2,
+                    "contribution_min": 0.2,
+                    "contribution_max": 0.2,
+                    "frequency": 100,
+                },
+                {
+                    "partition": "p1",
+                    "predictor_name": "Age",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[30:60]",
+                    "bin_order": 2,
+                    "contribution": 0.8,
+                    "contribution_abs": 0.8,
+                    "contribution_min": 0.8,
+                    "contribution_max": 0.8,
+                    "frequency": 50,
+                },
+            ]
+        )
+        result = aggregate._calculate_aggregates(
+            df,
+            frequency_over=[_COL.PARTITON.value, _COL.PREDICTOR_NAME.value, _COL.PREDICTOR_TYPE.value],
+            aggregate_over=[_COL.PARTITON.value, _COL.PREDICTOR_NAME.value, _COL.PREDICTOR_TYPE.value],
+        ).collect()
+
+        assert result.shape[0] == 1
+        weighted = result[_COL.CONTRIBUTION_WEIGHTED.value][0]
+        assert abs(weighted - 0.4) < 1e-9, f"Expected 0.4, got {weighted}"
+
+    def test_weighted_average_equal_frequencies_matches_mean(self, aggregate):
+        """When all bins have equal frequency, weighted avg equals simple mean."""
+
+        df = self._make_df(
+            [
+                {
+                    "partition": "p1",
+                    "predictor_name": "Color",
+                    "predictor_type": "SYMBOLIC",
+                    "bin_contents": "Red",
+                    "bin_order": 1,
+                    "contribution": 0.3,
+                    "contribution_abs": 0.3,
+                    "contribution_min": 0.3,
+                    "contribution_max": 0.3,
+                    "frequency": 100,
+                },
+                {
+                    "partition": "p1",
+                    "predictor_name": "Color",
+                    "predictor_type": "SYMBOLIC",
+                    "bin_contents": "Blue",
+                    "bin_order": 2,
+                    "contribution": 0.7,
+                    "contribution_abs": 0.7,
+                    "contribution_min": 0.7,
+                    "contribution_max": 0.7,
+                    "frequency": 100,
+                },
+            ]
+        )
+        result = aggregate._calculate_aggregates(
+            df,
+            frequency_over=[_COL.PARTITON.value, _COL.PREDICTOR_NAME.value, _COL.PREDICTOR_TYPE.value],
+            aggregate_over=[_COL.PARTITON.value, _COL.PREDICTOR_NAME.value, _COL.PREDICTOR_TYPE.value],
+        ).collect()
+
+        weighted = result[_COL.CONTRIBUTION_WEIGHTED.value][0]
+        mean_val = result[_COL.CONTRIBUTION.value][0]
+        assert abs(weighted - mean_val) < 1e-9
+
+    # ------------------------------------------------------------------
+    # frequency_over scoped per predictor (not per partition)
+    # ------------------------------------------------------------------
+
+    def test_weighted_average_scoped_per_predictor(self, aggregate):
+        """Each predictor's weighted average divides by its own bin frequencies.
+
+        Two predictors in the same partition with different frequency totals:
+          Age:   bins (freq=100, c=0.2) + (freq=100, c=0.8)  → total=200, weighted=0.5
+          Score: bins (freq=10,  c=0.1) + (freq=90,  c=0.9)  → total=100, weighted=0.82
+        If frequency_over were scoped to partition only, both would use total=300
+        and produce wrong results.
+        """
+
+        df = self._make_df(
+            [
+                {
+                    "partition": "p1",
+                    "predictor_name": "Age",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[0:30]",
+                    "bin_order": 1,
+                    "contribution": 0.2,
+                    "contribution_abs": 0.2,
+                    "contribution_min": 0.2,
+                    "contribution_max": 0.2,
+                    "frequency": 100,
+                },
+                {
+                    "partition": "p1",
+                    "predictor_name": "Age",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[30:60]",
+                    "bin_order": 2,
+                    "contribution": 0.8,
+                    "contribution_abs": 0.8,
+                    "contribution_min": 0.8,
+                    "contribution_max": 0.8,
+                    "frequency": 100,
+                },
+                {
+                    "partition": "p1",
+                    "predictor_name": "Score",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[0:50]",
+                    "bin_order": 1,
+                    "contribution": 0.1,
+                    "contribution_abs": 0.1,
+                    "contribution_min": 0.1,
+                    "contribution_max": 0.1,
+                    "frequency": 10,
+                },
+                {
+                    "partition": "p1",
+                    "predictor_name": "Score",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[50:100]",
+                    "bin_order": 2,
+                    "contribution": 0.9,
+                    "contribution_abs": 0.9,
+                    "contribution_min": 0.9,
+                    "contribution_max": 0.9,
+                    "frequency": 90,
+                },
+            ]
+        )
+        result = aggregate._calculate_aggregates(
+            df,
+            frequency_over=[_COL.PARTITON.value, _COL.PREDICTOR_NAME.value, _COL.PREDICTOR_TYPE.value],
+            aggregate_over=[_COL.PARTITON.value, _COL.PREDICTOR_NAME.value, _COL.PREDICTOR_TYPE.value],
+        ).collect()
+
+        by_name = {row["predictor_name"]: row for row in result.to_dicts()}
+
+        age_weighted = by_name["Age"][_COL.CONTRIBUTION_WEIGHTED.value]
+        # (0.2*100 + 0.8*100) / 200 = 100/200 = 0.5
+        assert abs(age_weighted - 0.5) < 1e-9, f"Age weighted: expected 0.5, got {age_weighted}"
+
+        score_weighted = by_name["Score"][_COL.CONTRIBUTION_WEIGHTED.value]
+        # (0.1*10 + 0.9*90) / 100 = (1 + 81) / 100 = 0.82
+        assert abs(score_weighted - 0.82) < 1e-9, f"Score weighted: expected 0.82, got {score_weighted}"
+
+    # ------------------------------------------------------------------
+    # _filter_single_bin_numeric_predictors
+    # ------------------------------------------------------------------
+
+    def test_single_bin_numeric_predictor_excluded(self, aggregate):
+        """A numeric predictor with exactly one non-missing bin is filtered out."""
+
+        df = self._make_df(
+            [
+                {
+                    "partition": "p1",
+                    "predictor_name": "OneRange",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[0:100]",
+                    "bin_order": 1,
+                    "contribution": 0.5,
+                    "contribution_abs": 0.5,
+                    "contribution_min": 0.5,
+                    "contribution_max": 0.5,
+                    "frequency": 200,
+                },
+            ]
+        )
+        result = aggregate._filter_single_bin_numeric_predictors(df).collect()
+        assert result.is_empty(), "Single-bin numeric predictor should be filtered out"
+
+    def test_multi_bin_numeric_predictor_retained(self, aggregate):
+        """A numeric predictor with two or more non-missing bins is kept."""
+
+        df = self._make_df(
+            [
+                {
+                    "partition": "p1",
+                    "predictor_name": "Age",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[0:30]",
+                    "bin_order": 1,
+                    "contribution": 0.2,
+                    "contribution_abs": 0.2,
+                    "contribution_min": 0.2,
+                    "contribution_max": 0.2,
+                    "frequency": 100,
+                },
+                {
+                    "partition": "p1",
+                    "predictor_name": "Age",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[30:60]",
+                    "bin_order": 2,
+                    "contribution": 0.8,
+                    "contribution_abs": 0.8,
+                    "contribution_min": 0.8,
+                    "contribution_max": 0.8,
+                    "frequency": 50,
+                },
+            ]
+        )
+        result = aggregate._filter_single_bin_numeric_predictors(df).collect()
+        assert result.shape[0] == 2, "Multi-bin numeric predictor should not be filtered"
+
+    def test_symbolic_single_bin_not_filtered(self, aggregate):
+        """A symbolic predictor with only one bin is NOT filtered (rule is numeric-only)."""
+
+        df = self._make_df(
+            [
+                {
+                    "partition": "p1",
+                    "predictor_name": "Color",
+                    "predictor_type": "SYMBOLIC",
+                    "bin_contents": "Red",
+                    "bin_order": 1,
+                    "contribution": 0.5,
+                    "contribution_abs": 0.5,
+                    "contribution_min": 0.5,
+                    "contribution_max": 0.5,
+                    "frequency": 100,
+                },
+            ]
+        )
+        result = aggregate._filter_single_bin_numeric_predictors(df).collect()
+        assert result.shape[0] == 1, "Single-bin symbolic predictor should be retained"
+
+    def test_missing_bin_not_counted_for_single_bin_check(self, aggregate):
+        """A MISSING bin does not count toward the bin count; a numeric predictor
+        with only one real bin plus a MISSING bin should still be filtered."""
+
+        df = self._make_df(
+            [
+                {
+                    "partition": "p1",
+                    "predictor_name": "Score",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": "[0:100]",
+                    "bin_order": 1,
+                    "contribution": 0.4,
+                    "contribution_abs": 0.4,
+                    "contribution_min": 0.4,
+                    "contribution_max": 0.4,
+                    "frequency": 80,
+                },
+                {
+                    "partition": "p1",
+                    "predictor_name": "Score",
+                    "predictor_type": "NUMERIC",
+                    "bin_contents": _SPECIAL.MISSING.name,
+                    "bin_order": 2,
+                    "contribution": 0.1,
+                    "contribution_abs": 0.1,
+                    "contribution_min": 0.1,
+                    "contribution_max": 0.1,
+                    "frequency": 20,
+                },
+            ]
+        )
+        result = aggregate._filter_single_bin_numeric_predictors(df).collect()
+        assert result.is_empty(), "Numeric predictor with only one real bin (plus MISSING) should be filtered"
 
 
 def assert_df_has_top_n(df, top_n):


### PR DESCRIPTION
# fix: weighted average report corrected

**Branch:** `team/easypz/TASK-1890691-weighted-average`  
**Commit:** `ad6f815e`

## Summary

Fixes two related bugs in the explanations/weighted-average reporting logic in the `Aggregate` class.

## Changes

### Bug fix: weighted average formula

Corrects the weighted average calculation from `.mean()` to `.sum()` in the `_apply` helper. The previous formula was computing `mean(contribution × frequency) / total_frequency`, which double-averaged and produced incorrect results. The correct formula is `sum(contribution × frequency) / total_frequency`.

### Bug fix: `frequency_over` scope for weighted contributions

The frequency denominator (`total_frequency`) is now computed per predictor (grouped by `PARTITION + PREDICTOR_NAME + PREDICTOR_TYPE`) rather than per partition only. This ensures each predictor's weighted average divides by its own bin frequencies, not the entire partition's total.

### New parameter: `include_numeric_single_bin`

Moves single-bin numeric predictor filtering from data load time (always-on) to query time (opt-in via `include_numeric_single_bin=True`, default `False`). This is threaded through `get_contributions`, `get_top_bins`, `_get_weighted_average_contributions`, and all `Plots` methods.

## Files changed

- `python/pdstools/explanations/Aggregate.py` — formula fix, frequency scope fix, lazy filtering
- `python/pdstools/explanations/ExplanationsUtils.py` — adds `include_numeric_single_bin` default
- `python/pdstools/explanations/Plots.py` — threads `single_bin_numeric` parameter through all plot methods

RCA -> 
[rca-weighted-avg-presentation.html](https://github.com/user-attachments/files/26671601/rca-weighted-avg-presentation.html)

