### PR TITLE
feat(plots): add metric limit lines to Health Check charts

### DIFF
--- a/python/pdstools/adm/Plots.py
+++ b/python/pdstools/adm/Plots.py
@@ -183,27 +183,7 @@ def add_metric_limit_lines(
     metric_id: str = "ModelPerformance",
     scale: float = 100.0,
 ) -> Figure:
-    """Add dashed vertical lines at metric limit thresholds.
-
-    Draws subtle dashed vertical lines at the threshold values defined
-    in MetricLimits for the given metric. Hard limits (minimum/maximum)
-    are shown in red, best practice limits in orange/amber.
-
-    Parameters
-    ----------
-    fig : Figure
-        The Plotly figure to annotate.
-    metric_id : str, optional
-        The metric ID to look up in MetricLimits, by default "ModelPerformance".
-    scale : float, optional
-        Scale factor applied to the limit values, by default 100.0
-        (converts from 0-1 to 0-100 scale used in bubble charts).
-
-    Returns
-    -------
-    Figure
-        The updated Plotly figure.
-    """
+    """Add dashed vertical lines at MetricLimits thresholds (red=hard, orange=best practice)."""
     limits = MetricLimits.get_limit_for_metric(metric_id)
     if not limits:
         return fig

--- a/python/pdstools/adm/Plots.py
+++ b/python/pdstools/adm/Plots.py
@@ -182,11 +182,15 @@ def add_metric_limit_lines(
     fig: Figure,
     metric_id: str = "ModelPerformance",
     scale: float = 100.0,
+    orientation: str = "vertical",
 ) -> Figure:
-    """Add dashed vertical lines at MetricLimits thresholds (red=hard, orange=best practice)."""
+    """Add dashed lines at MetricLimits thresholds (red=hard, green=best practice)."""
     limits = MetricLimits.get_limit_for_metric(metric_id)
     if not limits:
         return fig
