### PR TITLE
Clean up internal verbose parameters; refine AGENTS.md guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,14 @@ dependencies and execution.
   created yourself, or when the user explicitly asks for a commit/PR.
 - **Product naming.** User-facing text: "Decision Analysis Tool",
   "ADM Health Check". Code/CLI: `decision_analyzer`, `adm_healthcheck`.
-- **No `verbose` parameters.** Use `logging.debug()` instead of
-  `if verbose: print(...)`. Remove `verbose` if you encounter it.
+- **`verbose` parameters.** Reserve `verbose` for genuine user-facing
+  progress — tqdm progress bars on long-running I/O, multi-stage CLI
+  output (`"Step 1/3: writing parquet…"`). For anything that prints
+  internal technical detail (subprocess output, decoded values, "file
+  not found in dir X", schema warnings), drop the parameter and use
+  `logger.debug()` / `logger.info()` instead. Never overload `verbose`
+  to control non-output behaviour (e.g. cache invalidation, retry
+  policy) — that's a separate parameter.
 - **Prefer Polars over Pandas** for all data processing.
 
 ## Quick orientation

--- a/python/pdstools/adm/ADMTrees.py
+++ b/python/pdstools/adm/ADMTrees.py
@@ -95,7 +95,6 @@ class AGB:
         by: str = "Configuration",
         n_threads: int = 1,
         query: QUERY | None = None,
-        verbose: bool = True,
         **kwargs,
     ) -> ADMTrees:  # pragma: no cover
         """Method to automatically extract AGB models.
@@ -117,8 +116,6 @@ class AGB:
             helps speed up the import.
         query: Optional[Union[pl.Expr, list[pl.Expr], str, dict[str, list]]]
             Please refer to :meth:`._apply_query`
-        verbose: bool, default = False
-            Whether to print out information while importing
 
         """
         df = self.datamart.model_data
@@ -138,32 +135,28 @@ class AGB:
             return ADMTrees(
                 self.datamart.aggregates.last(data=df),
                 n_threads=n_threads,
-                verbose=verbose,
                 **kwargs,
             )
         return ADMTrees(
             df.select("Configuration", "SnapshotTime", "Modeldata").collect(),
             n_threads=n_threads,
-            verbose=verbose,
             **kwargs,
         )
 
 
 class ADMTrees:  # pragma: no cover
-    def __new__(cls, file, n_threads=6, verbose=True, **kwargs):
+    def __new__(cls, file, n_threads=6, **kwargs):
         if isinstance(file, pl.DataFrame):
             logger.info("DataFrame supplied.")
             file = file.filter(pl.col("Modeldata").is_not_null())
             if len(file) > 1:
-                logger.info("Multiple models found, so creating MultiTrees")
-                if verbose:
-                    print(
-                        f"AGB models found: {file.select(pl.col('Configuration').unique())}",
-                    )
+                logger.info(
+                    "Multiple AGB models found (%s), creating MultiTrees",
+                    file.select(pl.col("Configuration").unique()),
+                )
                 return cls.get_multi_trees(
                     file=file,
                     n_threads=n_threads,
-                    verbose=verbose,
                     **kwargs,
                 )
             logger.info("One model found, so creating ADMTrees")
@@ -177,17 +170,17 @@ class ADMTrees:  # pragma: no cover
         return ADMTreesModel(file, **kwargs)
 
     @staticmethod
-    def get_multi_trees(file: pl.DataFrame, n_threads=1, verbose=True, **kwargs):
+    def get_multi_trees(file: pl.DataFrame, n_threads=1, **kwargs):
         out = {}
         df = file.filter(pl.col("Modeldata").is_not_null()).select(
             pl.col("SnapshotTime").dt.round("1s").cast(pl.Utf8).str.strip_chars_end(".000000000"),
             pl.col("Modeldata").str.decode("base64"),
             pl.col("Configuration").cast(pl.Utf8),
         )
