### PR TITLE
refactor: remove _Defaults dataclass, use literal defaults in signatures

### DIFF
--- a/python/pdstools/explanations/Aggregate.py
+++ b/python/pdstools/explanations/Aggregate.py
@@ -14,7 +14,6 @@ from .ExplanationsUtils import (
     ContextInfo,
     ContextOperations,
     _resolve_agg_filter_kwargs,
-    defaults,
     validate,
 )
 
@@ -51,7 +50,7 @@ class Aggregate(LazyNamespace):
     def get_predictor_contributions(
         self,
         context: dict[str, str] | None = None,
-        top_n: int = defaults.top_n,
+        top_n: int = 20,
         **filter_kwargs,
     ):
         """Get the top-n predictor contributions for a given context or overall.
@@ -97,7 +96,7 @@ class Aggregate(LazyNamespace):
         self,
         predictors: list[str],
         context: dict[str, str] | None = None,
-        top_k: int = defaults.top_k,
+        top_k: int = 20,
         **filter_kwargs,
     ):
         """Get the top-k predictor value contributions for a given context or overall.
@@ -213,12 +212,12 @@ class Aggregate(LazyNamespace):
         self,
         contexts: list[ContextInfo] | None = None,
         predictors: list[str] | None = None,
-        limit: int = defaults.top_n,
-        descending: bool = defaults.descending,
-        missing: bool = defaults.missing,
-        remaining: bool = defaults.remaining,
-        include_numeric_single_bin: bool = defaults.include_numeric_single_bin,
-        sort_by: str = defaults.sort_by.value,
+        limit: int = 20,
+        descending: bool = True,
+        missing: bool = True,
+        remaining: bool = True,
+        include_numeric_single_bin: bool = False,
+        sort_by: str = "contribution_abs",
     ) -> pl.DataFrame:
         contexts = contexts or []
         predictors = predictors or []
@@ -296,12 +295,12 @@ class Aggregate(LazyNamespace):
         self,
         contexts: list[ContextInfo] | None = None,
         predictors: list[str] | None = None,
-        limit: int = defaults.top_k,
-        descending: bool = defaults.descending,
-        missing: bool = defaults.missing,
-        remaining: bool = defaults.remaining,
-        include_numeric_single_bin: bool = defaults.include_numeric_single_bin,
-        sort_by: str = defaults.sort_by.value,
+        limit: int = 20,
+        descending: bool = True,
+        missing: bool = True,
+        remaining: bool = True,
+        include_numeric_single_bin: bool = False,
+        sort_by: str = "contribution_abs",
     ) -> pl.DataFrame:
         # if no contexts are provided, then we return the overall data
         # if contexts are provided, then we generate the context filters
@@ -403,7 +402,7 @@ class Aggregate(LazyNamespace):
     def _get_df_with_sort_info(
         self,
         df: pl.LazyFrame,
-        sort_by: str = defaults.sort_by.value,
+        sort_by: str = "contribution_abs",
     ) -> pl.LazyFrame:
         """Add a sort column and value to the dataframe based on the predictor type.
         # Sort logic:
@@ -435,9 +434,9 @@ class Aggregate(LazyNamespace):
         self,
         df: pl.LazyFrame,
         over: list[str],
-        sort_by: str = defaults.sort_by.value,
-        limit: int = defaults.top_k,
-        descending: bool = defaults.descending,
+        sort_by: str = "contribution_abs",
+        limit: int = 20,
+        descending: bool = True,
     ) -> pl.LazyFrame:
         """Return the top `limit` rows per group, ranked by `sort_by`.
 

--- a/python/pdstools/explanations/ExplanationsUtils.py
+++ b/python/pdstools/explanations/ExplanationsUtils.py
@@ -8,11 +8,9 @@ __all__ = [
     "ContextOperations",
     "_resolve_agg_filter_kwargs",
     "_resolve_plot_filter_kwargs",
-    "defaults",
 ]
 
 import json
-from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, TypedDict, cast
 
@@ -113,21 +111,6 @@ class _SPECIAL(Enum):
     MISSING = "missing"
 
 
-@dataclass(frozen=True)
-class _Defaults:
-    top_n: int = 20
-    top_k: int = 20
-    descending: bool = True
-    missing: bool = True
-    remaining: bool = True
-    include_numeric_single_bin: bool = False
-    sort_by: _CONTRIBUTION_TYPE = _CONTRIBUTION_TYPE.CONTRIBUTION_ABS
-    display_by: _CONTRIBUTION_TYPE = _CONTRIBUTION_TYPE.CONTRIBUTION
-
-
-defaults = _Defaults()
-
-
 def _resolve_agg_filter_kwargs(**kwargs) -> dict:
     """Extract and validate aggregate-layer filter kwargs, filling defaults.
 
@@ -136,14 +119,14 @@ def _resolve_agg_filter_kwargs(**kwargs) -> dict:
     Any other key raises ``TypeError``.
     ``sort_by`` is validated against the accepted ``_CONTRIBUTION_TYPE`` values.
     """