+
+    add_line = fig.add_vline if orientation == "vertical" else fig.add_hline
+    pos_key = "x" if orientation == "vertical" else "y"
 
     line_specs = [
         ("minimum", "rgba(255, 69, 0, 0.5)", "Min"),
@@ -199,14 +203,14 @@ def add_metric_limit_lines(
         value = limits.get(limit_key)
         if value is not None:
             scaled = value * scale
-            fig.add_vline(
-                x=scaled,
+            add_line(
+                **{pos_key: scaled},
                 line_dash="dash",
                 line_width=1,
                 line_color=color,
                 layer="below",
                 annotation_text=f"{label} ({scaled:.0f})",
-                annotation_position="top",
+                annotation_position="top" if orientation == "vertical" else "right",
                 annotation_font_size=9,
                 annotation_font_color=color,
             )
@@ -361,6 +365,7 @@ class Plots(LazyNamespace):
         cumulative: bool = True,
         query: QUERY | None = None,
         facet: str | None = None,
+        show_metric_limits: bool = False,
         return_df: bool = False,
     ):
         """Statistics over time
@@ -380,6 +385,10 @@ class Plots(LazyNamespace):
             The query to apply to the data, by default None
         facet : Optional[str], optional
             Whether to facet the plot into subplots, by default None
+        show_metric_limits : bool, optional
+            Whether to show dashed horizontal lines at the metric limit
+            thresholds (from MetricLimits.csv), by default False.
+            Only applies when metric is "Performance".
         return_df : bool, optional
             Whether to return a dataframe instead of a plot, by default False
 
@@ -489,6 +498,9 @@ class Plots(LazyNamespace):
         if metric == "SuccessRate":
             fig.update_yaxes(tickformat=".2%")
             fig.update_layout(yaxis={"rangemode": "tozero"})
+
+        if show_metric_limits and metric == "Performance":
+            fig = add_metric_limit_lines(fig, orientation="horizontal")
 
         return fig
 

--- a/python/pdstools/adm/Plots.py
+++ b/python/pdstools/adm/Plots.py
@@ -190,8 +190,8 @@ def add_metric_limit_lines(
 
     line_specs = [
         ("minimum", "rgba(255, 69, 0, 0.5)", "Min"),
-        ("best_practice_min", "rgba(255, 165, 0, 0.5)", "Best"),
-        ("best_practice_max", "rgba(255, 165, 0, 0.5)", "Best"),
+        ("best_practice_min", "rgba(0, 128, 0, 0.5)", "Good"),
+        ("best_practice_max", "rgba(0, 128, 0, 0.5)", "Good"),
         ("maximum", "rgba(255, 69, 0, 0.5)", "Max"),
     ]
 

--- a/python/pdstools/adm/Plots.py
+++ b/python/pdstools/adm/Plots.py
@@ -137,7 +137,7 @@ def fig_update_facet(
     n_rows = max(math.ceil(len(fig.layout.annotations) / n_cols), 1)
     height = base_height + (n_rows * step_height)
     return fig.for_each_annotation(
-        lambda a: a.update(text=a.text.split("=")[1]),
+        lambda a: a.update(text=a.text.split("=")[1]) if "=" in a.text else a,
     ).update_layout(autosize=True, height=height)
 
 

--- a/python/pdstools/adm/Plots.py
+++ b/python/pdstools/adm/Plots.py
@@ -20,6 +20,7 @@ from typing_extensions import ParamSpec
 from typing import Concatenate
 
 from ..utils import cdh_utils
+from ..utils.metric_limits import MetricLimits
 from ..utils.namespaces import LazyNamespace
 from ..utils.plot_utils import get_colorscale
 from ..utils.types import QUERY
@@ -177,6 +178,62 @@ def add_bottom_left_text_to_bubble_plot(
     return fig
 
 
+def add_metric_limit_lines(
+    fig: Figure,
+    metric_id: str = "ModelPerformance",
+    scale: float = 100.0,
+) -> Figure:
+    """Add dashed vertical lines at metric limit thresholds.
+
+    Draws subtle dashed vertical lines at the threshold values defined
+    in MetricLimits for the given metric. Hard limits (minimum/maximum)
+    are shown in red, best practice limits in orange/amber.
+
+    Parameters
+    ----------
+    fig : Figure
+        The Plotly figure to annotate.
+    metric_id : str, optional
+        The metric ID to look up in MetricLimits, by default "ModelPerformance".
+    scale : float, optional
+        Scale factor applied to the limit values, by default 100.0
+        (converts from 0-1 to 0-100 scale used in bubble charts).
+
+    Returns
+    -------
+    Figure
+        The updated Plotly figure.
+    """
+    limits = MetricLimits.get_limit_for_metric(metric_id)
+    if not limits:
+        return fig
+
+    line_specs = [
+        ("minimum", "rgba(255, 69, 0, 0.5)", "Min"),
+        ("best_practice_min", "rgba(255, 165, 0, 0.5)", "Best"),
+        ("best_practice_max", "rgba(255, 165, 0, 0.5)", "Best"),
+        ("maximum", "rgba(255, 69, 0, 0.5)", "Max"),
+    ]
+
+    for limit_key, color, label in line_specs:
+        value = limits.get(limit_key)
+        if value is not None:
+            scaled = value * scale
+            fig.add_vline(
+                x=scaled,
+                line_dash="dash",
+                line_width=1,
+                line_color=color,
+                layer="below",
+                annotation_text=f"{label} ({scaled:.0f})",
+                annotation_position="top",
+                annotation_font_size=9,
+                annotation_font_color=color,
+            )
+
+    return fig
+
+
 def distribution_graph(df: pl.LazyFrame, title: str):
     plot_df = df.collect()
     fig = make_subplots(specs=[[{"secondary_y": True}]])
@@ -224,6 +281,7 @@ class Plots(LazyNamespace):
         query: QUERY | None = None,
         facet: str | pl.Expr | None = None,
         color: str | None = "Performance",
+        show_metric_limits: bool = False,
         return_df: bool = False,
     ):
         """The Bubble Chart, as seen in Prediction Studio
@@ -238,6 +296,9 @@ class Plots(LazyNamespace):
             The query to apply to the data, by default None
         facet : Optional[Union[str, pl.Expr]], optional
             Column name or Polars expression to facet the plot into subplots, by default None
+        show_metric_limits : bool, optional
+            Whether to show dashed vertical lines at the ModelPerformance
+            metric limit thresholds (from MetricLimits.csv), by default False
         return_df : bool, optional
             Whether to return a dataframe instead of a plot, by default False
 
@@ -302,6 +363,8 @@ class Plots(LazyNamespace):
             labels={"LastUpdate": "Last Updated"},
         )
         fig = add_bottom_left_text_to_bubble_plot(fig, df, 1)
+        if show_metric_limits:
+            fig = add_metric_limit_lines(fig)
         fig.update_traces(marker=dict(line=dict(color="black")))
         fig.update_yaxes(tickformat=".3%")
         return fig

--- a/python/pdstools/reports/HealthCheck.qmd
+++ b/python/pdstools/reports/HealthCheck.qmd
@@ -234,7 +234,7 @@ try:
         .height
     )
 
