### PR TITLE
Narrow bare `except Exception:` blocks; fix latent regex bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,12 @@ uv run ruff format ./python
 ```
 
 ### Tests
+The full suite takes ~10–15 minutes locally. **Prefer narrow, targeted runs**
+(single file, single function, or `-k` keyword filter) while iterating.
+Only run the full suite when you're done with a logical chunk of work
+or when you need broad confidence (e.g. before pushing a PR). CI re-runs
+everything, so a final full local run is usually enough.
+
 Full test suite (CI default, with coverage; skips heavy tests):
 
 ```bash

--- a/python/pdstools/adm/ADMTrees.py
+++ b/python/pdstools/adm/ADMTrees.py
@@ -428,18 +428,18 @@ class ADMTreesModel:
 
         try:
             self._properties = {prop[0]: prop[1] for prop in self.trees.items() if prop[0] != "model"}
-        except Exception:  # pragma: no cover
+        except (AttributeError, TypeError):  # pragma: no cover
             logger.info("Could not extract the properties.")
             self._properties = {}
 
         try:
             self.learning_rate = self._properties["configuration"]["parameters"]["learningRateEta"]
-        except Exception:  # pragma: no cover
+        except (KeyError, TypeError):  # pragma: no cover
             logger.info("Could not find the learning rate in the model.")
 
         try:
             self.context_keys = self._properties["configuration"]["contextKeys"]
-        except Exception:  # pragma: no cover
+        except (KeyError, TypeError):  # pragma: no cover
             logger.info("Could not find context keys.")
             self.context_keys = kwargs.get("context_keys")
 
@@ -806,8 +806,8 @@ class ADMTreesModel:
         total_predictors: dict[str, str] | None = None
         try:
             total_predictors = self.predictors
-        except Exception:
-            pass
+        except (KeyError, AttributeError, TypeError, IndexError) as exc:
+            logger.debug("Could not read total predictors: %s", exc)
 
         if total_predictors is not None:
             all_ih = {n for n in total_predictors if _classify_predictor(n) == "ih"}
@@ -1162,10 +1162,10 @@ class ADMTreesModel:
         self.nospaces = True
         try:
             predictors = self._properties["configuration"]["predictors"]
-        except Exception:  # pragma: no cover
+        except (KeyError, TypeError):  # pragma: no cover
             try:
                 predictors = self._properties["predictors"]
