### PR TITLE
Various code issues cleanup

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -691,44 +691,45 @@ class ADMDatamart:
         return modeldata_cache, predictordata_cache
 
     @cached_property
-    def unique_channels(self):
-        """A consistently ordered set of unique channels in the data
+    def unique_channels(self) -> list[str]:
+        """Sorted list of unique channels in the data.
 
-        Used for making the color schemes in different plots consistent
+        Used for making the color schemes in different plots consistent.
         """
-        return set(
-            self.model_data.select(pl.col("Channel").unique().sort()).collect()["Channel"],
-        )
+        return self.model_data.select(pl.col("Channel").unique().sort()).collect()["Channel"].to_list()
 
     @cached_property
-    def unique_configurations(self):
-        """A consistently ordered set of unique configurations in the data
+    def unique_configurations(self) -> list[str]:
+        """Sorted list of unique configurations in the data.
 
-        Used for making the color schemes in different plots consistent
+        Used for making the color schemes in different plots consistent.
         """
-        return set(
-            self.model_data.select(pl.col("Configuration").unique()).collect()["Configuration"].to_list(),
-        )
+        return self.model_data.select(pl.col("Configuration").unique().sort()).collect()["Configuration"].to_list()
 
     @cached_property
-    def unique_channel_direction(self):
-        """A consistently ordered set of unique channel+direction combos in the data
-        Used for making the color schemes in different plots consistent
+    def unique_channel_direction(self) -> list[str]:
+        """Sorted list of unique channel+direction combos in the data.
+
+        Used for making the color schemes in different plots consistent.
         """
-        return set(
+        return (
             self.model_data.select(
-                pl.concat_str(pl.col("Channel"), pl.col("Direction"), separator="/").unique().alias("ChannelDirection"),
+                pl.concat_str(pl.col("Channel"), pl.col("Direction"), separator="/")
+                .unique()
+                .sort()
+                .alias("ChannelDirection"),
             )
             .collect()["ChannelDirection"]
-            .to_list(),
+            .to_list()
         )
 
     @cached_property
-    def unique_configuration_channel_direction(self):
-        """A consistently ordered set of unique configuration+channel+direction
-        Used for making the color schemes in different plots consistent
+    def unique_configuration_channel_direction(self) -> list[str]:
+        """Sorted list of unique configuration+channel+direction combos.
+
+        Used for making the color schemes in different plots consistent.
         """