-    fig = datamart.plot.bubble_chart(query=active_models_filter_expr, color="Channel")
+    fig = datamart.plot.bubble_chart(query=active_models_filter_expr, color="Channel", show_metric_limits=True)
 
     fig.layout.coloraxis.colorscale = pega_template.success
 
@@ -1137,7 +1137,7 @@ The data contains many ({n_configs}) model configurations. To limit the size of 
             separator="/"
         ).alias("Facet")
 
-    fig = datamart.plot.bubble_chart(facet=facet, query=active_models_filter_expr)
+    fig = datamart.plot.bubble_chart(facet=facet, query=active_models_filter_expr, show_metric_limits=True)
     fig = (
         fig_update_facet(fig)
         .update_layout(

--- a/python/pdstools/reports/HealthCheck.qmd
+++ b/python/pdstools/reports/HealthCheck.qmd
@@ -769,6 +769,21 @@ fig = px.line(
 )
 fig.update_xaxes(title="")
 fig.update_layout(hovermode="x")
+
+from pdstools.utils.metric_limits import MetricLimits
+for key, color, label in [
+    ("minimum", "rgba(255, 69, 0, 0.5)", "Min"),
+    ("best_practice_min", "rgba(0, 128, 0, 0.5)", "Good"),
+]:
+    value = MetricLimits.get_limit_for_metric("ActionCount").get(key)
+    if value is not None:
+        fig.add_hline(
+            y=value, line_dash="dash", line_width=1, line_color=color,
+            layer="below", annotation_text=f"{label} ({value:.0f})",
+            annotation_position="right", annotation_font_size=9,
+            annotation_font_color=color,
+        )
+
 fig.show()
 ```
 
@@ -1198,7 +1213,7 @@ n_model_techniques = (
 )
 facet_col_wrap = safe_facet_col_wrap(n_model_techniques, max_rows=15)
 try:
-    fig = datamart.plot.over_time(metric="Performance", facet="ModelTechnique", by=by)
+    fig = datamart.plot.over_time(metric="Performance", facet="ModelTechnique", by=by, show_metric_limits=True)
     fig = fig_update_facet(fig, facet_col_wrap, 200, 250)
     fig = (
         fig.update_layout(title="Trend of Model Performance")

--- a/python/tests/test_plots.py
+++ b/python/tests/test_plots.py
@@ -90,12 +90,12 @@ def test_add_metric_limit_lines_standalone():
     x_values = sorted(s.x0 for s in shapes)
     assert x_values == pytest.approx([52.0, 55.0, 80.0, 90.0])
 
-    # Hard limits (52, 90) should use red, best practice (55, 80) should use orange
+    # Hard limits (52, 90) should use red, best practice (55, 80) should use green
     for shape in shapes:
         if shape.x0 == pytest.approx(52.0) or shape.x0 == pytest.approx(90.0):
-            assert "255, 69, 0" in shape.line.color  # orangered rgba
+            assert "255, 69, 0" in shape.line.color  # red rgba
         else:
-            assert "255, 165, 0" in shape.line.color  # orange rgba
+            assert "0, 128, 0" in shape.line.color  # green rgba
 
 
 def test_over_time(sample2: ADMDatamart):

--- a/python/tests/test_plots.py
+++ b/python/tests/test_plots.py
@@ -98,6 +98,38 @@ def test_add_metric_limit_lines_standalone():
             assert "0, 128, 0" in shape.line.color  # green rgba
 
 
+def test_add_metric_limit_lines_horizontal():
+    """Test the helper function with horizontal orientation."""
+    from pdstools.adm.Plots import add_metric_limit_lines
+
+    fig = px.scatter(x=[1, 2, 3], y=[50, 70, 90])
+    fig = add_metric_limit_lines(fig, orientation="horizontal")
+
+    # Horizontal lines have y0 == y1
+    shapes = [s for s in fig.layout.shapes if s.type == "line" and s.y0 == s.y1]
+    assert len(shapes) == 4
+
+    y_values = sorted(s.y0 for s in shapes)
+    assert y_values == pytest.approx([52.0, 55.0, 80.0, 90.0])
+
+
+def test_over_time_with_metric_limits(sample2: ADMDatamart):
+    """Test over_time with metric limit lines for Performance."""
+    fig = sample2.plot.over_time(metric="Performance", by="ModelID", show_metric_limits=True)
+    assert isinstance(fig, Figure)
+
+    # Should have 4 horizontal lines
+    shapes = [s for s in fig.layout.shapes if s.type == "line" and s.y0 == s.y1]
+    assert len(shapes) == 4
+
+
+def test_over_time_metric_limits_only_for_performance(sample2: ADMDatamart):
+    """Test that metric limits are not shown for non-Performance metrics."""
+    fig = sample2.plot.over_time(metric="ResponseCount", by="ModelID", show_metric_limits=True)
+    shapes = [s for s in fig.layout.shapes if s.type == "line" and s.y0 == s.y1]
+    assert len(shapes) == 0
+
+
 def test_over_time(sample2: ADMDatamart):
     fig = sample2.plot.over_time(metric="Performance", by="ModelID")
     assert fig is not None

--- a/python/tests/test_plots.py
+++ b/python/tests/test_plots.py
@@ -54,6 +54,50 @@ def test_bubble_chart(sample: ADMDatamart):
     assert plot is not None
 
 
+def test_bubble_chart_with_metric_limits(sample: ADMDatamart):
+    """Test bubble chart with metric limit lines enabled."""
+    fig = sample.plot.bubble_chart(show_metric_limits=True)
+    assert isinstance(fig, Figure)
+
+    # Should have 4 vertical lines (shapes) for the 4 ModelPerformance thresholds
+    shapes = [s for s in fig.layout.shapes if s.type == "line" and s.x0 == s.x1]
+    assert len(shapes) == 4
+
+    x_values = sorted(s.x0 for s in shapes)
+    assert x_values == pytest.approx([52.0, 55.0, 80.0, 90.0])
+
+    for shape in shapes:
+        assert shape.line.dash == "dash"
+
+
+def test_bubble_chart_metric_limits_off_by_default(sample: ADMDatamart):
+    """Test that metric limit lines are not shown by default."""
+    fig = sample.plot.bubble_chart()
+    shapes = [s for s in fig.layout.shapes if s.type == "line" and s.x0 == s.x1]
+    assert len(shapes) == 0
+
+
+def test_add_metric_limit_lines_standalone():
+    """Test the helper function directly on a bare figure."""
+    from pdstools.adm.Plots import add_metric_limit_lines
+
+    fig = px.scatter(x=[50, 60, 70, 80, 90], y=[1, 2, 3, 4, 5])
+    fig = add_metric_limit_lines(fig)
+
+    shapes = [s for s in fig.layout.shapes if s.type == "line" and s.x0 == s.x1]
+    assert len(shapes) == 4
+
+    x_values = sorted(s.x0 for s in shapes)
+    assert x_values == pytest.approx([52.0, 55.0, 80.0, 90.0])
+
+    # Hard limits (52, 90) should use red, best practice (55, 80) should use orange
+    for shape in shapes:
+        if shape.x0 == pytest.approx(52.0) or shape.x0 == pytest.approx(90.0):
+            assert "255, 69, 0" in shape.line.color  # orangered rgba
+        else:
+            assert "255, 165, 0" in shape.line.color  # orange rgba
+
+
 def test_over_time(sample2: ADMDatamart):
     fig = sample2.plot.over_time(metric="Performance", by="ModelID")
     assert fig is not None


### PR DESCRIPTION
## Summary

- Add `add_metric_limit_lines()` helper that draws dashed lines at MetricLimits thresholds (red for hard limits, green for best practice)
- Add `show_metric_limits` parameter to `bubble_chart()` and `over_time()`
- Enable on three Health Check charts: bubble charts (vertical AUC lines), Performance over time (horizontal AUC lines), action trend (horizontal ActionCount lower limits)