-        if len(df) > 50 and n_threads == 1 and verbose:
-            print(
-                f"""Decoding {len(df)} models,
-            setting n_threads to a higher value may speed up processing time.""",
+        if len(df) > 50 and n_threads == 1:
+            logger.info(
+                "Decoding %d models; setting n_threads higher may speed this up.",
+                len(df),
             )
         df2 = df.select(
             pl.concat_list(["Configuration", "SnapshotTime"]),
@@ -331,12 +324,12 @@ class ADMTreesModel:
         self._post_import_cleanup(decode=decode, **kwargs)
 
     def _decode_trees(self):  # pragma: no cover
-        def quantile_decoder(encoder: dict, index: int, verbose=False):
+        def quantile_decoder(encoder: dict, index: int):
             if encoder["summaryType"] == "INITIAL_SUMMARY":
                 return encoder["summary"]["initialValues"][index]  # Note: could also be index-1
             return encoder["summary"]["list"][index - 1].split("=")[0]
 
-        def string_decoder(encoder: dict, index: int, sign, verbose=False):
+        def string_decoder(encoder: dict, index: int, sign):
             def set_types(split):
                 logger.debug(split)
                 split = split.rsplit("=", 1)
@@ -348,8 +341,7 @@ class ADMTreesModel:
             )
             splitvalues = list()
             for key, value in valuelist.items():
-                if verbose:
-                    print(key, value, index)
+                logger.debug("string_decoder candidate: %s=%s (index=%s)", key, value, index)
                 if int(key) == index - 129 and index == 129 and sign == "<":
                     splitvalues.append("Missing")
                     break
@@ -360,7 +352,7 @@ class ADMTreesModel:
             output = ", ".join(splitvalues)
             return output
 
-        def decode_split(split: str, verbose=False):
+        def decode_split(split: str):
             if not isinstance(split, str):
                 return split
             logger.debug(f"Decoding split: {split}")
@@ -371,8 +363,9 @@ class ADMTreesModel:
             elif sign == "EQ":
                 sign = "=="
             else:
-                print("For now, only supporting less than and equality splits")
-                raise ValueError((predictor, sign, splitval))
+                raise ValueError(
+                    f"Unsupported split operator (only LT/EQ supported): {(predictor, sign, splitval)}",
+                )
             variable = encoderkeys[int(predictor)]
             encoder = encoders[variable]
             variable_type = list(encoder["encoder"].keys())[0]
@@ -384,7 +377,6 @@ class ADMTreesModel:
                     to_decode,
                     int(splitval),
                     sign=sign,
-                    verbose=verbose,
                 )
                 if val == "Missing":
                     sign, val = "is", "Missing"

--- a/python/pdstools/adm/Reports.py
+++ b/python/pdstools/adm/Reports.py
@@ -46,7 +46,6 @@ class Reports(LazyNamespace):
         only_active_predictors: bool = True,
         output_type: str = "html",
         keep_temp_files: bool = False,
-        verbose: bool = False,
         progress_callback: Callable[[int, int], None] | None = None,
         model_file_path: PathLike | None = None,
         predictor_file_path: PathLike | None = None,
@@ -75,8 +74,6 @@ class Reports(LazyNamespace):
             The type of the output file (e.g., "html", "pdf").
         keep_temp_files : bool, optional
             If True, the temporary directory with temp files will not be deleted after report generation.
-        verbose: bool, optional
-            If True, prints detailed logs during execution.
         progress_callback : Callable[[int, int], None], optional
             A callback function to report progress. Used only in the Streamlit app.
             The function should accept two integers: the current progress and the total.
@@ -162,19 +159,17 @@ class Reports(LazyNamespace):
                         "models": (self.datamart.model_data is not None),
                     },
                     temp_dir=temp_dir,
-                    verbose=verbose,
                     full_embed=full_embed,
                 )
                 output_path = temp_dir / output_filename
-                if verbose or not output_path.exists():
-                    # print parameters so they can be copy/pasted into the quarto docs for debugging
-                    if model_file_path is not None:
-                        print(f'model_file_path = "{model_file_path}"')
-                    if predictor_file_path is not None:
-                        print(f'predictor_file_path = "{predictor_file_path}"')
-                    print(f'model_id = "{model_id}"')
-                    print(f"output_path = {output_path}")
                 if not output_path.exists():
+                    # Log parameters so they can be copy/pasted into the quarto docs for debugging
+                    if model_file_path is not None:
+                        logger.info('model_file_path = "%s"', model_file_path)
+                    if predictor_file_path is not None:
+                        logger.info('predictor_file_path = "%s"', predictor_file_path)
+                    logger.info('model_id = "%s"', model_id)
+                    logger.info("output_path = %s", output_path)
                     raise ValueError(f"Failed to write the report: {output_filename}")
                 output_path = bundle_quarto_resources(output_path)
                 output_file_paths.append(output_path)
