### PR TITLE
Knock out four small TODOs identified during the triage sweep

### DIFF
--- a/docs/plans/decision-analyzer-TODO.md
+++ b/docs/plans/decision-analyzer-TODO.md
@@ -39,7 +39,10 @@ removed or marked done as commits land on master.
 - [ ] **Treatment support** — Treatment column commented out in schema. When present, same action appears multiple times per interaction with different propensities. Key decisions needed: aggregation strategy, UX approach, which metrics need treatment-specific handling. Low prevalence (~0.6% of rows).
 - [ ] **Customer-level aggregates** — Per-customer statistics. Postponed until representative multi-customer dataset available.
 - [ ] **AB test: include IA properties** — `get_ab_test_results` doesn't join Impact Analyzer properties when present.
-- [ ] **AB test: maintain standard stage order** — `get_ab_test_results` currently sorts by Test count for visual prominence; should preserve the canonical stage order from `AvailableNBADStages` for consistency with other tables.
+- [x] **AB test: maintain standard stage order** — `get_ab_test_results` now
+  joins onto `AvailableNBADStages` and sorts by canonical stage order
+  (stages absent from the data are omitted). Verified by an exact-value
+  assertion in `test_get_ab_test_results_no_crash`.
 - [ ] **Stratified sampling** — Add optional `sample_stratified_by` parameter for proportional representation across channels/directions.
 - [ ] **Scale up counts after sampling** — Show estimated full-volume counts in UI (infrastructure in place via sample fraction metadata).
 - [ ] **Streaming pre-aggregation** — `preaggregated_filter_view` calls `.collect()` on full dataset. Investigate polars streaming mode for GB-scale data.

--- a/docs/plans/health-check-TODO.md
+++ b/docs/plans/health-check-TODO.md
@@ -12,7 +12,11 @@ Open work items for the ADM Health Check report and supporting ADM library code.
 
 - [ ] **[P2] Consistent legend coloring across partitioned plots** — Same predictor category gets different colors in different partitions (`_boxplot_pre_aggregated` uses local `fixed_colors` with index-shifting fallback). Reuse `pdstools/utils/color_mapping.py` (`create_categorical_color_mappings()`) — already proven in Decision Analyzer's `color_mappings` property. Compute global mapping at `ADMDatamart` level; pass `color_discrete_map` into box plot functions.
 
-- [ ] **[P3] Standardize long axis label abbreviation** — Ad-hoc `s[:25] + "..."` truncation in `BinAggregator.py`. Extract to shared `abbreviate_labels()` utility; apply to predictor names, action names, config names.
+- [x] **[P3] Standardize long axis label abbreviation** — `abbreviate_label` /
+  `abbreviate_label_expr` in `utils/plot_utils.py` are the canonical helpers.
+  HealthCheck.qmd now uses `abbreviate_label(..., from_end=True)` instead of
+  inline slicing. Remaining work (ensuring truncated labels stay unique within
+  a plot) is captured by the inline TODO at `BinAggregator.py` line ~822.
 
 ---
 
@@ -43,6 +47,11 @@ Open work items for the ADM Health Check report and supporting ADM library code.
 
 - [ ] **[P3] Move report-local plot helpers into `adm/Plots.py`** — `ModelReport.qmd` defines several plotly figures inline (cumulative gains/lift area charts, base-propensity hline overlay on predictor binning, the "Philip Mann" lift bar plot duplicated between BinAggregator.py and the qmd). Lift these into reusable functions on `ADMDatamart.plot` so they can be tested and shared.
 
-- [ ] **[P3] Replace silent ValueError swallow in `predictors_overview`** — `Aggregates.predictors_overview` wraps its body in `try/except ValueError: return None` (documented as "returns None on error" but hides the cause). Narrow the exception, log the reason, or re-raise so callers can distinguish "no data" from "broken data".
+- [x] **[P3] Replace silent ValueError swallow in `predictors_overview`** —
+  Narrowed: now only catches the specific `ValueError` from `last()` when no
+  predictor data is loaded, logs it at debug level, and returns `None`.
 
