### PR TITLE
Decouple DecisionAnalyzer from Streamlit session_state (#648)

### DIFF
--- a/docs/decision-analyzer-architecture.md
+++ b/docs/decision-analyzer-architecture.md
@@ -95,10 +95,14 @@ page's sidebar. Session state keys:
 - `page_channel_filter` — UI display value ("Any" or "Channel/Direction")
 - `page_channel_expr` — Polars filter expression or None
 
-Applied via `DecisionAnalyzer.filtered_sample` property, which reads session state
-and filters the sample. To add new contextual filters (e.g., Issue, Group), extend
-`contextual_filters()`, add corresponding session state keys, and update
-`filtered_sample` to collect all filter expressions.
+Pages collect the active expressions via `collect_page_filters()` (also in
+`da_streamlit_utils.py`) and pass the resulting list to
+`DecisionAnalyzer.filtered(filters)`. The library deliberately does **not**
+read `st.session_state` itself — keeping that translation in the app layer
+means the analyser stays usable from notebooks and scripts. To add a new
+contextual filter (e.g. Issue, Group), add a selector to
+`contextual_filters()`, store the expression in a `page_{name}_expr` key,
+and append that key to the tuple inside `collect_page_filters()`.
 
 ### Ranking
 
@@ -131,7 +135,7 @@ definition.
 3. Set `st.session_state["sidebar"] = st.sidebar`
 4. Add page-specific controls in the sidebar block
 5. Call `contextual_filters()` as the **last** sidebar item
-6. Read `filtered_sample` and `page_channel_expr` from session state
+6. Compute `filtered_data = da.filtered(collect_page_filters())` for filtered access to the sample
 7. Check for empty results when channel filter is active (standard pattern in all pages)
 8. Use `additional_filters=channel_filter` when calling DA query methods
 
@@ -140,7 +144,7 @@ definition.
 1. Add selector function in `da_streamlit_utils.py` (follow `channel_direction_selector()` pattern)
 2. Add it inside `contextual_filters()` after the channel selector
 3. Store selection in `page_{name}_filter` / `page_{name}_expr` session state keys
-4. Update `DecisionAnalyzer.filtered_sample` to read the new expression
+4. Append the new `page_{name}_expr` key to the tuple in `collect_page_filters()`
 5. Update empty-data checks on all pages
 
 ### Adding a New DA Method

--- a/docs/plans/decision-analyzer-TODO.md
+++ b/docs/plans/decision-analyzer-TODO.md
@@ -53,8 +53,8 @@ removed or marked done as commits land on master.
 
 ### P2
 
-- [ ] **Add Issue filter to contextual filters section** — Extend `contextual_filters()` with an `issue_selector()` multiselect (empty = no filter). Store in `page_issue_filter`/`page_issue_expr` session state keys (same pattern as channel). Extend `DecisionAnalyzer.filtered_sample` to collect all contextual filter expressions. Update empty-data checks on all pages.
-- [ ] **Add cascading Group filter to contextual filters section** — After Issue filter is in place, add `group_selector()` that dynamically constrains its options based on the current Issue selection (Issue → Group hierarchy). Same session state pattern (`page_group_filter`/`page_group_expr`). Requires `filtered_sample` to apply all three filters (channel, issue, group).
+- [ ] **Add Issue filter to contextual filters section** — Extend `contextual_filters()` with an `issue_selector()` multiselect (empty = no filter). Store in `page_issue_filter`/`page_issue_expr` session state keys (same pattern as channel). Append the new key to the tuple in `collect_page_filters()` (in `da_streamlit_utils.py`) so it flows through `DecisionAnalyzer.filtered`. Update empty-data checks on all pages.
+- [ ] **Add cascading Group filter to contextual filters section** — After Issue filter is in place, add `group_selector()` that dynamically constrains its options based on the current Issue selection (Issue → Group hierarchy). Same session state pattern (`page_group_filter`/`page_group_expr`). Add the key to `collect_page_filters()`; pages already pick up new keys automatically via `da.filtered(collect_page_filters())`.
 - [ ] **Improve file upload robustness** — Filter META-INF/MANIFEST.mf files, clear session state on new upload, improve error messages. Apply patterns from Impact Analyzer.
 - [ ] **Dynamic stage UI** — Hardcoded stage names remain in Optionality page (`stage="Output"`) and plots.py (`"Final"` filter). Replace with data-driven `DecisionAnalyzer.stages`.
 

--- a/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
+++ b/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
@@ -690,6 +690,24 @@ def get_available_channel_directions(sample_df: pl.LazyFrame) -> list[str]:
         return []
 
 
+def collect_page_filters() -> list[pl.Expr]:
+    """Gather page-level filter expressions from Streamlit session state.
+
+    Pages should call this and pass the result to
+    :meth:`DecisionAnalyzer.filtered` rather than relying on the analyser
+    to reach into ``st.session_state`` itself. Adding new contextual
+    filters (e.g. Issue, Group) means appending another ``page_*_expr``
+    key here — no library changes required.
+
+    Returns
+    -------
+    list[pl.Expr]
+        Active page-level filters. Empty list if none are set.
+    """
+    keys = ("page_channel_expr",)
+    return [expr for key in keys if (expr := st.session_state.get(key)) is not None]
+
+
 def _update_channel_filter():
     """Callback to update filter expression when channel selection changes."""
     selected = st.session_state._channel_direction_widget
@@ -722,7 +740,8 @@ def channel_direction_selector():
 
     Stores selection in st.session_state.page_channel_filter (UI value)
     and st.session_state.page_channel_expr (Polars filter expression).
-    The filter is applied via DecisionAnalyzer.filtered_sample property.
+    Pages collect this expression via :func:`collect_page_filters` and
+    apply it through ``DecisionAnalyzer.filtered``.
     """
     da = st.session_state.decision_data
 

--- a/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
@@ -2,6 +2,7 @@
 import polars as pl
 import streamlit as st
 from da_streamlit_utils import (
+    collect_page_filters,
     contextual_filters,
     ensure_data,
     get_current_index,
@@ -60,7 +61,7 @@ with st.session_state["sidebar"]:
     contextual_filters()
 
 # Apply channel filter to sample data
-filtered_data = st.session_state.decision_data.filtered_sample
+filtered_data = st.session_state.decision_data.filtered(collect_page_filters())
 
 # Check for empty results when a specific channel is selected
 if st.session_state.get("page_channel_filter", "Any") != "Any":

--- a/python/pdstools/app/decision_analyzer/pages/2_Overview.py
+++ b/python/pdstools/app/decision_analyzer/pages/2_Overview.py
@@ -1,7 +1,7 @@
 # python/pdstools/app/decision_analyzer/pages/3_Overview.py
 import polars as pl
 import streamlit as st
-from da_streamlit_utils import ensure_data
+from da_streamlit_utils import collect_page_filters, ensure_data
 from pdstools.decision_analyzer.plots import offer_quality_single_pie
 
 # TODO see if we can speed up on first use - it's doing a lot now
@@ -104,7 +104,7 @@ with col2:
         approach, balanced with business value.
         """
 
-        total_decisions = da.filtered_sample.select(pl.n_unique("Interaction ID")).collect().item()
+        total_decisions = da.filtered(collect_page_filters()).select(pl.n_unique("Interaction ID")).collect().item()
         st.plotly_chart(
             st.session_state.decision_data.plot.sensitivity(
                 win_rank=1,

--- a/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
@@ -2,6 +2,7 @@ import polars as pl
 import streamlit as st
 
 from da_streamlit_utils import (
+    collect_page_filters,
     contextual_filters,
     get_current_index,
     ensure_data,
@@ -43,7 +44,7 @@ with st.session_state["sidebar"]:
     contextual_filters()
 
 # Apply channel filter to sample data
-filtered_data = st.session_state.decision_data.filtered_sample
+filtered_data = st.session_state.decision_data.filtered(collect_page_filters())
 
 # Check for empty results when a specific channel is selected
 if st.session_state.get("page_channel_filter", "Any") != "Any":

--- a/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
+++ b/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
@@ -2,6 +2,7 @@
 import polars as pl
 import streamlit as st
 from da_streamlit_utils import (
+    collect_page_filters,
     contextual_filters,
     ensure_data,
     ensure_funnel,
@@ -71,7 +72,7 @@ with st.session_state["sidebar"]:
     )
     contextual_filters()
 
-filtered_data = st.session_state.decision_data.filtered_sample
+filtered_data = st.session_state.decision_data.filtered(collect_page_filters())
 
 if st.session_state.get("page_channel_filter", "Any") != "Any":
     filtered_count = filtered_data.select(pl.len()).collect().item()

--- a/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
+++ b/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
@@ -1,6 +1,6 @@
 import polars as pl
 import streamlit as st
-from da_streamlit_utils import contextual_filters, ensure_data, get_current_index
+from da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data, get_current_index
 
 from pdstools.decision_analyzer.utils import apply_filter
 
@@ -34,7 +34,7 @@ with st.session_state["sidebar"]:
     contextual_filters()
 
 # Apply channel filter to sample data
-filtered_data = st.session_state.decision_data.filtered_sample
+filtered_data = st.session_state.decision_data.filtered(collect_page_filters())
 
 # Check for empty results when a specific channel is selected
 if st.session_state.get("page_channel_filter", "Any") != "Any":

--- a/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
@@ -1,6 +1,7 @@
 import polars as pl
 import streamlit as st
 from da_streamlit_utils import (
+    collect_page_filters,
     contextual_filters,
     ensure_data,
     get_current_index,
@@ -74,7 +75,7 @@ facetting = "pyChannel/pyDirection"
 # )
 with st.session_state["sidebar"]:
     scope_options = st.session_state.decision_data.get_possible_scope_values()
-    filtered_data = st.session_state.decision_data.filtered_sample
+    filtered_data = st.session_state.decision_data.filtered(collect_page_filters())
     comparison_filter_columns = [
         c
         for c in st.session_state.decision_data.get_available_fields_for_filtering(

--- a/python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
@@ -2,6 +2,7 @@
 import polars as pl
 import streamlit as st
 from da_streamlit_utils import (
+    collect_page_filters,
     contextual_filters,
     ensure_data,
     stage_level_selector,
@@ -25,7 +26,7 @@ with st.session_state["sidebar"]:
     contextual_filters()
 
 # Apply channel filter to sample data
-filtered_data = st.session_state.decision_data.filtered_sample
+filtered_data = st.session_state.decision_data.filtered(collect_page_filters())
 
 # Check for empty results when a specific channel is selected
 if st.session_state.get("page_channel_filter", "Any") != "Any":

--- a/python/pdstools/app/decision_analyzer/pages/8_Offer_Quality_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/8_Offer_Quality_Analysis.py
@@ -4,6 +4,7 @@ import streamlit as st
 
 from pdstools.decision_analyzer.plots import getTrendChart, offer_quality_piecharts
 from da_streamlit_utils import (
+    collect_page_filters,
     contextual_filters,
     ensure_data,
     stage_level_selector,
@@ -82,7 +83,7 @@ with st.session_state["sidebar"]:
 
 
 # Apply channel filter to sample data
-filtered_data = st.session_state.decision_data.filtered_sample
+filtered_data = st.session_state.decision_data.filtered(collect_page_filters())
 
 # Check for empty results when a specific channel is selected
 if st.session_state.get("page_channel_filter", "Any") != "Any":

--- a/python/pdstools/app/decision_analyzer/pages/9_Thresholding_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/9_Thresholding_Analysis.py
@@ -5,7 +5,7 @@ import plotly.express as px
 import polars as pl
 import streamlit as st
 
-from da_streamlit_utils import contextual_filters, ensure_data
+from da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data
 from pdstools.decision_analyzer.utils import apply_filter
 
 "# Thresholding Analysis"
@@ -26,7 +26,7 @@ ensure_data()
 da = st.session_state.decision_data
 
 # Apply channel filter to sample data
-filtered_data = da.filtered_sample
+filtered_data = da.filtered(collect_page_filters())
 
 # Check for empty results when a specific channel is selected
 if st.session_state.get("page_channel_filter", "Any") != "Any":

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -772,29 +772,51 @@ class DecisionAnalyzer:
 
     @property
     def filtered_sample(self):
-        """Sample data with page-level filters applied.
+        """Deprecated: use `filtered(filters)` and pass filters explicitly.
 
-        Reads filter expressions from st.session_state.page_channel_expr if available.
-        Falls back to unfiltered sample if no page filters are set or not in Streamlit context.
-
-        This property is not cached because it depends on mutable session_state.
-        Page-level code should cache the result locally if needed for performance.
+        Kept as a thin alias that returns the unfiltered sample. Apps that
+        need page-level filtering should collect the relevant Polars
+        expressions in the app layer (see
+        ``pdstools.app.decision_analyzer.da_streamlit_utils.collect_page_filters``)
+        and call :meth:`filtered` instead.
 
         Returns
         -------
         pl.LazyFrame
-            Sampled data with page filters applied, or unfiltered sample if no filters.
+            The unfiltered sample. Equivalent to ``self.sample``.
         """
-        try:
-            import streamlit as st
+        import warnings
 
-            channel_expr = st.session_state.get("page_channel_expr", None)
-            if channel_expr is not None:
-                return apply_filter(self.sample, [channel_expr])
-        except ImportError:
-            pass  # Not in Streamlit context
-
+        warnings.warn(
+            "DecisionAnalyzer.filtered_sample is deprecated; "
+            "call filtered(filters) with explicit page filters instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.sample
+
+    def filtered(self, filters: list[pl.Expr] | pl.Expr | None = None) -> pl.LazyFrame:
+        """Return ``self.sample`` with the given filter expressions applied.
+
+        Parameters
+        ----------
+        filters : list[pl.Expr] | pl.Expr | None, default None
+            Filter expressions to AND together. ``None`` or an empty list
+            returns the sample unchanged. Apps should construct this list
+            from their own state (for Streamlit pages, see
+            :func:`pdstools.app.decision_analyzer.da_streamlit_utils.collect_page_filters`);
+            the library deliberately does not read UI state.
+
+        Returns
+        -------
+        pl.LazyFrame
+            The (possibly filtered) sample.
+        """
+        if filters is None:
+            return self.sample
+        if isinstance(filters, list) and not filters:
+            return self.sample
+        return apply_filter(self.sample, filters)
 
     def get_available_fields_for_filtering(self, categoricalOnly=False) -> list[str]:
         """Return column names available for data filtering.

--- a/python/tests/test_decision_analyzer_filtered_sample.py
+++ b/python/tests/test_decision_analyzer_filtered_sample.py
@@ -1,8 +1,7 @@
-"""Tests for DecisionAnalyzer.filtered_sample property."""
+"""Tests for DecisionAnalyzer.filtered and the Streamlit filter glue."""
 
 import polars as pl
 import pytest
-from unittest.mock import MagicMock, patch
 
 
 @pytest.fixture
@@ -25,50 +24,80 @@ def mock_decision_analyzer(sample_data_v2):
     """Create a mock DecisionAnalyzer with sample property."""
     from pdstools.decision_analyzer.DecisionAnalyzer import DecisionAnalyzer
 
-    # Create analyzer with minimal init
     analyzer = DecisionAnalyzer.__new__(DecisionAnalyzer)
-
-    # Mock the sample property to return our test data
     type(analyzer).sample = property(lambda self: sample_data_v2.lazy())
-
     return analyzer
 
 
-def test_filtered_sample_without_filters(mock_decision_analyzer, sample_data_v2):
-    """When no page filters set, filtered_sample should return sample unchanged."""
-    with patch("streamlit.session_state", new_callable=MagicMock) as mock_st:
-        mock_st.get.return_value = None  # No page_channel_expr
+def test_filtered_without_filters(mock_decision_analyzer, sample_data_v2):
+    """``filtered(None)`` and ``filtered([])`` should return sample unchanged."""
+    expected = sample_data_v2.lazy().collect()
+    assert mock_decision_analyzer.filtered(None).collect().equals(expected)
+    assert mock_decision_analyzer.filtered([]).collect().equals(expected)
 
+
+def test_filtered_with_single_expression(mock_decision_analyzer):
+    """A single Polars expression should be applied."""
+    expr = (pl.col("Channel") == "Web") & (pl.col("Direction") == "Inbound")
+    result = mock_decision_analyzer.filtered(expr).collect()
+
+    assert len(result) == 2
+    assert (result["Channel"] == "Web").all()
+    assert (result["Direction"] == "Inbound").all()
+
+
+def test_filtered_with_list_of_expressions(mock_decision_analyzer):
+    """Multiple expressions should AND together."""
+    filters = [pl.col("Channel") == "Web", pl.col("Priority") >= 95.0]
+    result = mock_decision_analyzer.filtered(filters).collect()
+
+    assert len(result) == 1
+    assert result["Action"][0] == "A1"
+
+
+def test_filtered_sample_is_deprecated(mock_decision_analyzer, sample_data_v2):
+    """The legacy ``filtered_sample`` alias should warn but still return the sample."""
+    with pytest.warns(DeprecationWarning, match="filtered_sample is deprecated"):
         result = mock_decision_analyzer.filtered_sample
-        expected = sample_data_v2.lazy()
-
-        # Compare collected DataFrames
-        assert result.collect().equals(expected.collect())
+    assert result.collect().equals(sample_data_v2.lazy().collect())
 
 
-def test_filtered_sample_with_channel_filter(mock_decision_analyzer, sample_data_v2):
-    """When page_channel_expr is set, filtered_sample should apply the filter."""
-    with patch("streamlit.session_state", new_callable=MagicMock) as mock_st:
-        # Set up a channel filter for Web/Inbound
-        channel_expr = (pl.col("Channel") == "Web") & (pl.col("Direction") == "Inbound")
-        mock_st.get.return_value = channel_expr
+def test_filtered_does_not_import_streamlit(mock_decision_analyzer, monkeypatch):
+    """``filtered`` must not look at Streamlit state even when it's set."""
+    from pdstools.app.decision_analyzer import da_streamlit_utils
 
-        result = mock_decision_analyzer.filtered_sample
+    monkeypatch.setattr(
+        da_streamlit_utils.st,
+        "session_state",
+        {"page_channel_expr": pl.col("Channel") == "Web"},
+        raising=False,
+    )
 
-        # Should only have Web/Inbound rows (first 2 rows)
-        result_collected = result.collect()
-        assert len(result_collected) == 2
-        assert (result_collected["Channel"] == "Web").all()
-        assert (result_collected["Direction"] == "Inbound").all()
+    # No filter passed → full sample regardless of session_state contents.
+    assert len(mock_decision_analyzer.filtered().collect()) == 6
 
 
-def test_filtered_sample_outside_streamlit(mock_decision_analyzer, sample_data_v2):
-    """When not in Streamlit context, filtered_sample should return sample."""
-    # Don't mock streamlit - let ImportError occur naturally
-    result = mock_decision_analyzer.filtered_sample
-    expected = sample_data_v2.lazy()
+def test_collect_page_filters_returns_expressions(monkeypatch):
+    """The Streamlit helper should pull only set keys from session_state."""
+    from pdstools.app.decision_analyzer import da_streamlit_utils
+    from pdstools.app.decision_analyzer.da_streamlit_utils import collect_page_filters
 
-    assert result.collect().equals(expected.collect())
+    expr = pl.col("Channel") == "Web"
+    monkeypatch.setattr(da_streamlit_utils.st, "session_state", {"page_channel_expr": expr}, raising=False)
+
+    result = collect_page_filters()
+    assert len(result) == 1
+    # Expressions don't compare with ==, but should be the same object we stored.
+    assert result[0] is expr
+
+
+def test_collect_page_filters_empty_when_none_set(monkeypatch):
+    """No keys set → empty list."""
+    from pdstools.app.decision_analyzer import da_streamlit_utils
+    from pdstools.app.decision_analyzer.da_streamlit_utils import collect_page_filters
+
+    monkeypatch.setattr(da_streamlit_utils.st, "session_state", {}, raising=False)
+    assert collect_page_filters() == []
 
 
 @pytest.fixture


### PR DESCRIPTION
DecisionAnalyzer.filtered_sample previously imported streamlit and reached into st.session_state.page_channel_expr, coupling the core analyser to UI runtime state. Same instance returned different data in Streamlit vs notebook/script contexts and silently no-op'd when streamlit was unavailable.

Move the session_state lookup into the app layer:

- Add DecisionAnalyzer.filtered(filters) — pure library API that takes a Polars expression or list of expressions explicitly.
- Add da_streamlit_utils.collect_page_filters() — single home for gathering page-level filter expressions from session_state. New contextual filters (Issue, Group, …) only need a key appended to the tuple here; pages and library both stay unchanged.
- Update all 9 analysis pages to use da.filtered(collect_page_filters()) instead of da.filtered_sample.
- Keep filtered_sample as a deprecation-warning shim returning the unfiltered sample, so any external code or notebook caller fails loudly rather than silently dropping filters.
- Replace streamlit-mocking tests with monkeypatched session_state dicts and add coverage for the new API surface.
- Update docs/decision-analyzer-architecture.md and docs/plans/decision-analyzer-TODO.md to describe the new pattern and the (now trivial) extension path for Issue/Group filters.

Refs #648