### PR TITLE
Trivial code-quality cleanups

### DIFF
--- a/python/pdstools/cli.py
+++ b/python/pdstools/cli.py
@@ -187,7 +187,7 @@ def run(args, unknown):
         from streamlit.web import cli as stcli
     except ImportError:
         print(
-            "Error: streamlit is not installed. Try installing the optionall dependency group 'app'.\n"
+            "Error: streamlit is not installed. Try installing the optional dependency group 'app'.\n"
             "If you are using uvx, try running uvx 'pdstools[app]' instead.",
         )
         sys.exit(1)

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1738,7 +1738,6 @@ class DecisionAnalyzer:
 
         return optionality_data
 
-    # @cached_property
     def get_optionality_funnel(self, df=None) -> pl.LazyFrame:
         """Optionality funnel: interaction counts bucketed by available-action count.
 

--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -547,15 +547,6 @@ def import_file(
 
     if extension == ".json":
         try:
-            # if isinstance(file, BytesIO):
-            #     from pyarrow import json
-
-            #     return pl.LazyFrame(
-            #         json.read_json(
-            #             file,
-            #         )
-            #     )
-            # else:
             df = pl.scan_ndjson(
                 file,
                 infer_schema_length=reading_opts.pop("infer_schema_length", 10000),

--- a/python/pdstools/utils/cdh_utils.py
+++ b/python/pdstools/utils/cdh_utils.py
@@ -12,8 +12,6 @@ from operator import is_not
 from os import PathLike
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
-    Any,
     TypeVar,
     overload,
 )
@@ -26,13 +24,6 @@ from .types import QUERY
 logger = logging.getLogger(__name__)
 
 F = TypeVar("F", pl.DataFrame, pl.LazyFrame)
-if TYPE_CHECKING:  # pragma: no cover
-    try:
-        import plotly.express as px  # noqa: F401
-
-        Figure = "px.Figure" | Any
-    except ImportError:
-        Figure = Any
 
 
 # Pattern for validating Polars duration strings (e.g., "1d", "2w", "1h30m")

--- a/python/pdstools/utils/metric_limits.py
+++ b/python/pdstools/utils/metric_limits.py
@@ -12,7 +12,6 @@ values in tables.
 
 import difflib
 import re
-from functools import lru_cache
 from typing import Any, Literal, Optional
 from collections.abc import Callable
 
@@ -49,16 +48,24 @@ class MetricLimits:
     def __new__(cls) -> "MetricLimits":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
+            cls._instance._limits_df = None  # type: ignore[attr-defined]
         return cls._instance
 
     @classmethod
-    @lru_cache(maxsize=1)
     def get_limits(cls) -> pl.DataFrame:
         """Get all metric limits as a DataFrame.
+
+        Cached on the singleton instance via ``__new__``; the first call
+        loads + builds the DataFrame, subsequent calls reuse the cached
+        attribute.
 
         The CSV contains numeric values directly. Boolean metrics are detected
         by checking if all defined limit values are either 0.0 or 1.0.
         """
+        instance = cls()
+        if getattr(instance, "_limits_df", None) is not None:
+            return instance._limits_df  # type: ignore[return-value]
+
         limits_df = pl.read_csv(source=get_metric_limits_path()).filter(
             pl.col("MetricID").is_not_null() & (pl.col("MetricID") != ""),
         )
@@ -76,9 +83,10 @@ class MetricLimits:
                 return False
             return all(v in (0.0, 1.0) for v in defined_values)
 
-        return limits_df.with_columns(
+        instance._limits_df = limits_df.with_columns(
             pl.struct(_LIMIT_COLUMNS).map_elements(is_boolean_metric, return_dtype=pl.Boolean).alias("is_boolean"),
         )
+        return instance._limits_df
 
     @classmethod
     def get_limit_for_metric(cls, metric_id: str) -> dict:


### PR DESCRIPTION
Five small audit items, each independent and safe:

- cli.py: fix typo "optionall" → "optional".
- utils/cdh_utils.py: remove dead `Figure = "px.Figure" | Any` alias (broken at module load — `str | type` raises TypeError; saved only by being inside `if TYPE_CHECKING`). Nothing imports it; the actually-used `Figure` lives in `utils/plot_utils.py`. Also drops now-unused `TYPE_CHECKING` and `Any` imports.
- utils/metric_limits.py: drop redundant `@lru_cache(maxsize=1)` on `get_limits`. The class is already a singleton via `__new__`; cache the DataFrame on the instance (`_limits_df`) instead of through a parallel `lru_cache` keyed on the class object.
- pega_io/File.py: delete the multi-line commented-out pyarrow JSON alternative inside `read_pega_json`. Stale and obscured the live code path.
- decision_analyzer/DecisionAnalyzer.py: remove the `# @cached_property` line above `get_optionality_funnel` — the method takes a `df=` argument, so it cannot be a property.