-        return set(
+        return (
             self.model_data.select(
                 pl.concat_str(
                     pl.col("Configuration"),
@@ -737,21 +738,24 @@ class ADMDatamart:
                     separator="/",
                 )
                 .unique()
+                .sort()
                 .alias("ChannelDirection"),
             )
             .collect()["ChannelDirection"]
-            .to_list(),
+            .to_list()
         )
 
     @cached_property
-    def unique_predictor_categories(self):
-        """A consistently ordered set of unique predictor categories in the data
-        Used for making the color schemes in different plots consistent
+    def unique_predictor_categories(self) -> list[str]:
+        """Sorted list of unique predictor categories in the data.
+
+        Used for making the color schemes in different plots consistent.
         """
-        return set(
+        return (
             self.predictor_data.select(pl.col("PredictorCategory").unique().sort())
             .filter(pl.col("PredictorCategory").is_not_null())
-            .collect()["PredictorCategory"],
+            .collect()["PredictorCategory"]
+            .to_list()
         )
 
     def get_last_data_for_report(self) -> pl.DataFrame:

--- a/python/pdstools/adm/ADMTrees.py
+++ b/python/pdstools/adm/ADMTrees.py
@@ -291,7 +291,7 @@ class ADMTreesModel:
             try:  # pragma: no cover
                 self.trees = json.loads(decode_string(file))
                 if not self.trees["_serialClass"].endswith("GbModel"):
-                    return ValueError("Not an AGB model")
+                    raise ValueError("Not an AGB model")
                 decode = True
                 logger.info("Model needs to be decoded")
             except Exception:
@@ -320,7 +320,7 @@ class ADMTreesModel:
         elif isinstance(file, bytes):  # pragma: no cover
             self.trees = json.loads(zlib.decompress(file))
             if not self.trees["_serialClass"].endswith("GbModel"):
-                return ValueError("Not an AGB model")
+                raise ValueError("Not an AGB model")
             decode = True
             logger.info("Model needs to be decoded")
         elif isinstance(file, dict):  # pragma: no cover

--- a/python/pdstools/utils/cdh_utils.py
+++ b/python/pdstools/utils/cdh_utils.py
@@ -1525,21 +1525,38 @@ def create_working_and_temp_dir(
 
 
 # Safe flattening of nested lists, removing None elements, and not splitting strings
-def safe_flatten_list(alist: list, extras: list | None = None) -> list:
-    if extras is None:
-        extras = []
+def safe_flatten_list(alist: list | None, extras: list | None = None) -> list | None:
+    """Flatten one level of ``alist``, drop ``None`` entries, and prepend ``extras``.
+
+    The result is order-preserving and de-duplicated. Strings are treated as
+    atoms (not iterated). Both ``alist`` and ``extras`` are read-only — the
+    caller's lists are never mutated. Returns ``None`` when the result would
+    be empty so callers can use the truthiness as a "no grouping" signal.
+    """
     if alist is None:
         alist = []
     alist = list(filter(partial(is_not, None), alist))
     alist = [item for sublist in [[item] if type(item) is not list else item for item in alist] for item in sublist]
     alist = list(filter(partial(is_not, None), alist))
-    seen = set()
-    unique_alist = extras
+    unique_alist: list = list(extras) if extras else []
+    seen_ids: set[int] = {id(x) for x in unique_alist}
+    seen_hashable: set = set()
+    for x in unique_alist:
+        try:
+            seen_hashable.add(x)
+        except TypeError:
+            pass
     for item in alist:
-        if item not in seen:
-            unique_alist.append(item)
-            seen.add(item)
-    return unique_alist if len(unique_alist) > 0 else None  # type: ignore[return-value]
+        try:
+            if item in seen_hashable:
+                continue
+            seen_hashable.add(item)
+        except TypeError:
+            if id(item) in seen_ids:
+                continue
+        seen_ids.add(id(item))
+        unique_alist.append(item)
+    return unique_alist or None
 
 
 def _get_start_end_date_args(

--- a/python/pdstools/utils/namespaces.py
+++ b/python/pdstools/utils/namespaces.py
@@ -97,15 +97,16 @@ class MissingDependenciesException(Exception):
 
         message += (
             f"\nPlease install {'it' if len(deps) == 1 else 'them'} using your "
-            f"favorite package manager (e.g. pip install {' '.join(install_names)})"
+            f"favorite package manager. Package name"
+            f"{'' if len(deps) == 1 else 's'}: {' '.join(install_names)}"
         )
 
         if deps_group:
             message += (
-                f",\n\nNOTE: these dependencies are also shipped with the optional "
-                f"dependency group '{deps_group}', \nso you can install them "
-                f"automatically with pdstools as well "
-                f"(e.g. pip install 'pdstools[{deps_group}]')."
+                f".\n\nNOTE: these dependencies are also shipped with the optional "
+                f"pdstools extra '{deps_group}', \nso you can install them "
+                f"automatically by adding the 'pdstools[{deps_group}]' extra "
+                f"with your package manager."
             )
         else:
             message += "."

--- a/python/tests/test_ADMDatamart.py
+++ b/python/tests/test_ADMDatamart.py
@@ -25,17 +25,17 @@ def test_cdh_sample_init(sample):
 
 
 def test_cached_properties(sample: ADMDatamart):
-    assert sample.unique_channel_direction == {
+    assert sample.unique_channel_direction == [
         "Email/Outbound",
         "SMS/Outbound",
         "Web/Inbound",
-    }
+    ]
 
-    assert sample.unique_channels == {"Email", "SMS", "Web"}
+    assert sample.unique_channels == ["Email", "SMS", "Web"]
 
-    assert sample.unique_configurations == {"OmniAdaptiveModel"}
+    assert sample.unique_configurations == ["OmniAdaptiveModel"]
 
-    assert sample.unique_predictor_categories == {"Customer", "IH", "Param"}
+    assert sample.unique_predictor_categories == ["Customer", "IH", "Param"]
 
 
 def test_write_then_load(sample: ADMDatamart):

--- a/python/tests/test_namespaces.py
+++ b/python/tests/test_namespaces.py
@@ -68,7 +68,7 @@ def test_raising_without_namespace_name():
 def test_install_name_mapping_for_yaml():
     """Error message should suggest the pip install name, not the import name."""
     exc = MissingDependenciesException(["yaml"], namespace="Reports", deps_group="explanations")
-    assert "pip install pyyaml" in str(exc)
+    assert "pyyaml" in str(exc)
     # The human-readable summary still references the import name the user sees
     assert "yaml" in str(exc)
     assert "explanations" in str(exc)
@@ -76,7 +76,7 @@ def test_install_name_mapping_for_yaml():
 
 def test_install_name_mapping_for_polars_hash():
     exc = MissingDependenciesException(["polars_hash"], namespace="Anonymization", deps_group="pega_io")
-    assert "pip install polars-hash" in str(exc)
+    assert "polars-hash" in str(exc)
 
 
 def test_install_hint_is_package_manager_neutral():


### PR DESCRIPTION
- ADMTrees: raise ValueError instead of returning it (validation was silently bypassed)
- ADMDatamart.unique_*: return sorted list[str] instead of set for deterministic order
- safe_flatten_list: don't mutate caller's extras, add type hints + docstring, handle unhashable items (polars Exprs)
- MissingDependenciesException: package-manager-neutral wording (no hardcoded pip install, per AGENTS.md)