-            except Exception:
+            except (KeyError, TypeError):
                 try:
                     predictors = []
                     for i in self._properties.split("=")[4].split(
@@ -1177,7 +1177,7 @@ class ADMTreesModel:
                             else:
                                 predictors += [i[:-2]]
 
-                except Exception:
+                except (AttributeError, IndexError, TypeError):
                     # No explicit predictor metadata available — infer
                     # from tree splits (see docstring above).
                     return self._infer_predictors_from_splits()

--- a/python/pdstools/app/decision_analyzer/Home.py
+++ b/python/pdstools/app/decision_analyzer/Home.py
@@ -186,7 +186,7 @@ if raw_data is not None:
             min_time, max_time = estimate_sampling_time(row_count, target_n)
             time_msg = format_time_estimate(min_time, max_time)
             sampling_msg += f" (estimated: {time_msg})"
-        except Exception:
+        except (ImportError, AttributeError, ValueError):
             pass  # Keep the simple message
 
         try:

--- a/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
+++ b/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
@@ -474,7 +474,7 @@ def handle_data_path() -> pl.LazyFrame | None:
             min_time, max_time = estimate_extraction_time(file_size)
             time_msg = format_time_estimate(min_time, max_time)
             spinner_msg = f"Extracting archive... (estimated: {time_msg})"
-        except Exception:
+        except (ImportError, OSError, AttributeError):
             spinner_msg = "Extracting archive..."
 
         tmp_dir = tempfile.mkdtemp(prefix="da_path_")
@@ -499,7 +499,7 @@ def handle_data_path() -> pl.LazyFrame | None:
             min_time, max_time = estimate_extraction_time(file_size)
             time_msg = format_time_estimate(min_time, max_time)
             spinner_msg = f"Extracting archive... (estimated: {time_msg})"
-        except Exception:
+        except (ImportError, OSError, AttributeError):
             spinner_msg = "Extracting archive..."
 
         tmp_dir = tempfile.mkdtemp(prefix="da_path_tar_")
@@ -553,7 +553,7 @@ def _read_uploaded_zip(file_buffer) -> pl.LazyFrame:
             min_time, max_time = estimate_extraction_time(file_size)
             time_msg = format_time_estimate(min_time, max_time)
             spinner_msg = f"Extracting uploaded archive... (estimated: {time_msg})"
-        except Exception:
+        except (ImportError, OSError, AttributeError):
             spinner_msg = "Extracting uploaded archive..."
 
         tmp_dir = tempfile.mkdtemp(prefix="da_upload_")
@@ -582,7 +582,7 @@ def _read_uploaded_tar(file_buffer) -> pl.LazyFrame:
         min_time, max_time = estimate_extraction_time(file_size)
         time_msg = format_time_estimate(min_time, max_time)
         spinner_msg = f"Extracting uploaded archive... (estimated: {time_msg})"
-    except Exception:
+    except (ImportError, OSError, AttributeError):
         spinner_msg = "Extracting uploaded archive..."
 
     tmp_dir = tempfile.mkdtemp(prefix="da_tar_")

--- a/python/pdstools/app/impact_analyzer/Home.py
+++ b/python/pdstools/app/impact_analyzer/Home.py
@@ -121,7 +121,7 @@ def _show_data_summary(ia, is_sample_data: bool = False):
             format_label = "**VBD Scenario Planner**"
         else:
             format_label = "**PDC Export**"
-    except Exception:
+    except (pl.exceptions.PolarsError, AttributeError, KeyError):
         format_label = "**Unknown format**"
 
     try:
@@ -136,7 +136,7 @@ def _show_data_summary(ia, is_sample_data: bool = False):
             prefix = "Data loaded successfully"
 
         st.success(f"{prefix}. Detected format: {format_label}\n\n**{rows:,}** rows · **{channels}** channels")
-    except Exception:
+    except (pl.exceptions.PolarsError, AttributeError, KeyError):
         prefix = "Sample data loaded" if is_sample_data else "Data loaded successfully"
         st.success(f"{prefix}. Detected format: {format_label}")
 

--- a/python/pdstools/cli.py
+++ b/python/pdstools/cli.py
@@ -246,7 +246,7 @@ def run(args, unknown):
             except (KeyboardInterrupt, EOFError):
                 print("\nExiting...")
                 sys.exit(0)
-            except Exception:
+            except ValueError:
                 print("Invalid input. Please try again.")
 
     # Propagate CLI flags to the Streamlit process via env vars
@@ -259,7 +259,7 @@ def run(args, unknown):
             import polars as _pl
 
             has_rt64 = _pl.get_index_type() == _pl.UInt64
-        except Exception:
+        except (ImportError, AttributeError):
             has_rt64 = False
         if not has_rt64:
             print(

--- a/python/pdstools/decision_analyzer/utils.py
+++ b/python/pdstools/decision_analyzer/utils.py
@@ -1295,7 +1295,8 @@ def _read_source_metadata(source_path: str) -> dict[str, str | float] | None:
         p = Path(source_path)
         if not p.exists() or not p.is_file() or p.suffix.lower() != ".parquet":
             return None
-    except Exception:
+    except (OSError, TypeError, ValueError) as exc:
+        logger.debug("Could not stat %s: %s", source_path, exc)
         return None
 
     try:

--- a/python/pdstools/infinity/internal/_base_client.py
+++ b/python/pdstools/infinity/internal/_base_client.py
@@ -321,7 +321,7 @@ class SyncAPIClient(BaseClient[httpx.Client]):
 
         try:
             return response.json()
-        except Exception:
+        except ValueError:
             return response
 
     def patch(
@@ -379,7 +379,7 @@ class SyncAPIClient(BaseClient[httpx.Client]):
             raise self.handle_pega_exception(endpoint, params, response)
         try:
             return response.json()
-        except Exception:
+        except ValueError:
             return response
 
     def get_api_list(self):  # pragma: no cover
@@ -409,7 +409,7 @@ class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
         try:
             # TODO(someday): support non asyncio runtimes here
             asyncio.get_running_loop().create_task(self.aclose())
-        except Exception:
+        except RuntimeError:
             pass
 
 
@@ -566,7 +566,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient]):  # pragma: no cover
 
         try:
             return response.json()
-        except Exception:
+        except ValueError:
             return response
 
     async def patch(
@@ -624,7 +624,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient]):  # pragma: no cover
             raise self.handle_pega_exception(endpoint, params, response)
         try:
             return response.json()