-- [ ] **[P3] Auto-detect `name` ending in `.html`** — `Reports.model_reports` and `Reports.health_check` accept `name` as the *base* file name and append the extension from `output_type`. When a caller passes `name="report.html"` they probably mean "use this exact filename" — handle that in `get_output_filename` rather than producing `report.html.html`.
+- [x] **[P3] Auto-detect `name` ending in `.html`** — `get_output_filename`
+  now returns `name` verbatim when it already ends with the configured
+  output extension (case-insensitive), so `name="report.html"` no longer
+  produces `report.html.html`.

--- a/python/pdstools/adm/Aggregates.py
+++ b/python/pdstools/adm/Aggregates.py
@@ -1,5 +1,6 @@
 __all__ = ["Aggregates"]
 import datetime
+import logging
 from typing import TYPE_CHECKING, Literal
 
 import polars as pl
@@ -14,6 +15,8 @@ from ..utils.types import QUERY
 
 if TYPE_CHECKING:  # pragma: no cover
     from .ADMDatamart import ADMDatamart
+
+logger = logging.getLogger(__name__)
 
 
 class Aggregates:
@@ -895,55 +898,90 @@ class Aggregates:
         """
         try:
             data = self.last(table="predictor_data")
-
-            if model_id is not None:
-                data = data.filter(pl.col("ModelID") == model_id)
-                group_cols = ["PredictorName", "PredictorCategory"]
-            else:
-                group_cols = ["ModelID", "PredictorName", "PredictorCategory"]
-
-            default_aggs = [
-                pl.last("ResponseCount").cast(pl.Int64).alias("Responses"),
-                pl.last("Positives").cast(pl.Int64),
-                pl.last("EntryType"),
-                (pl.last("EntryType") == "Active").alias("isActive"),
-                pl.last("GroupIndex").cast(pl.Int16),
-                pl.last("Type"),
-                pl.last("Performance").cast(pl.Float32).alias("Univariate Performance"),
-                pl.max("BinIndex").cast(pl.Int16).alias("Bins"),
-                (
-                    pl.col("BinResponseCount").filter(pl.col("BinType") == "MISSING").sum()
-                    * 100
-                    / pl.sum("BinResponseCount")
-                )
-                .cast(pl.Float64)
-                .alias("Missing %"),
-                (
-                    pl.col("BinResponseCount").filter(pl.col("BinType") == "RESIDUAL").sum()
-                    * 100
-                    / pl.sum("BinResponseCount")
-                )
-                .cast(pl.Float64)
-                .alias("Residual %"),
-            ]
-
-            if additional_aggregations is not None:
-                default_aggs.extend(additional_aggregations)
-
-            result = data.group_by(group_cols).agg(*default_aggs)
-            result = result.sort(
-                ["GroupIndex", "isActive", "Univariate Performance"],
-                descending=[False, True, True],
-                nulls_last=True,
-            )
-
-            return result
-        except ValueError:
-            # NOTE: documented behaviour ("Returns None if an error is
-            # encountered"). Tracked in docs/plans/health-check-TODO.md
-            # (P3: Replace silent ValueError swallow in predictors_overview)
-            # — narrow the except, log the reason, or re-raise.
+        except ValueError as e:
+            # `last()` raises ValueError when the underlying lazy frame is
+            # missing (no predictor data loaded). That's the only case we
+            # want to silently degrade — anything else should surface.
+            logger.debug("predictors_overview: no predictor data available (%s)", e)
             return None
+
+        if model_id is not None:
+            data = data.filter(pl.col("ModelID") == model_id)
+            group_cols = ["PredictorName", "PredictorCategory"]
+        else:
+            group_cols = ["ModelID", "PredictorName", "PredictorCategory"]
+
+        default_aggs = [
+            pl.last("ResponseCount").cast(pl.Int64).alias("Responses"),
+            pl.last("Positives").cast(pl.Int64),
+            pl.last("EntryType"),
+            (pl.last("EntryType") == "Active").alias("isActive"),
+            pl.last("GroupIndex").cast(pl.Int16),
+            pl.last("Type"),
+            pl.last("Performance").cast(pl.Float32).alias("Univariate Performance"),
+            pl.max("BinIndex").cast(pl.Int16).alias("Bins"),
+            (pl.col("BinResponseCount").filter(pl.col("BinType") == "MISSING").sum() * 100 / pl.sum("BinResponseCount"))
+            .cast(pl.Float64)
+            .alias("Missing %"),
+            (
+                pl.col("BinResponseCount").filter(pl.col("BinType") == "RESIDUAL").sum()
+                * 100
+                / pl.sum("BinResponseCount")
+            )
+            .cast(pl.Float64)
+            .alias("Residual %"),
+        ]
+
+        if additional_aggregations is not None:
+            default_aggs.extend(additional_aggregations)
+
+        result = data.group_by(group_cols).agg(*default_aggs)
+        result = result.sort(
+            ["GroupIndex", "isActive", "Univariate Performance"],
+            descending=[False, True, True],
+            nulls_last=True,
+        )
+
+        return result
+
+        if model_id is not None:
+            data = data.filter(pl.col("ModelID") == model_id)
+            group_cols = ["PredictorName", "PredictorCategory"]
+        else:
+            group_cols = ["ModelID", "PredictorName", "PredictorCategory"]
+
+        default_aggs = [
+            pl.last("ResponseCount").cast(pl.Int64).alias("Responses"),
+            pl.last("Positives").cast(pl.Int64),
+            pl.last("EntryType"),
+            (pl.last("EntryType") == "Active").alias("isActive"),
+            pl.last("GroupIndex").cast(pl.Int16),
+            pl.last("Type"),
+            pl.last("Performance").cast(pl.Float32).alias("Univariate Performance"),
+            pl.max("BinIndex").cast(pl.Int16).alias("Bins"),
+            (pl.col("BinResponseCount").filter(pl.col("BinType") == "MISSING").sum() * 100 / pl.sum("BinResponseCount"))
+            .cast(pl.Float64)
+            .alias("Missing %"),
+            (
+                pl.col("BinResponseCount").filter(pl.col("BinType") == "RESIDUAL").sum()
+                * 100
+                / pl.sum("BinResponseCount")
+            )
+            .cast(pl.Float64)
+            .alias("Residual %"),
+        ]
+
+        if additional_aggregations is not None:
+            default_aggs.extend(additional_aggregations)
+
+        result = data.group_by(group_cols).agg(*default_aggs)
+        result = result.sort(
+            ["GroupIndex", "isActive", "Univariate Performance"],
+            descending=[False, True, True],
+            nulls_last=True,
+        )
+
+        return result
 
     def overall_summary(
         self,

--- a/python/pdstools/adm/Reports.py
+++ b/python/pdstools/adm/Reports.py
@@ -120,7 +120,7 @@ class Reports(LazyNamespace):
         self,
         model_ids: str | list[str],
         *,
-        name: str | None = None,  # tracked in docs/plans/health-check-TODO.md (P3: Auto-detect name ending in .html)
+        name: str | None = None,
         only_active_predictors: bool = True,
         progress_callback: Callable[[int, int], None] | None = None,
         model_file_path: PathLike | None = None,
@@ -271,7 +271,7 @@ class Reports(LazyNamespace):
 
     def health_check(
         self,
-        name: str | None = None,  # tracked in docs/plans/health-check-TODO.md (P3: Auto-detect name ending in .html)
+        name: str | None = None,
         *,
         query: QUERY | None = None,
         prediction=None,

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1894,8 +1894,6 @@ class DecisionAnalyzer:
 
         return result.lazy()
 
-    # Tracked in docs/plans/decision-analyzer-TODO.md (P3: AB test:
-    # maintain standard stage order) — currently sorted on counts.
     def get_ab_test_results(self) -> pl.DataFrame:
         """A/B test summary: control vs test counts and control percentage per stage.
 
