### PR TITLE
Replace per-row `map_elements` lookups with `replace_strict`

### DIFF
--- a/python/pdstools/adm/ADMTrees.py
+++ b/python/pdstools/adm/ADMTrees.py
@@ -84,7 +84,7 @@ class AGB:
             .group_by(by)
             .agg(pl.col("Modeldata").last())
             .collect()
-            .with_columns(pl.col("Modeldata").map_elements(lambda v: _get_type(v)))
+            .with_columns(pl.col("Modeldata").map_elements(lambda v: _get_type(v), return_dtype=pl.Utf8))
             .to_dicts()
         )
         return {key: value for key, value in [i.values() for i in types]}

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -11,7 +11,7 @@ import polars.selectors as cs
 
 from .data_read_utils import validate_columns
 from .plots import Plot
-from .stage_grouping import get_display_name
+from .stage_grouping import DISPLAY_NAME_LOOKUP
 from .column_schema import (
     DecisionAnalyzer as DecisionAnalyzer_TD,
     ExplainabilityExtract as ExplainabilityExtract_TD,
@@ -857,7 +857,10 @@ class DecisionAnalyzer:
         if stage_cols:
             df = df.with_columns(
                 [
-                    pl.col(c).cast(pl.Utf8).map_elements(get_display_name, return_dtype=pl.Utf8).cast(pl.Categorical)
+                    pl.col(c)
+                    .cast(pl.Utf8)
+                    .replace_strict(DISPLAY_NAME_LOOKUP, default=pl.col(c).cast(pl.Utf8), return_dtype=pl.Utf8)
+                    .cast(pl.Categorical)
                     for c in stage_cols
                 ]
             )
@@ -1133,7 +1136,7 @@ class DecisionAnalyzer:
         stage_order_no_output = {s: i for i, s in enumerate(stages)}
         decisions_by_stage = (
             without_actions.with_columns(pl.col(level).cast(pl.Utf8))
-            .sort(pl.col(level).map_elements(lambda s: stage_order_no_output.get(s, 999), return_dtype=pl.Int32))
+            .sort(pl.col(level).replace_strict(stage_order_no_output, default=999, return_dtype=pl.Int32))
             .with_columns(pl.col("decisions_without_actions").cum_sum().alias("_cumulative_without_actions"))
             .with_columns((pl.lit(total_interactions) - pl.col("_cumulative_without_actions")).alias("Decisions"))
             .select([level, "Decisions"])
@@ -1166,6 +1169,7 @@ class DecisionAnalyzer:
             summary = pl.concat([synthetic_row, summary], how="diagonal_relaxed")
 
         display_stage_order = [synthetic_label] + stages
+        display_stage_index = {name: idx for idx, name in enumerate(display_stage_order)}
         summary = (
             summary.with_columns(
                 (pl.col("Filtered Actions") / pl.col("Filtered Actions").sum() * 100)
@@ -1178,12 +1182,7 @@ class DecisionAnalyzer:
                 .round(1)
                 .alias("% Decisions without Actions"),
             )
-            .sort(
-                pl.col(level).map_elements(
-                    lambda s: display_stage_order.index(s) if s in display_stage_order else 999,
-                    return_dtype=pl.Int32,
-                )
-            )
+            .sort(pl.col(level).replace_strict(display_stage_index, default=999, return_dtype=pl.Int32))
             .select(
                 level,
                 "Available Actions",

--- a/python/pdstools/decision_analyzer/stage_grouping.py
+++ b/python/pdstools/decision_analyzer/stage_grouping.py
@@ -147,6 +147,14 @@ _STAGE_TO_GROUP: dict[str, str] = {
     stage: group_name for group_name, group in NBAD_PIPELINE.items() for stage in group["stages"]
 }
 
+# Combined display-name lookup: stage groups first (so a name colliding with
+# both is resolved as the group), then stages. Mirrors ``get_display_name``.
+# Suitable for ``pl.Expr.replace_strict(..., default=pl.col(...))``.
+DISPLAY_NAME_LOOKUP: dict[str, str] = {
+    **_STAGE_DISPLAY_NAMES,
+    **{group_name: group["display_name"] for group_name, group in NBAD_PIPELINE.items()},
+}
+
 
 def get_stage_group_display_name(internal_name: str) -> str:
     """Return the display name for a stage group, or ``internal_name`` if not found."""


### PR DESCRIPTION
Three call sites in DecisionAnalyzer used `map_elements(lambda s: dict.get(s, default))` to map stage / stage-order labels — a Python callback executed once per row. Polars' `replace_strict` does the same lookup natively in Rust with no per-row Python overhead.

Sites:
- DecisionAnalyzer:get_preprocessed_data — map internal stage / stage group names to display names. Added a flat `DISPLAY_NAME_LOOKUP` dict in `stage_grouping.py` (groups + stages combined; mirrors `get_display_name`).
- DecisionAnalyzer:get_offer_count_funnel — sort by `stage_order_no_output` rank.
- DecisionAnalyzer:get_offer_count_funnel — sort by `display_stage_order` position. Convert the list to an index dict once at function scope.

Also adds a missing `return_dtype=pl.Utf8` to the `map_elements` in `adm/ADMTrees.py:_get_modeltype` to silence the per-call PolarsInefficientMapWarning.