-        except Exception:
+        except ValueError:
             return response
 
     def get_api_list(self):  # pragma: no cover

--- a/python/pdstools/infinity/internal/_exceptions.py
+++ b/python/pdstools/infinity/internal/_exceptions.py
@@ -123,7 +123,7 @@ def handle_pega_exception(
 ) -> PegaException | Exception:
     try:
         content = response.json()
-    except Exception:
+    except ValueError:
         raise InvalidRequest(
             str(base_url),
             endpoint,

--- a/python/pdstools/infinity/internal/_pagination.py
+++ b/python/pdstools/infinity/internal/_pagination.py
@@ -142,7 +142,7 @@ class PaginatedList(Generic[T]):
             if not response:
                 raise ValueError(__key)
             return response
-        except Exception:
+        except (IndexError, KeyError, ValueError, AttributeError, TypeError):
             return __default
 
     def __iter__(self) -> Iterator[T]:
@@ -301,7 +301,7 @@ class AsyncPaginatedList(Generic[T]):
                     for el in items:
                         if getattr(el, "id", None) == __key:
                             return el
-            except Exception:
+            except (IndexError, KeyError, ValueError, AttributeError, TypeError):
                 pass
         return __default  # type: ignore[return-value]
 

--- a/python/pdstools/pega_io/Anonymization.py
+++ b/python/pdstools/pega_io/Anonymization.py
@@ -1,8 +1,11 @@
 import math
 import os
+import logging
 from glob import glob
 
 import polars as pl
+
+logger = logging.getLogger(__name__)
 
 
 class Anonymization:
@@ -141,11 +144,12 @@ class Anonymization:
                 ser = df.get_column(col)
                 try:
                     ser = ser.replace("", None)
-                except Exception:
+                except (pl.exceptions.InvalidOperationError, pl.exceptions.ComputeError):
                     pass
                 ser.cast(pl.Float64)
                 types[col] = "numeric"
-            except Exception:
+            except (pl.exceptions.InvalidOperationError, pl.exceptions.ComputeError, ValueError) as exc:
+                logger.debug("Column %s defaulted to symbolic: %s", col, exc)
                 types[col] = "symbolic"
 
         return types

--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -560,10 +560,12 @@ def import_file(
                 file,
                 infer_schema_length=reading_opts.pop("infer_schema_length", 10000),
             )
-        except Exception:  # pragma: no cover
+        except (pl.exceptions.ComputeError, pl.exceptions.SchemaError, OSError) as exc:  # pragma: no cover
+            logger.debug("scan_ndjson failed for %s: %s", file, exc)
             try:
                 df = pl.read_json(file).lazy()
-            except Exception:
+            except (pl.exceptions.ComputeError, pl.exceptions.SchemaError, ValueError) as exc:
+                logger.debug("read_json fallback failed for %s: %s", file, exc)
                 import json
 
                 with open(file) as f:  # type: ignore[arg-type]
@@ -746,9 +748,10 @@ def get_latest_file(
     def f(x):
         try:
             return from_prpc_date_time(
-                re.search(r"\d.{0,15}*GMT", x)[0].replace("_", " "),
+                re.search(r"\d.{0,15}GMT", x)[0].replace("_", " "),
             )
-        except Exception:
+        except (AttributeError, TypeError, ValueError) as exc:
+            logger.debug("Falling back to ctime for %s: %s", x, exc)
             return datetime.fromtimestamp(os.path.getctime(x), tz=timezone.utc)
 
     dates = pl.Series([f(i) for i in paths])

--- a/python/pdstools/utils/cdh_utils.py
+++ b/python/pdstools/utils/cdh_utils.py
@@ -1277,10 +1277,11 @@ def _apply_schema_types(df: F, definition, **timestamp_opts) -> F:
                     types.append(parse_pega_date_time_formats(col, **timestamp_opts))
                 else:
                     types.append(pl.col(col).cast(new_type, strict=False))
-        except Exception:
+        except (KeyError, AttributeError) as exc:
             logger.debug(
-                "Column %s not in default table schema; can't set type.",
+                "Column %s not in default table schema; can't set type: %s",
                 col,
+                exc,
             )
     return df.with_columns(types)
 
@@ -1484,9 +1485,10 @@ def get_latest_pdstools_version():
     import requests  # type: ignore[import-untyped]
 
     try:
-        response = requests.get("https://pypi.org/pypi/pdstools/json")
+        response = requests.get("https://pypi.org/pypi/pdstools/json", timeout=5)
         return response.json()["info"]["version"]
-    except Exception:
+    except (requests.RequestException, ValueError, KeyError) as exc:
+        logger.debug("Could not fetch latest pdstools version: %s", exc)
         return None
 
 

--- a/python/tests/infinity/test_base_client.py
+++ b/python/tests/infinity/test_base_client.py
@@ -205,7 +205,7 @@ class TestSyncAPIClientRequest:
     def test_delete_returns_response_on_204_no_body(self, mocker):
         client = self._make_client()
         resp = self._mock_response(204)
-        resp.json.side_effect = Exception("no body")
+        resp.json.side_effect = ValueError("no body")
         mocker.patch.object(client, "_request", return_value=resp)
         result = client.delete("/api/test")
         # Should return the raw response when json() fails.
@@ -335,7 +335,7 @@ class TestHandlePegaException:
     def test_non_json_response_raises_invalid_request(self):
         resp = MagicMock(spec=httpx.Response)
         resp.status_code = 500
-        resp.json.side_effect = Exception("not json")
+        resp.json.side_effect = ValueError("not json")
         resp.content = b"Internal Server Error"
         from pdstools.infinity.internal._exceptions import InvalidRequest
 


### PR DESCRIPTION
Replaces 32 of 35 bare `except Exception:` clauses with specific exception types so genuine bugs surface instead of being silently swallowed. Adds `logger.debug` traceability where the catch is still an intentional fallback.

Sites narrowed:
- pega_io/Anonymization.py: column type inference (polars compute errors)
- pega_io/File.py: ndjson/json read fallbacks, file-date parsing
- utils/cdh_utils.py: schema cast (KeyError/AttributeError), get_latest_pdstools_version (RequestException/ValueError/KeyError)
- cli.py: input loop (ValueError), polars rt64 probe (ImportError)
- decision_analyzer/utils.py: Path stat (OSError)
- app/decision_analyzer/{Home,da_streamlit_utils}.py: optional progress_utils import + size estimate fallbacks
- app/impact_analyzer/Home.py: data inspection (PolarsError)
- adm/ADMTrees.py: properties / learning_rate / context_keys / predictors cascades — narrowed to KeyError/TypeError/AttributeError. The three top-level decoder cascade catches already log with `exc_info=True` and remain broad by design.
- infinity/internal/_base_client.py: response.json() fallbacks (ValueError), AsyncHttpxClientWrapper.__del__ (RuntimeError)
- infinity/internal/_pagination.py: get() lookup fallbacks
- infinity/internal/_exceptions.py: response.json() in handle_pega_exception

Bug fixes uncovered by narrowing:
- pega_io/File.py find_latest_files regex `\d.{0,15}*GMT` was a `re.PatternError` (multiple repeat) on every call; the bare except silently routed everything through the ctime fallback. Removed the spurious `*`.

Tests:
- Updated test_base_client.py mocks to raise ValueError (the narrowed catch type) instead of bare Exception.

Also documents in AGENTS.md to prefer targeted test runs over the ~14-minute full suite during local iteration.