@@ -1903,7 +1901,9 @@ class DecisionAnalyzer:
         -------
         pl.DataFrame
             One row per stage with columns for Control, Test counts and
-            Control Percentage.
+            Control Percentage. Rows preserve the canonical
+            ``AvailableNBADStages`` order (stages absent from the data are
+            omitted).
         """
         tbl = (
             self.preaggregated_remaining_view.group_by(
@@ -1921,7 +1921,12 @@ class DecisionAnalyzer:
                 sort_columns=True,
             )
             .with_columns((pl.col("Control") / (pl.col("Test") + pl.col("Control"))).alias("Control Percentage"))
-            .sort("Test", descending=True)
+        )
+        stage_order = pl.DataFrame(
+            {self.level: self.AvailableNBADStages, "_stage_order": list(range(len(self.AvailableNBADStages)))}
+        )
+        tbl = (
+            tbl.join(stage_order, on=self.level, how="left").sort("_stage_order", nulls_last=True).drop("_stage_order")
         )
         return tbl
 

--- a/python/pdstools/reports/HealthCheck.qmd
+++ b/python/pdstools/reports/HealthCheck.qmd
@@ -38,6 +38,7 @@ from pdstools import (
     read_ds_export,
 )
 from pdstools.utils import pega_template, report_utils, cdh_utils
+from pdstools.utils.plot_utils import abbreviate_label
 from pdstools.adm.Plots import fig_update_facet
 
 # from plotly.offline import iplot
@@ -1566,14 +1567,11 @@ if datamart.predictor_data is not None:
         )
         if fig is not None:
             fig.update_layout(
-                # Tracked in docs/plans/health-check-TODO.md (P3:
-                # Standardize long axis label abbreviation) — replace this
-                # ad-hoc truncation with a shared helper.
                 xaxis={
                     "tickmode": "array",
                     "tickvals": fig.data[0]["x"],
                     "ticktext": [
-                        "..." + tick[-25:] if len(tick) > 25 else tick
+                        abbreviate_label(tick, from_end=True)
                         for tick in fig.data[0]["x"]
                     ],
                 },

--- a/python/pdstools/utils/plot_utils.py
+++ b/python/pdstools/utils/plot_utils.py
@@ -85,7 +85,12 @@ def get_colorscale(
 DEFAULT_LABEL_MAX_LENGTH = 25
 
 
-def abbreviate_label(label: str, max_length: int = DEFAULT_LABEL_MAX_LENGTH) -> str:
+def abbreviate_label(
+    label: str,
+    max_length: int = DEFAULT_LABEL_MAX_LENGTH,
+    *,
+    from_end: bool = False,
+) -> str:
     """Truncate a label to ``max_length`` chars, appending ``...`` when shortened.
 
     Used for axis tick labels (predictor names, bin symbols, action names) that