@@ -214,7 +209,6 @@ class Reports(LazyNamespace):
         query: QUERY | None = None,
         output_type: str = "html",
         keep_temp_files: bool = False,
-        verbose: bool = False,
         prediction=None,
         model_file_path: PathLike | None = None,
         predictor_file_path: PathLike | None = None,
@@ -242,8 +236,6 @@ class Reports(LazyNamespace):
             The type of the output file (e.g., "html", "pdf").
         keep_temp_files : bool, optional
             If True, the temporary directory with temp files will not be deleted after report generation.
-        verbose: bool, optional
-            If True, prints detailed logs during execution.
         prediction : Prediction, optional
             Optional Prediction object to include in the health check. If provided without
             prediction_file_path, the prediction data will be automatically cached to a temporary file.
@@ -328,21 +320,18 @@ class Reports(LazyNamespace):
                     "models": (self.datamart.model_data is not None),
                 },
                 temp_dir=temp_dir,
-                verbose=verbose,
                 full_embed=full_embed,
             )
 
-            # TODO why not print paths earlier, before the quarto call?
             output_path = temp_dir / output_filename
-            if verbose or not output_path.exists():
-                if model_file_path is not None:
-                    print(f'model_file_path = "{model_file_path}"')
-                if predictor_file_path is not None:
-                    print(f'predictor_file_path = "{predictor_file_path}"')
-                if prediction_file_path is not None:
-                    print(f'prediction_file_path = "{prediction_file_path}"')
-                print(f"output_path = {output_path}")
             if not output_path.exists():
+                if model_file_path is not None:
+                    logger.info('model_file_path = "%s"', model_file_path)
+                if predictor_file_path is not None:
+                    logger.info('predictor_file_path = "%s"', predictor_file_path)
+                if prediction_file_path is not None:
+                    logger.info('prediction_file_path = "%s"', prediction_file_path)
+                logger.info("output_path = %s", output_path)
                 raise ValueError(f"Failed to generate report: {output_filename}")
 
             output_path = bundle_quarto_resources(output_path)

--- a/python/pdstools/app/health_check/pages/2_Reports.py
+++ b/python/pdstools/app/health_check/pages/2_Reports.py
@@ -52,7 +52,6 @@ with health_check:
                     query=st.session_state.get("filters", None),
                     output_type=output_type,
                     keep_temp_files=keep_temp_files,
-                    verbose=False,
                     prediction=st.session_state.get("prediction"),
                     full_embed=True,
                 )

--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -321,7 +321,6 @@ def read_data(path: str | Path | BytesIO) -> pl.LazyFrame:
 def read_ds_export(
     filename: str | os.PathLike | BytesIO,
     path: str | os.PathLike = ".",
-    verbose: bool = False,
     **reading_opts,
 ) -> pl.LazyFrame | None:
     """Read Pega dataset exports with additional capabilities.
@@ -342,8 +341,6 @@ def read_ds_export(
         - BytesIO object (delegates to read_data)
     path : str or os.PathLike, default='.'
         Directory to search for files (ignored for BytesIO or full paths)
-    verbose : bool, default=False
-        Print file selection details
     **reading_opts
         Additional Polars scan_* options. Common options include:
         - infer_schema_length (int, default=10000): Rows to scan for schema inference
@@ -445,8 +442,6 @@ def read_ds_export(
 
         except Exception as e:
             logger.info(e)
-            if verbose:
-                print(f"File {filename_str} not found in dir {path_str}")
             logger.info(f"File not found: {path_str}/{filename_str}")
             return None
 
@@ -601,7 +596,6 @@ def import_file(
 
 def read_zipped_file(
     file: str | BytesIO,
-    verbose: bool = False,
 ) -> tuple[BytesIO, str]:
     """Read a zipped NDJSON file.
     Reads a dataset export file as exported and downloaded from Pega. The export