-    sort_by = kwargs.pop("sort_by", defaults.sort_by.value)
+    sort_by = kwargs.pop("sort_by", "contribution_abs")
     _CONTRIBUTION_TYPE.validate_and_get_type(sort_by)
     result = {
         "sort_by": sort_by,
-        "descending": kwargs.pop("descending", defaults.descending),
-        "missing": kwargs.pop("missing", defaults.missing),
-        "remaining": kwargs.pop("remaining", defaults.remaining),
-        "include_numeric_single_bin": kwargs.pop("include_numeric_single_bin", defaults.include_numeric_single_bin),
+        "descending": kwargs.pop("descending", True),
+        "missing": kwargs.pop("missing", True),
+        "remaining": kwargs.pop("remaining", True),
+        "include_numeric_single_bin": kwargs.pop("include_numeric_single_bin", False),
     }
     if kwargs:
         raise TypeError(
@@ -162,7 +145,7 @@ def _resolve_plot_filter_kwargs(**kwargs) -> dict:
     ``sort_by`` and ``display_by`` are returned as ``_CONTRIBUTION_TYPE`` enum
     members so callers can use ``.value`` and ``.alt`` without re-validating.
     """
-    display_by = kwargs.pop("display_by", defaults.display_by.value)
+    display_by = kwargs.pop("display_by", "contribution")
     display_by_enum = _CONTRIBUTION_TYPE.validate_and_get_type(display_by)
     result = _resolve_agg_filter_kwargs(**kwargs)
     result["sort_by"] = _CONTRIBUTION_TYPE.validate_and_get_type(result["sort_by"])

--- a/python/pdstools/explanations/Plots.py
+++ b/python/pdstools/explanations/Plots.py
@@ -12,7 +12,6 @@ from .ExplanationsUtils import (
     _SPECIAL,
     ContextInfo,
     _resolve_plot_filter_kwargs,
-    defaults,
 )
 
 logger = logging.getLogger(__name__)
@@ -41,8 +40,8 @@ class Plots(LazyNamespace):
 
     def contributions(
         self,
-        top_n: int = defaults.top_n,
-        top_k: int = defaults.top_k,
+        top_n: int = 20,
+        top_k: int = 20,
         **filter_kwargs,
     ):
         """Plots contributions for the overall model or a selected context.
@@ -106,8 +105,8 @@ class Plots(LazyNamespace):
 
     def plot_contributions_for_overall(
         self,
-        top_n: int = defaults.top_n,
-        top_k: int = defaults.top_k,
+        top_n: int = 20,
+        top_k: int = 20,
         **filter_kwargs,
     ) -> tuple[go.Figure, list[go.Figure]]:
         display_by, resolved = self._resolve_kwargs(**filter_kwargs)
@@ -149,8 +148,8 @@ class Plots(LazyNamespace):
     def plot_contributions_by_context(
         self,
         context: dict[str, str],
-        top_n: int = defaults.top_n,
-        top_k: int = defaults.top_k,
+        top_n: int = 20,
+        top_k: int = 20,
         **filter_kwargs,
     ) -> tuple[go.Figure, go.Figure, list[go.Figure]]:
         display_by, resolved = self._resolve_kwargs(**filter_kwargs)

--- a/python/pdstools/explanations/Reports.py
+++ b/python/pdstools/explanations/Reports.py
@@ -15,7 +15,7 @@ from ..utils.report_utils import (
     generate_zipped_report,
     run_quarto,
 )
-from .ExplanationsUtils import _CONTRIBUTION_TYPE, _resolve_plot_filter_kwargs, defaults
+from .ExplanationsUtils import _CONTRIBUTION_TYPE, _resolve_plot_filter_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +45,8 @@ class Reports(LazyNamespace):
     def generate(
         self,
         report_filename: str = "explanations_report.zip",
-        top_n: int = defaults.top_n,
-        top_k: int = defaults.top_k,
+        top_n: int = 20,
+        top_k: int = 20,
         zip_output: bool = False,
         **filter_kwargs,
     ):
@@ -136,12 +136,12 @@ class Reports(LazyNamespace):
 
     def _set_params(
         self,
-        top_n: int = defaults.top_n,
-        top_k: int = defaults.top_k,
+        top_n: int = 20,
+        top_k: int = 20,
         from_date: str = "",
         to_date: str = "",
-        sort_by: _CONTRIBUTION_TYPE = defaults.sort_by,
-        display_by: _CONTRIBUTION_TYPE = defaults.display_by,
+        sort_by: _CONTRIBUTION_TYPE = _CONTRIBUTION_TYPE.CONTRIBUTION_ABS,
+        display_by: _CONTRIBUTION_TYPE = _CONTRIBUTION_TYPE.CONTRIBUTION,
     ):
         params: dict[str, str | int] = {}
         params["top_n"] = top_n

--- a/python/tests/explanations/test_ExplanationsPlots.py
+++ b/python/tests/explanations/test_ExplanationsPlots.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import plotly.graph_objects as go
 import pytest
 from pdstools.explanations import Explanations
-from pdstools.explanations.ExplanationsUtils import _SPECIAL, defaults
+from pdstools.explanations.ExplanationsUtils import _SPECIAL
 from pdstools.explanations.Plots import Plots
 
 basePath = Path(__file__).parent.parent.parent.parent
@@ -67,7 +67,7 @@ def test_plot_contributions_for_overall_default_params(plots):
     # +1 for the remaining bar
     _assert_fig_bar_data_overall(
         overall_fig,
-        defaults.top_n + 1,
+        20 + 1,
         check_condition="le",
     )
     _assert_fig_bar_data_predictors(predictors_figs, 1, check_condition="gt")
@@ -354,12 +354,12 @@ def test_plot_contributions_for_overall_no_kwargs_uses_defaults(plots):
     """Calling with no filter kwargs should produce the same structure as passing explicit defaults."""
     _, figs_no_kwargs = plots.plot_contributions_for_overall()
     _, figs_explicit = plots.plot_contributions_for_overall(
-        sort_by=defaults.sort_by.value,
-        display_by=defaults.display_by.value,
-        descending=defaults.descending,
-        missing=defaults.missing,
-        remaining=defaults.remaining,
-        include_numeric_single_bin=defaults.include_numeric_single_bin,
+        sort_by="contribution_abs",
+        display_by="contribution",
+        descending=True,
+        missing=True,
+        remaining=True,
+        include_numeric_single_bin=False,
     )
     # Same number of predictor figures — same set of top predictors selected
     assert len(figs_no_kwargs) == len(figs_explicit)

--- a/python/tests/explanations/test_ExplanationsReports.py
+++ b/python/tests/explanations/test_ExplanationsReports.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 from pdstools.explanations import Explanations
-from pdstools.explanations.ExplanationsUtils import _CONTRIBUTION_TYPE, defaults
+from pdstools.explanations.ExplanationsUtils import _CONTRIBUTION_TYPE
 
 basePath = Path(__file__).parent.parent.parent.parent
 
@@ -85,10 +85,10 @@ def test_set_params(reports):
     assert params["top_k"] == 3
     assert params["from_date"] == "2026-01-01"
     assert params["to_date"] == "2026-01-31"
-    assert params["sort_by"] == defaults.sort_by.value
-    assert params["sort_by_text"] == defaults.sort_by.text
-    assert params["display_by"] == defaults.display_by.value
-    assert params["display_by_text"] == defaults.display_by.text
+    assert params["sort_by"] == "contribution_abs"
+    assert params["sort_by_text"] == "absolute average contribution"
+    assert params["display_by"] == "contribution"
+    assert params["display_by_text"] == "average contribution"
     assert params["data_folder"] == reports.aggregate_folder.name
 
 
@@ -156,8 +156,8 @@ class TestGenerateFilterKwargs:
 
             mock_set_params.assert_called_once()
             call_kwargs = mock_set_params.call_args
-            assert call_kwargs.kwargs["sort_by"] == defaults.sort_by
-            assert call_kwargs.kwargs["display_by"] == defaults.display_by
+            assert call_kwargs.kwargs["sort_by"] == _CONTRIBUTION_TYPE.CONTRIBUTION_ABS
+            assert call_kwargs.kwargs["display_by"] == _CONTRIBUTION_TYPE.CONTRIBUTION
 
     def test_generate_resolves_custom_kwargs(self, reports):
         """generate() passes custom sort_by/display_by through the resolver."""


### PR DESCRIPTION
Remove the _Defaults frozen dataclass and defaults singleton from ExplanationsUtils. Replace all defaults.* references across Aggregate, Plots, Reports, and tests with their literal values:

- top_n/top_k: 20
- sort_by: "contribution_abs"
- display_by: "contribution"
- descending: True
- missing: True
- remaining: True
- include_numeric_single_bin: False

Per AGENTS.md, function signatures with literal defaults are idiomatic Python, self-documenting, and immediately visible in IDE tooltips.