@@ -99,15 +104,23 @@ def abbreviate_label(label: str, max_length: int = DEFAULT_LABEL_MAX_LENGTH) -> 
         The original label.
     max_length : int, optional
         Maximum length before the ellipsis is appended, by default 25.
+    from_end : bool, optional
+        If True, keep the trailing ``max_length`` characters and prepend
+        ``...`` instead of truncating from the end. Useful for action /
+        treatment names whose distinguishing suffix is more informative
+        than the common prefix. Defaults to False.
 
     Returns
     -------
     str
-        The original ``label`` if it fits, otherwise ``label[:max_length] + "..."``.
+        The original ``label`` if it fits, otherwise the truncated label
+        with ``...`` on the truncated side.
     """
-    if len(label) > max_length:
-        return label[:max_length] + "..."
-    return label
+    if len(label) <= max_length:
+        return label
+    if from_end:
+        return "..." + label[-max_length:]
+    return label[:max_length] + "..."
 
 
 def abbreviate_label_expr(

--- a/python/pdstools/utils/report_utils.py
+++ b/python/pdstools/utils/report_utils.py
@@ -36,13 +36,22 @@ logger = logging.getLogger(__name__)
 
 
 def get_output_filename(
-    name: str | None,  # going to be the full file name
+    name: str | None,
     report_type: str,
     model_id: str | None = None,
     output_type: str = "html",
 ) -> str:
-    """Generate the output filename based on the report parameters."""
-    name = name.replace(" ", "_") if name else None
+    """Generate the output filename based on the report parameters.
+
+    If ``name`` already ends with ``.{output_type}`` (case-insensitive), it
+    is treated as a full filename and returned verbatim (after replacing
+    spaces with underscores). Otherwise the filename is composed from
+    ``report_type``, ``name``, and ``model_id`` with the extension appended.
+    """
+    if name:
+        name = name.replace(" ", "_")
+        if name.lower().endswith(f".{output_type.lower()}"):
+            return name
     if report_type == "ModelReport":
         return f"{report_type}_{name}_{model_id}.{output_type}" if name else f"{report_type}_{model_id}.{output_type}"
     return f"{report_type}_{name}.{output_type}" if name else f"{report_type}.{output_type}"

--- a/python/tests/test_DecisionAnalyzer.py
+++ b/python/tests/test_DecisionAnalyzer.py
@@ -1418,6 +1418,11 @@ class TestAnalysisMethods:
             result = da_v2.get_ab_test_results()
             assert isinstance(result, pl.DataFrame)
             assert result.height > 0
+            # Stages must follow the canonical AvailableNBADStages order
+            # (subset, since not every stage has AB rows).
+            stages_in_result = result.get_column(da_v2.level).to_list()
+            canonical = [s for s in da_v2.AvailableNBADStages if s in stages_in_result]
+            assert stages_in_result == canonical
 
     def test_get_thresholding_data_propensity(self, da_v1):
         result = da_v1.get_thresholding_data(fld="Propensity")

--- a/python/tests/test_report_utils.py
+++ b/python/tests/test_report_utils.py
@@ -79,6 +79,17 @@ def test_get_output_filename():
         report_utils.get_output_filename("test report", "HealthCheck", None, "html") == "HealthCheck_test_report.html"
     )
 
+    # When `name` already ends with `.<output_type>`, return it verbatim
+    # (after underscore-substitution) instead of double-suffixing.
+    assert report_utils.get_output_filename("my_report.html", "HealthCheck", None, "html") == "my_report.html"
+    assert report_utils.get_output_filename("My Report.HTML", "HealthCheck", None, "html") == "My_Report.HTML"
+    assert report_utils.get_output_filename("my_report.html", "ModelReport", "model1", "html") == "my_report.html"
+    # Mismatched extension still gets the canonical extension appended.
+    assert (
+        report_utils.get_output_filename("my_report.html", "HealthCheck", None, "pdf")
+        == "HealthCheck_my_report.html.pdf"
+    )
+
 
 def test_set_command_options():
     """Test the _set_command_options function."""


### PR DESCRIPTION
These are well-scoped items lifted from docs/plans/health-check-TODO.md and decision-analyzer-TODO.md that were small enough to ship as a single follow-up to p3-todos-triage.

1. **Auto-detect `name` ending in the output extension** — when a caller passes `name="report.html"` to `Reports.health_check` / `Reports.model_reports`, treat it as the full filename instead of producing `report.html.html`. Implemented in `get_output_filename` so it covers both report types and respects the configured `output_type`. Mismatched extensions still get the canonical suffix appended.

2. **Narrow the silent ValueError swallow in `predictors_overview`** — only catch the `ValueError` raised by `last()` when no predictor data is loaded, log it at debug level, and return `None`. All other exceptions now propagate.

3. **`get_ab_test_results` preserves the canonical stage order** — stages now follow `AvailableNBADStages` (Arbitration → Output) instead of being sorted by Test count. Stages absent from the data are omitted; ordering is verified by an exact-value assertion in `test_get_ab_test_results_no_crash`.

4. **Wire up `abbreviate_label` at the HealthCheck.qmd call site** — replaced the inline `"..." + tick[-25:]` slice with a new `from_end=True` option on `abbreviate_label`, which keeps the distinguishing suffix of long action names (the use case here) while consolidating on the existing helper.