@@ -612,8 +606,6 @@ def read_zipped_file(
     ----------
     file : str
         The full path to the file
-    verbose : str, default=False
-        Whether to print the names of the files within the unzipped file for debugging purposes
 
     Returns
     -------
@@ -637,15 +629,9 @@ def read_zipped_file(
         zfile = get_valid_files(z.namelist())
         logger.debug(f"Opening file {file}")
         if zfile is not None:
-            logger.debug("data.json found.")
-            if verbose:
-                print(
-                    (
-                        "Zipped json file found. For faster reading, we recommend",
-                        "parsing the files to a format such as arrow or parquet. ",
-                        "See example in docs #TODO",
-                    ),
-                )
+            logger.debug(
+                "data.json found. For faster reading, parse to arrow or parquet.",
+            )
             with z.open(zfile) as zippedfile:
                 return (BytesIO(zippedfile.read()), ".json")
         else:  # pragma: no cover
@@ -712,7 +698,6 @@ def read_multi_zip(
 def get_latest_file(
     path: str | os.PathLike,
     target: str,
-    verbose: bool = False,
 ) -> str | None:
     """Convenience method to find the latest model snapshot.
     It has a set of default names to search for and finds all files who match it.
@@ -727,8 +712,6 @@ def get_latest_file(
     target : str in ['model_data', 'predictor_data', 'prediction_data']
         Whether to look for data about the predictive models ('model_data')
         or the predictor bins ('predictor_data')
-    verbose : bool, default = False
-        Whether to print all found files before comparing name criteria for debugging purposes
 
     Returns
     -------
@@ -748,15 +731,14 @@ def get_latest_file(
 
     files_dir = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
     files_dir = [f for f in files_dir if os.path.splitext(f)[-1].lower() in supported]
-    if verbose:
-        print(files_dir)  # pragma: no cover
+    logger.debug("Candidate files in %s: %s", path, files_dir)
     matches = find_files(files_dir, target)
 
     if len(matches) == 0:  # pragma: no cover
-        if verbose:
-            print(
-                f"Unable to find data for {target}. Please check if the data is available.",
-            )
+        logger.debug(
+            "Unable to find data for %s. Check if the data is available.",
+            target,
+        )
         return None
 
     paths = [os.path.join(path, name) for name in matches]

--- a/python/pdstools/utils/cdh_utils.py
+++ b/python/pdstools/utils/cdh_utils.py
@@ -4,7 +4,6 @@ import logging
 import math
 import re
 import tempfile
-import warnings
 import zipfile
 from collections.abc import Iterable, Sequence
 from functools import partial
@@ -1232,7 +1231,7 @@ def feature_importance(
     return result
 
 
-def _apply_schema_types(df: F, definition, verbose=False, **timestamp_opts) -> F:
+def _apply_schema_types(df: F, definition, **timestamp_opts) -> F:
     """This function is used to convert the data types of columns in a DataFrame to a desired types.
     The desired types are defined in a `PegaDefaultTables` class.
 
@@ -1242,8 +1241,6 @@ def _apply_schema_types(df: F, definition, verbose=False, **timestamp_opts) -> F
         The DataFrame whose columns' data types need to be converted.
     definition : PegaDefaultTables
         A `PegaDefaultTables` object that contains the desired data types for the columns.
-    verbose : bool
-        If True, the function will print a message when a column is not in the default table schema.
     timestamp_opts : str
         Additional arguments for timestamp parsing.
 
@@ -1272,8 +1269,7 @@ def _apply_schema_types(df: F, definition, verbose=False, **timestamp_opts) -> F
             new_type = getattr(definition, typed[renamedCol])
             original_type = schema[col].base_type()
             if original_type == pl.Null:
-                if verbose:
-                    warnings.warn(f"Warning: {col} column is Null data type.")
+                logger.debug("Column %s has Null data type; skipping cast.", col)
             elif original_type != new_type:
                 if original_type == pl.Categorical and new_type in pl.selectors.numeric():  # type: ignore[operator]
                     types.append(pl.col(col).cast(pl.Utf8).cast(new_type))
@@ -1282,10 +1278,10 @@ def _apply_schema_types(df: F, definition, verbose=False, **timestamp_opts) -> F
                 else:
                     types.append(pl.col(col).cast(new_type, strict=False))
         except Exception:
-            if verbose:  # pragma: no cover
-                warnings.warn(
-                    f"Column {col} not in default table schema, can't set type.",
-                )
+            logger.debug(
+                "Column %s not in default table schema; can't set type.",
+                col,
+            )
     return df.with_columns(types)
 
 

--- a/python/pdstools/utils/report_utils.py
+++ b/python/pdstools/utils/report_utils.py
@@ -144,7 +144,6 @@ def run_quarto(
     project: dict = {"type": "default"},
     analysis: dict | None = None,
     temp_dir: Path = Path(),
-    verbose: bool = False,
     *,
     full_embed: bool = False,
 ) -> int:
@@ -166,8 +165,6 @@ def run_quarto(
         Analysis configuration settings, by default None
     temp_dir : Path, optional
         Temporary directory for processing, by default Path(".")
-    verbose : bool, optional
-        Whether to print detailed execution logs, by default False
     full_embed : bool, default=False
         When True, fully embeds all JavaScript libraries (Plotly, itables,
         etc.) into the HTML output (larger file).
@@ -191,7 +188,7 @@ def run_quarto(
     """
 
     def get_command() -> list[str]:
-        quarto_exec, _ = get_quarto_with_version(verbose)
+        quarto_exec, _ = get_quarto_with_version()
         _command = [str(quarto_exec), "render"]
 
         if qmd_file is not None:
@@ -218,8 +215,7 @@ def run_quarto(
     # render file or render project with options
     command = get_command()
 
-    if verbose:
-        print(f"Executing: {' '.join(command)} in temp directory {temp_dir}")
+    logger.info("Executing: %s in temp directory %s", " ".join(command), temp_dir)
 
     # Set QUARTO_PYTHON to ensure Quarto uses the same Python that's running pdstools.
     # This is critical for isolated environments (uv tool, pipx) where the default
@@ -246,8 +242,6 @@ def run_quarto(
         for line in iter(process.stdout.readline, ""):
             line = line.strip()
             output_lines.append(line)
-            if verbose:
-                print(line)
             logger.info(line)
     else:  # pragma: no cover
         logger.warning("subprocess.stdout is None, unable to read output")
@@ -463,7 +457,7 @@ def _get_version_only(versionstr: str) -> str:
     return match.group(1) if match else ""
 
 
-def get_quarto_with_version(verbose: bool = True) -> tuple[Path, str]:
+def get_quarto_with_version() -> tuple[Path, str]:
     """Get Quarto executable path and version."""
     try:
         quarto_path = shutil.which("quarto")
@@ -474,17 +468,14 @@ def get_quarto_with_version(verbose: bool = True) -> tuple[Path, str]:
         executable = Path(quarto_path)
 
         version_string = _get_version_only(_get_cmd_output(["quarto", "--version"])[0])
-        message = f"quarto version: {version_string}"
-        logger.info(message)
-        if verbose:
-            print(message)
+        logger.info("quarto version: %s", version_string)
         return executable, version_string
     except Exception as e:
         logger.error(f"Error getting quarto version: {e}")
         raise
 
 
-def get_pandoc_with_version(verbose: bool = True) -> tuple[Path, str]:
+def get_pandoc_with_version() -> tuple[Path, str]:
     """Get Pandoc executable path and version."""
     try:
         pandoc_path = shutil.which("pandoc")
@@ -499,10 +490,7 @@ def get_pandoc_with_version(verbose: bool = True) -> tuple[Path, str]:
             )
 
         version_string = _get_version_only(_get_cmd_output(["pandoc", "--version"])[0])
-        message = f"pandoc version: {version_string}"
-        logger.info(message)
-        if verbose:
-            print(message)
+        logger.info("pandoc version: %s", version_string)
         return executable, version_string
     except Exception as e:
         logger.error(f"Error getting pandoc version: {e}")
@@ -1029,8 +1017,8 @@ def show_credits(quarto_source: str | None = None):
         standalone reports where knowing the source is useful. Omit for
         Quarto website projects where pages are generated from templates.
     """
-    _, quarto_version = get_quarto_with_version(verbose=False)
-    _, pandoc_version = get_pandoc_with_version(verbose=False)
+    _, quarto_version = get_quarto_with_version()
+    _, pandoc_version = get_pandoc_with_version()
 
     timestamp_str = datetime.datetime.now().strftime("%d %b %Y %H:%M:%S")
 

--- a/python/tests/test_IO.py
+++ b/python/tests/test_IO.py
@@ -81,7 +81,6 @@ def test_import_produces_bytes():
             f"{basePath}/data",
             "Data-Decision-ADM-ModelSnapshot_pyModelSnapshots_20210101T010000_GMT.zip",
         ),
-        verbose=True,
     )
 
     assert isinstance(ret[0], BytesIO)

--- a/python/tests/test_Reports.py
+++ b/python/tests/test_Reports.py
@@ -29,7 +29,7 @@ def test_health_check_file_size_optimization():
     try:
         from pdstools.utils.report_utils import get_quarto_with_version
 
-        get_quarto_with_version(verbose=False)
+        get_quarto_with_version()
     except (FileNotFoundError, Exception) as e:
         pytest.skip(f"Quarto not available in this environment: {e}")
 
@@ -48,7 +48,6 @@ def test_health_check_file_size_optimization():
                 output_path = reports.health_check(
                     name="size_test",
                     output_dir=temp_path,
-                    verbose=True,  # Enable verbose for better debugging
                 )
             except Exception as e:
                 pytest.fail(f"Health check generation failed: {e}")
@@ -102,7 +101,7 @@ def test_full_embed_integration():
     try:
         from pdstools.utils.report_utils import get_quarto_with_version
 
-        get_quarto_with_version(verbose=False)
+        get_quarto_with_version()
     except (FileNotFoundError, Exception) as e:
         pytest.skip(f"Quarto not available: {e}")
 
@@ -122,7 +121,6 @@ def test_full_embed_integration():
                 output = reports.health_check(
                     name=f"test_{label}",
                     output_dir=temp_path,
-                    verbose=False,
                     full_embed=full_embed,
                 )
                 if output and isinstance(output, Path) and output.exists():

--- a/python/tests/test_report_utils.py
+++ b/python/tests/test_report_utils.py
@@ -605,12 +605,12 @@ class TestShowCredits:
         monkeypatch.setattr(
             report_utils,
             "get_quarto_with_version",
-            lambda verbose=False: (None, "1.4.0"),
+            lambda: (None, "1.4.0"),
         )
         monkeypatch.setattr(
             report_utils,
             "get_pandoc_with_version",
-            lambda verbose=False: (None, "3.1.0"),
+            lambda: (None, "3.1.0"),
         )
         self.printed_text = ""
 
@@ -888,12 +888,12 @@ class TestGetQuartoAndPandoc:
     def test_quarto_missing_raises(self, monkeypatch):
         monkeypatch.setattr(report_utils.shutil, "which", lambda _name: None)
         with pytest.raises(FileNotFoundError, match="Quarto executable not found"):
-            report_utils.get_quarto_with_version(verbose=False)
+            report_utils.get_quarto_with_version()
 
     def test_pandoc_missing_raises(self, monkeypatch):
         monkeypatch.setattr(report_utils.shutil, "which", lambda _name: None)
         with pytest.raises(FileNotFoundError, match="Pandoc executable not found"):
-            report_utils.get_pandoc_with_version(verbose=False)
+            report_utils.get_pandoc_with_version()
 
     def test_quarto_success(self, monkeypatch, tmp_path):
         fake_exe = tmp_path / "quarto"
@@ -904,7 +904,7 @@ class TestGetQuartoAndPandoc:
             "_get_cmd_output",
             lambda _args: ["quarto 1.4.550"],
         )
-        path, version = report_utils.get_quarto_with_version(verbose=True)
+        path, version = report_utils.get_quarto_with_version()
         assert path == fake_exe
         assert version == "1.4.550"
 
@@ -917,7 +917,7 @@ class TestGetQuartoAndPandoc:
             "_get_cmd_output",
             lambda _args: ["pandoc 3.1.2"],
         )
-        path, version = report_utils.get_pandoc_with_version(verbose=True)
+        path, version = report_utils.get_pandoc_with_version()
         assert path == fake_exe
         assert version == "3.1.2"
 


### PR DESCRIPTION
Remove verbose=... parameters that were used to gate internal noise (subprocess output, schema warnings, decoded values, raw os.listdir). Such output now goes through logger.debug/info instead.

Cat A keepers (tqdm progress bars + multi-stage CLI output): S3, read_multi_zip, Anonymization — all unchanged.

Refine AGENTS.md verbose rule to a more nuanced 'Cat A vs Cat B' guidance instead of a blanket prohibition.

Affected functions:
- cdh_utils._apply_schema_types
- report_utils.get_quarto_with_version, get_pandoc_with_version, run_quarto
- adm.Reports.model_reports, health_check (also fixes a latent 'verbose or not output_path.exists()' coupling between verbosity and cache/error reporting)
- pega_io.File.read_ds_export, read_zipped_file, get_latest_file
- adm.ADMTrees.get_agb_models, ADMTrees.__new__, get_multi_trees, and _decode_trees inner helpers