### PR TITLE
Decision Analyzer typing cleanup + test-quality sweep + AGENTS.md conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,3 +510,49 @@ silently-dropped follow-up.
 - When the IDE shows type errors after an edit, distinguish
   **pre-existing** from **newly introduced**. Only fix the new ones
   silently; ask before touching pre-existing issues.
+
+## Parallel sub-agent workflow (git worktrees)
+
+When dispatching multiple background sub-agents that each work on a
+**different branch in parallel**, they MUST be isolated via
+`git worktree` — otherwise they share the user's working directory,
+which is a recipe for:
+
+- One agent's `git checkout <branch>` switching the user's HEAD without
+  warning.
+- Agent A's WIP edits showing up in agent B's `git status` and getting
+  swept into the wrong commit.
+- The user's foreground edits getting tangled with agent edits and
+  ending up on the wrong branch.
+
+### Setup
+
+Create one worktree per parallel branch under a sibling directory:
+
+```bash
+mkdir -p ../pdstools-worktrees
+git worktree add ../pdstools-worktrees/<branch-name> <branch-name>
+```
+
+Each sub-agent is told to `cd ../pdstools-worktrees/<branch-name>` first
+and do **all** work there (edits, tests, commits, push). The agent prompt
+should explicitly forbid touching the main checkout.
+
+After `git worktree add`, run `uv sync --extra tests` once in the new
+worktree — the `.venv` is per-worktree, not shared.
+
+### Cleanup
+
+When a branch is merged or abandoned, prune its worktree:
+
+```bash
+git worktree remove ../pdstools-worktrees/<branch-name>
+```
+
+### When to skip worktrees
+
+- A single background sub-agent + the user staying in read-only mode in
+  the main checkout is usually fine.
+- Sequential sub-agent runs (one finishes before the next starts) don't
+  need worktrees.
+- The moment a second concurrent writer is involved, set up worktrees.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,6 +386,44 @@ documentation of its defaults. A frozen-dataclass of defaults is
 an engine/enterprise pattern, not a fit for a lightweight analysis
 package.
 
+### Namespace facade for large analyzer classes
+For any class that grows beyond ~20 public methods, split related
+methods into sub-namespace classes attached as instance attributes.
+`ADMDatamart` is the reference: `dm.plot`, `dm.aggregates`, `dm.agb`,
+`dm.generate`, `dm.bin_aggregator`. Each sub-namespace:
+
+- Lives in its own module (`adm/Plots.py`, `adm/Aggregates.py`, …).
+- Takes a single parent argument named **`datamart`** (or the
+  equivalent name used by the parent class) and stores it as
+  `self.datamart`.
+- Uses `if TYPE_CHECKING: from .Parent import Parent` to avoid
+  circular imports for the back-reference.
+- Is instantiated in the parent's `__init__` and assigned to a
+  short, dot-completion-friendly attribute (`self.plot = Plots(self)`).
+
+This keeps the public API discoverable (one class to import; dot
+completion reveals everything) without ballooning the parent into a
+multi-thousand-line god class. Use the same pattern when refactoring
+existing fat classes — don't invent a new convention.
+
+### I/O lives in classmethods, not `__init__`
+Keep `__init__` pure: it should only accept already-loaded data
+structures (typically `pl.LazyFrame`s) and configuration. All file,
+network, and S3 I/O lives in alternative constructors named
+`from_<source>` (e.g. `from_ds_export`, `from_s3`,
+`from_dataflow_export`, `from_pdc`). This mirrors the
+`pl.read_csv` / `pl.scan_csv` idiom and makes the class trivially
+testable with synthesized data — no monkey-patching required.
+
+### `return_df` parameter on plot methods
+Every public method that produces a chart should accept
+`return_df: bool = False` as a keyword-only argument. When `True`,
+return the underlying (Lazy)Frame that drives the chart instead of
+the figure. This pattern (used consistently across `ADMDatamart.plot`)
+makes plots scriptable, testable, and composable without forcing
+users to re-derive the aggregation. Pair with `@overload` so type
+checkers know which return shape applies.
+
 ## Feature backlog / TODO files
 
 Major features maintain a living TODO file in `docs/plans/` (e.g.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,14 @@ dependencies and execution.
 - **Git workflow.** Do not `git commit` on the user's working branch.
   Stage with `git add` and let the user commit. Exception: branches you
   created yourself, or when the user explicitly asks for a commit/PR.
+- **Stay focused, but fix tightly-coupled bugs.** Don't fix
+  pre-existing issues unrelated to the task at hand. However, if a
+  refactor surfaces a bug that is directly caused by or tightly
+  coupled to the code you're changing (e.g. a wrong return-type
+  annotation that callers were defensively working around, a stale
+  `# type: ignore` that hid a real mismatch), fix it in the same PR
+  and call it out in the commit message. Splitting it off creates a
+  regression window where the fix lacks the surrounding context.
 - **Product naming.** User-facing text: "Decision Analysis Tool",
   "ADM Health Check". Code/CLI: `decision_analyzer`, `adm_healthcheck`.
 - **`verbose` parameters.** Reserve `verbose` for genuine user-facing
@@ -146,6 +154,31 @@ python -m build --sdist --wheel --outdir dist/ .
   `Optional[X]`). Do not import `Optional`, `Union`, `List`, `Dict`
   from `typing`.
 
+#### `# type: ignore` is a smell, not a tool
+Treat `# type: ignore` as a last resort, and treat existing ones as
+suspicious during any refactor — they often hide real bugs.
+
+- **Drop redundant explicit annotations first.** Most
+  `# type: ignore[assignment]` on lines like
+  `df: pl.DataFrame = lf.collect()` are caused by the redundant
+  annotation itself (polars overloads return the right type already).
+  Remove the annotation; the ignore disappears with it.
+- **Use `cast` over `# type: ignore[arg-type]` for genuine narrowing.**
+  `cast(list[str], scope_config["group_cols"])` documents intent;
+  `# type: ignore[arg-type]` hides it.
+- **Class-level annotations for lazily-set attributes.** When an
+  attribute is assigned from a method (not `__init__`), declare it at
+  class level (`_num_sample_interactions: int`) instead of writing
+  `# type: ignore[attr-defined]` at every access site.
+- **`# type: ignore[return-value]` almost always means the signature
+  lies.** If you have to suppress a return mismatch, the real fix is
+  to update the function's annotated return type to match what it
+  actually returns. Callers downstream are probably defensively
+  working around the wrong type.
+- Reserve `# type: ignore` for genuinely external problems
+  (third-party stubs missing, library bugs) and add a comment
+  explaining why.
+
 ### Naming conventions
 - Functions/variables: `snake_case`.
 - Classes: `PascalCase`.
@@ -196,6 +229,11 @@ python -m build --sdist --wheel --outdir dist/ .
   where every expected value can be traced back to the input data.
   Structural/smoke tests on larger datasets are fine as a complement,
   but the correctness backbone should be exact-value tests.
+- **Drop `# pragma: no cover` when you add tests.** Pragmas are for
+  code that genuinely can't be exercised (platform-specific branches,
+  defensive `raise` after exhaustive `if/elif`). Once a method has a
+  test, the pragma is stale and misleading — remove it in the same PR
+  that adds the test.
 
 ### Notebooks and reports
 - Notebooks for docs should be empty/not pre-run.
@@ -386,6 +424,41 @@ Use the right venue for the right kind of note:
 - **Don't park lists of TODOs at the top of a file/page.** Lift them
   into the relevant plan file and replace the block with a single
   pointer comment.
+
+## Surfacing follow-up work
+
+When a conversation or refactor uncovers something that won't be
+addressed in the current PR, *don't let it evaporate*. Pick the right
+venue and either file it or hand the user a draft they can file:
+
+- **GitHub issue** for anything other contributors should see and pick
+  up: bugs, missing features, design questions, promotion candidates
+  from prototype → product. Agents typically can't `gh issue create`
+  on this repo (EMU restrictions) — write a ready-to-paste draft
+  (title + body in markdown) and hand it to the user. Keep one issue
+  per concern, not omnibus dumps.
+- **Plan-file entry** (`docs/plans/<feature>-TODO.md`) for backlog
+  items scoped to a specific feature area that aren't substantial
+  enough to be their own issue, or that need design work before they
+  can be filed.
+- **Inline `# TODO`** for code-local hints (see "Inline `# TODO` vs
+  plan-file entries" below).
+
+Triggers to raise follow-ups proactively:
+- A "we should also…" or "while we're here…" thought that's out of
+  scope for the current PR.
+- A bug discovered that *isn't* tightly coupled to the current change
+  (the coupled ones get fixed in-PR — see "Stay focused" in critical
+  rules).
+- A `# type: ignore`, defensive `isinstance` branch, or `# pragma: no
+  cover` you can't justify removing in the current PR.
+- Repeated workarounds across multiple files that point to a missing
+  abstraction.
+- Prototype code that has matured enough to belong in `pdstools` proper.
+
+Default to nudging the user: *"This is out of scope for the current
+PR — want me to draft an issue?"* — better one too many drafts than a
+silently-dropped follow-up.
 
 ## Contrib and workflow notes
 - Main tests are `python/tests`; CI runs multi-OS and multi-Python.

--- a/docs/plans/adm-TODO.md
+++ b/docs/plans/adm-TODO.md
@@ -1,0 +1,83 @@
+# ADM module — TODO and improvements
+
+Living backlog for the `python/pdstools/adm/` module. This module is the
+reference implementation for the namespace-facade pattern (see
+AGENTS.md "Namespace facade for large analyzer classes"). Items here
+either bring the module further into compliance with its own
+conventions or DRY-up duplicated patterns.
+
+Priority levels: P1 = high, P2 = medium, P3 = nice-to-have.
+
+## Open items
+
+### Conventions / consistency
+
+- [ ] **P2 — Lazy plotly imports in `Plots.py`.** Plotly is currently
+  imported at module level inside a `try/except ImportError`
+  (`adm/Plots.py:35-40`). This violates the AGENTS.md "lazy imports
+  inside the method" rule for optional deps, and it means importing
+  `ADMDatamart` pulls plotly even when no plot is rendered. Move the
+  imports inside each plot method, or have `Plots` properly leverage
+  the existing `LazyNamespace` base class for deferred resolution.
+- [ ] **P3 — Rename `BinAggregator(dm=...)` → `BinAggregator(datamart=...)`.**
+  Every other sub-namespace in `ADMDatamart` takes a `datamart=`
+  argument; `BinAggregator` is the lone outlier (`ADMDatamart.py:149`).
+  Trivial rename, removes a needless inconsistency.
+- [ ] **P3 — Add `from __future__ import annotations` to all `adm/`
+  modules.** Currently only `ADMDatamart.py` has it. Adding it to
+  `Aggregates.py`, `Plots.py`, `BinAggregator.py`, `Reports.py`,
+  `ADMTrees.py` lets us drop string-quoted forward refs and is a
+  one-liner per file.
+- [ ] **P3 — Add Examples sections to `Plots` method docstrings.** The
+  `ADMDatamart` classmethods are exemplary (numpydoc with runnable
+  Examples); most `Plots` methods skip the Examples block. Filling
+  these in is high-value for users browsing API docs.
+
+### DRY-ups
+
+- [ ] **P2 — Extract `_require_model_data()` / `_require_predictor_data()`
+  helpers.** Multiple sites in `Plots.py` and `Aggregates.py` carry
+  `# type: ignore[union-attr]` because `model_data` is typed
+  `pl.LazyFrame | None`. A small helper that returns the LazyFrame
+  or raises a clear `ValueError("Model data not available — …")`
+  eliminates the type:ignores and replaces silent `None`-propagation
+  with an actionable error.
+- [ ] **P3 — Factor out Performance auto-rescale.** The
+  `50–100 → 0.5–1.0` rescale block is duplicated verbatim in
+  `_validate_model_data` and `_validate_predictor_data`
+  (`ADMDatamart.py:474-479` and `:512-518`). Pull into a single
+  `_normalize_performance_scale(df)` helper.
+- [ ] **P3 — DRY-up the `unique_*` cached properties.** The five
+  `cached_property` lookups (`unique_channels`,
+  `unique_configurations`, `unique_channel_direction`,
+  `unique_configuration_channel_direction`,
+  `unique_predictor_categories`) are all the same shape:
+  `.select(pl.col(X).unique().sort()).collect()[X].to_list()`. A
+  generic `_unique_sorted(col_or_expr)` helper compresses all five
+  into one-liners while keeping the cached_properties as the public
+  surface.
+
+### Pre-existing typing debt (out of scope until DA sweep is merged)
+
+- [ ] **P2 — `ADMDatamart.py:737, 759` mypy errors.** "Item 'None' of
+  'LazyFrame | None' has no attribute 'select'". Resolved
+  automatically once `_require_model_data()` helper above is in
+  place.
+- [ ] **P2 — `Plots.py` pre-existing mypy errors** at lines 751, 1144,
+  1573, 1596, 1604 (arg-type / assignment). Triage as part of the
+  planned `typing-adm-plots` PR.
+
+## Done
+
+(none yet — file initialized 2026-04-21)
+
+---
+
+## Cross-references
+
+- AGENTS.md → "Namespace facade for large analyzer classes"
+- AGENTS.md → "I/O lives in classmethods, not `__init__`"
+- AGENTS.md → "`return_df` parameter on plot methods"
+- `docs/plans/decision-analyzer-TODO.md` — DA module backlog (DA is
+  in the process of adopting these same conventions; see the
+  decoupling-from-Streamlit issue and the typing sweep PR series)

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -67,6 +67,10 @@ class DecisionAnalyzer:
     >>> da.plot.sensitivity()
     """
 
+    # Lazily-set attribute populated when ``sample`` is first accessed.
+    # Declared here so type-checkers see it on the class.
+    _num_sample_interactions: int
+
     @classmethod
     def from_explainability_extract(
         cls,
@@ -599,7 +603,7 @@ class DecisionAnalyzer:
         if not hasattr(self, "_num_sample_interactions"):
             # Trigger sample calculation to set _num_sample_interactions
             _ = self.sample
-        return self._num_sample_interactions  # type: ignore[attr-defined]
+        return self._num_sample_interactions
 
     def _invalidate_cached_properties(self):
         """Resets the properties of the class. Needed for global filters."""
@@ -695,7 +699,7 @@ class DecisionAnalyzer:
                 ]
                 + [pl.sum(f"Win_at_rank{i}") for i in range(1, self.max_win_rank + 1)],
             )
-            .collect()  # type: ignore[union-attribute]  # materialize to cache
+            .collect()  # materialize to cache
             .lazy()  # re-wrap so downstream consumers stay lazy
         )
         return self.preaggregated_decision_data_remainingview
@@ -2636,7 +2640,7 @@ class DecisionAnalyzer:
                 additional_filters=pl.col(self.level).is_in(self.stages_from_arbitration_down),
             ).select(["Issue", "Group", "Action"] + ["Interaction ID", "Rank"])
 
-            result: pl.DataFrame = (  # type: ignore[assignment]
+            result = (
                 original_winners.group_by(["Issue", "Group", "Action"])
                 .agg(
                     original_win_count=pl.col("Rank").filter(pl.col("Rank") == 1).len(),
@@ -2651,7 +2655,7 @@ class DecisionAnalyzer:
 
             # Add no winner count if all_interactions is provided
             if all_interactions is not None:
-                winner_df: pl.DataFrame = original_winners.select("Interaction ID").collect()  # type: ignore[assignment]
+                winner_df = original_winners.select("Interaction ID").collect()
                 interactions_with_winners = winner_df.n_unique()
                 no_winner_count = max(0, all_interactions - interactions_with_winners)  # Ensure non-negative
 
@@ -2691,14 +2695,12 @@ class DecisionAnalyzer:
                     selected_action=pl.when(lever_condition).then(pl.lit("Selected")).otherwise(pl.lit("Rest"))
                 )
             )
-            result: pl.DataFrame = result_lf.collect().sort("new_win_count", descending=True)  # type: ignore[assignment]
+            result = result_lf.collect().sort("new_win_count", descending=True)
 
             # Add no winner count if all_interactions is provided
             if all_interactions is not None:
                 # Calculate no winner count based on new ranking
-                new_winner_df: pl.DataFrame = (  # type: ignore[assignment]
-                    recalculated_winners.filter(pl.col("rank_PVCL") == 1).select("Interaction ID").collect()
-                )
+                new_winner_df = recalculated_winners.filter(pl.col("rank_PVCL") == 1).select("Interaction ID").collect()
                 interactions_with_new_winners = new_winner_df.n_unique()
                 no_winner_count = max(0, all_interactions - interactions_with_new_winners)  # Ensure non-negative
 
@@ -2805,11 +2807,9 @@ class DecisionAnalyzer:
                 additional_filters=pl.col(self.level).is_in(self.stages_from_arbitration_down),
             ).filter(pl.col("rank_PVCL") <= win_rank)
 
-            selected_wins_df: pl.DataFrame = (  # type: ignore[assignment]
-                ranked_df.filter(lever_condition).select("Interaction ID").collect()
-            )
+            selected_wins_df = ranked_df.filter(lever_condition).select("Interaction ID").collect()
             selected_wins = selected_wins_df.height
-            selected_total_df: pl.DataFrame = ranked_df.select("Interaction ID").collect()  # type: ignore[assignment]  # noqa: E501
+            selected_total_df = ranked_df.select("Interaction ID").collect()
             selected_total = selected_total_df.height
             percentage = (selected_wins / selected_total) * 100
             return percentage

--- a/python/pdstools/decision_analyzer/data_read_utils.py
+++ b/python/pdstools/decision_analyzer/data_read_utils.py
@@ -15,7 +15,7 @@ from .utils import ColumnResolver
 # Core read_data is now in pega_io.File
 
 
-def read_nested_zip_files(file_buffer) -> pl.DataFrame:
+def read_nested_zip_files(file_buffer) -> pl.LazyFrame:
     """Read Pega Action Analysis export format (nested archive with gzipped NDJSON).
 
     Pega's Action Analysis feature exports decision data as a ZIP archive containing
@@ -23,7 +23,7 @@ def read_nested_zip_files(file_buffer) -> pl.DataFrame:
     are **gzipped NDJSON** (not ZIP archives). This function handles this format by:
     1. Opening the outer ZIP archive
     2. Treating each inner `.zip` file as gzipped NDJSON
-    3. Decompressing and concatenating all data into a single DataFrame
+    3. Decompressing and concatenating all data into a single LazyFrame
 
     This format is used for high-volume decision event exports where data is partitioned
     across multiple compressed files.
@@ -36,8 +36,9 @@ def read_nested_zip_files(file_buffer) -> pl.DataFrame:
 
     Returns
     -------
-    pl.DataFrame
-        Concatenated DataFrame from all inner files, with consistent column ordering.
+    pl.LazyFrame
+        Concatenated LazyFrame from all inner files, with consistent column ordering.
+        Call ``.collect()`` to materialize.
 
     Notes
     -----
@@ -45,7 +46,7 @@ def read_nested_zip_files(file_buffer) -> pl.DataFrame:
     hive-partitioned parquet directories instead, which can be read with read_data().
 
     """
-    dfs: list[pl.DataFrame] = []
+    dfs: list[pl.LazyFrame] = []
     columns: list[str] = []
 
     with zipfile.ZipFile(file_buffer, "r") as zip_ref:
@@ -62,7 +63,7 @@ def read_nested_zip_files(file_buffer) -> pl.DataFrame:
     return pl.concat(dfs, rechunk=True)
 
 
-def read_gzipped_data(data: BytesIO) -> pl.DataFrame | None:
+def read_gzipped_data(data: BytesIO) -> pl.LazyFrame | None:
     """Read a single gzipped NDJSON chunk from Pega Action Analysis export.
 
     Helper function for read_nested_zip_files(). Reads one inner file from the
@@ -76,8 +77,8 @@ def read_gzipped_data(data: BytesIO) -> pl.DataFrame | None:
 
     Returns
     -------
-    pl.DataFrame | None
-        Polars DataFrame, or None if decompression/parsing fails.
+    pl.LazyFrame | None
+        Polars LazyFrame, or None if decompression/parsing fails.
 
     Notes
     -----
@@ -87,18 +88,18 @@ def read_gzipped_data(data: BytesIO) -> pl.DataFrame | None:
     try:
         with gzip.open(data, "rb") as file:
             file_content = file.read()
-            return pl.read_ndjson(BytesIO(file_content)).lazy()  # type: ignore[return-value]
+            return pl.read_ndjson(BytesIO(file_content)).lazy()
     except Exception as e:
         print(f"Error reading gzipped data: {e}")
         return None
 
 
-def read_gzipped_ndjson_directory(path: str) -> pl.DataFrame:
+def read_gzipped_ndjson_directory(path: str) -> pl.LazyFrame:
     """Read directory of Pega Action Analysis gzipped NDJSON files.
 
     For extracted Action Analysis exports, this function recursively finds all files with
     `.zip` extension (which are actually gzipped NDJSON, not ZIP archives) and concatenates
-    them into a single DataFrame. Useful when the outer archive has been extracted to disk.
+    them into a single LazyFrame. Useful when the outer archive has been extracted to disk.
 
     Parameters
     ----------
@@ -108,8 +109,9 @@ def read_gzipped_ndjson_directory(path: str) -> pl.DataFrame:
 
     Returns
     -------
-    pl.DataFrame
-        Concatenated DataFrame from all files with consistent column ordering.
+    pl.LazyFrame
+        Concatenated LazyFrame from all files with consistent column ordering.
+        Call ``.collect()`` to materialize.
 
     Notes
     -----
@@ -117,7 +119,7 @@ def read_gzipped_ndjson_directory(path: str) -> pl.DataFrame:
     (including hive-partitioned directories), use read_data() from pega_io instead.
 
     """
-    dfs: list[pl.DataFrame] = []
+    dfs: list[pl.LazyFrame] = []
     columns: list[str] = []
 
     for file_path in sorted(Path(path).rglob("*.zip")):
@@ -127,8 +129,8 @@ def read_gzipped_ndjson_directory(path: str) -> pl.DataFrame:
             file_content = file.read()
             df = pl.read_ndjson(BytesIO(file_content)).lazy()
             if columns == []:
-                columns = df.columns
-            dfs.append(df.select(columns))  # type: ignore[arg-type]
+                columns = df.collect_schema().names()
+            dfs.append(df.select(columns))
 
     return pl.concat(dfs, rechunk=True)
 

--- a/python/pdstools/decision_analyzer/plots.py
+++ b/python/pdstools/decision_analyzer/plots.py
@@ -5,6 +5,8 @@ from plotly.subplots import make_subplots
 
 import polars as pl
 
+from typing import cast
+
 from .utils import PRIO_FACTORS, apply_filter
 from ..utils.pega_template import colorway
 from ..utils.plot_utils import simplify_facet_titles
@@ -1098,15 +1100,10 @@ def offer_quality_piecharts(
         "only_irrelevant_actions",
         "has_no_offers",
     ]
-    all_frames = (
-        df.group_by(level)
-        .agg(pl.sum(*value_finder_names))
-        .collect()  # type: ignore[union-attribute]
-        .partition_by(level, as_dict=True)
-    )
+    all_frames = df.group_by(level).agg(pl.sum(*value_finder_names)).collect().partition_by(level, as_dict=True)
 
     # Filter to only include stages that exist in the data
-    df_dict = {}  # type: ignore[assignment]
+    df_dict: dict[tuple, pl.DataFrame] = {}
     stages_to_plot = []
     for stage in AvailableNBADStages:
         if (stage,) in all_frames:
@@ -1272,9 +1269,7 @@ def getTrendChart(df: pl.LazyFrame, stage: str = "Output", return_df=False, leve
         "only_irrelevant_actions",
         "has_no_offers",
     ]
-    trend_df = (
-        df.filter(pl.col(level) == stage).group_by("day").agg(pl.sum(*value_finder_names)).collect().sort("day")  # type: ignore[union-attribute]
-    )
+    trend_df = df.filter(pl.col(level) == stage).group_by("day").agg(pl.sum(*value_finder_names)).collect().sort("day")
     if return_df:
         return trend_df.lazy()
     status_labels = {
@@ -1411,7 +1406,7 @@ def plot_component_overview(value_data: pl.LazyFrame, components: list[str], gra
         fig.add_annotation(text="No component columns available", showarrow=False)
         return fig
 
-    collected: pl.DataFrame = value_data.select([granularity] + components).collect()  # type: ignore[assignment]
+    collected = value_data.select([granularity] + components).collect()
     groups = collected.get_column(granularity).unique().sort().to_list()
 
     n_cols = min(3, len(components))
@@ -1540,7 +1535,7 @@ def create_win_distribution_plot(
             # If we have "No Winner" data, we need to select only the columns that match aggregated_regular
             if no_winner_data.height > 0:
                 # Select only the columns that exist in aggregated_regular
-                group_cols = list(scope_config["group_cols"])  # type: ignore[arg-type]
+                group_cols = list(cast(list[str], scope_config["group_cols"]))
                 columns_to_keep = group_cols + [win_count_col]
                 no_winner_data_selected = no_winner_data.select(columns_to_keep)
                 plot_data = pl.concat([aggregated_regular, no_winner_data_selected])
@@ -1549,7 +1544,7 @@ def create_win_distribution_plot(
         else:
             # If no regular data, just use no_winner_data (select appropriate columns)
             if no_winner_data.height > 0:
-                group_cols = list(scope_config["group_cols"])  # type: ignore[arg-type]
+                group_cols = list(cast(list[str], scope_config["group_cols"]))
                 columns_to_keep = group_cols + [win_count_col]
                 plot_data = no_winner_data.select(columns_to_keep)
             else:

--- a/python/pdstools/decision_analyzer/utils.py
+++ b/python/pdstools/decision_analyzer/utils.py
@@ -395,7 +395,7 @@ def create_hierarchical_selectors(
     """
 
     # Step 1: Get all available issues
-    issues_df: pl.DataFrame = data.select("Issue").unique().collect()  # type: ignore[assignment]
+    issues_df = data.select("Issue").unique().collect()
     available_issues = issues_df.get_column("Issue").to_list()
     issue_index = 0
     if selected_issue and selected_issue in available_issues:
@@ -406,9 +406,7 @@ def create_hierarchical_selectors(
 
     # Step 2: Get groups for current issue
     filtered_by_issue = data.filter(pl.col("Issue") == current_issue)
-    groups_df: pl.DataFrame = (
-        filtered_by_issue.select("Group").unique().collect()  # type: ignore[assignment]
-    )
+    groups_df = filtered_by_issue.select("Group").unique().collect()
     available_groups = groups_df.get_column("Group").to_list()
     group_options = ["All"] + available_groups
     group_index = 0  # Default to "All"
@@ -424,9 +422,7 @@ def create_hierarchical_selectors(
     else:
         filtered_by_issue_group = filtered_by_issue.filter(pl.col("Group") == current_group)
 
-    actions_df: pl.DataFrame = (
-        filtered_by_issue_group.select("Action").unique().collect()  # type: ignore[assignment]
-    )
+    actions_df = filtered_by_issue_group.select("Action").unique().collect()
     available_actions = actions_df.get_column("Action").to_list()
     action_options = ["All"] + available_actions
     action_index = 0  # Default to "All"

--- a/python/tests/test_DecisionAnalyzer.py
+++ b/python/tests/test_DecisionAnalyzer.py
@@ -66,7 +66,7 @@ class TestClassMethodConstructors:
             sample_size=1000,
         )
         assert da.extract_type == "explainability_extract"
-        assert da.decision_data.collect().height > 0
+        assert da.decision_data.collect().height == 7297
 
     def test_from_decision_analyzer(self):
         da = DecisionAnalyzer.from_decision_analyzer(
@@ -74,7 +74,7 @@ class TestClassMethodConstructors:
             sample_size=1000,
         )
         assert da.extract_type == "decision_analyzer"
-        assert da.decision_data.collect().height > 0
+        assert da.decision_data.collect().height == 1342623
 
     def test_from_explainability_extract_invalid_path(self):
         with pytest.raises(Exception):
@@ -119,11 +119,11 @@ class TestConstruction:
 
     def test_v1_has_decision_data(self, da_v1):
         assert isinstance(da_v1.decision_data, pl.LazyFrame)
-        assert da_v1.decision_data.collect().height > 0
+        assert da_v1.decision_data.collect().height == 7297
 
     def test_v2_has_decision_data(self, da_v2):
         assert isinstance(da_v2.decision_data, pl.LazyFrame)
-        assert da_v2.decision_data.collect().height > 0
+        assert da_v2.decision_data.collect().height == 1342623
 
     def test_construction_with_additional_columns(self):
         raw = pl.scan_parquet(f"{basePath}/data/sample_explainability_extract.parquet")
@@ -186,7 +186,7 @@ class TestDataCleanup:
     def test_v2_has_real_stages(self, da_v2):
         """v2 should have real stage groups from the data."""
         stages = da_v2.AvailableNBADStages
-        assert len(stages) > 2
+        assert len(stages) == 5
         assert "Arbitration" in stages
 
     def test_v1_rank_1_is_output(self, da_v1):
@@ -237,12 +237,12 @@ class TestStages:
     def test_stages_from_arbitration_down(self, da_v1):
         stages = da_v1.stages_from_arbitration_down
         assert stages[0] == "Arbitration"
-        assert len(stages) >= 1
+        assert len(stages) == 2
 
     def test_v2_stages_are_ordered(self, da_v2):
         """Stages should be in StageOrder sequence."""
         stages = da_v2.AvailableNBADStages
-        assert len(stages) >= 2
+        assert len(stages) == 5
 
 
 # ---------------------------------------------------------------------------
@@ -255,15 +255,17 @@ class TestSampling:
 
     def test_v1_sample_returns_lazyframe(self, da_v1):
         assert isinstance(da_v1.sample, pl.LazyFrame)
+        assert da_v1.sample.collect().height == 7297
 
     def test_v2_sample_returns_lazyframe(self, da_v2):
         assert isinstance(da_v2.sample, pl.LazyFrame)
+        assert da_v2.sample.collect().height == 956675
 
     def test_v1_sample_not_empty(self, da_v1):
-        assert da_v1.sample.collect().height > 0
+        assert da_v1.sample.collect().height == 7297
 
     def test_v2_sample_not_empty(self, da_v2):
-        assert da_v2.sample.collect().height > 0
+        assert da_v2.sample.collect().height == 956675
 
     def test_sample_respects_size_limit(self):
         """With a very small sample_size, the number of interactions should be limited."""
@@ -296,11 +298,11 @@ class TestPreaggregation:
 
     def test_v1_filter_view_not_empty(self, da_v1):
         df = da_v1.preaggregated_filter_view.collect()
-        assert df.height > 0
+        assert df.height == 769
 
     def test_v2_filter_view_not_empty(self, da_v2):
         df = da_v2.preaggregated_filter_view.collect()
-        assert df.height > 0
+        assert df.height == 3797
 
     def test_filter_view_has_decisions_column(self, da_v1):
         cols = da_v1.preaggregated_filter_view.collect_schema().names()
@@ -308,11 +310,11 @@ class TestPreaggregation:
 
     def test_v1_remaining_view_not_empty(self, da_v1):
         df = da_v1.preaggregated_remaining_view.collect()
-        assert df.height > 0
+        assert df.height == 769
 
     def test_v2_remaining_view_not_empty(self, da_v2):
         df = da_v2.preaggregated_remaining_view.collect()
-        assert df.height > 0
+        assert df.height == 6818
 
     def test_remaining_view_has_win_rank_columns(self, da_v1):
         cols = da_v1.preaggregated_remaining_view.collect_schema().names()
@@ -344,13 +346,13 @@ class TestPreaggregation:
 class TestDistributionData:
     def test_v1_distribution_by_name(self, da_v1):
         df = da_v1.get_distribution_data(stage="Arbitration", grouping_levels="Action").collect()
-        assert df.height > 0
+        assert df.height == 152
         assert "Action" in df.columns
         assert "Decisions" in df.columns
 
     def test_v2_distribution_by_name(self, da_v2):
         df = da_v2.get_distribution_data(stage="Arbitration", grouping_levels="Action").collect()
-        assert df.height > 0
+        assert df.height == 27
 
     def test_distribution_sorted_descending(self, da_v1):
         df = da_v1.get_distribution_data(stage="Arbitration", grouping_levels="Action").collect()
@@ -369,12 +371,18 @@ class TestFunnelData:
         assert isinstance(available, pl.LazyFrame)
         assert isinstance(passing, pl.DataFrame)
         assert isinstance(filtered, pl.DataFrame)
+        assert available.collect().height == 12
+        assert passing.height == 9
+        assert filtered.height == 10
 
     def test_v1_funnel_returns_three_frames(self, da_v1):
         available, passing, filtered = da_v1.get_funnel_data(scope="Issue")
         assert isinstance(available, pl.LazyFrame)
         assert isinstance(passing, pl.DataFrame)
         assert isinstance(filtered, pl.DataFrame)
+        assert available.collect().height == 7
+        assert passing.height == 2
+        assert filtered.height == 5
 
     def test_passing_lte_available(self, da_v2):
         """Passing actions at each stage must be <= available actions."""
@@ -414,11 +422,13 @@ class TestFunnelData:
         assert "decisions_without_actions" in result.columns
         expected_stages = [s for s in da_v2.AvailableNBADStages if s != "Output"]
         assert len(result) == len(expected_stages)
+        assert result.height == 4
         assert "Output" not in result[da_v2.level].to_list()
 
     def test_decisions_without_actions_non_negative(self, da_v2):
         result = da_v2.get_decisions_without_actions_data()
-        assert (result["decisions_without_actions"] >= 0).all()
+        assert result["decisions_without_actions"].min() == 0.0
+        assert result["decisions_without_actions"].sum() == 6693.0
 
     def test_decisions_without_actions_per_stage(self, da_v2):
         """Values are stage deltas and total knockouts should be bounded by total decisions."""
@@ -485,8 +495,8 @@ class TestFunnelSummary:
     def test_decisions_pct_in_range(self, da_v2):
         available, passing, filtered = da_v2.get_funnel_data(scope="Issue")
         result = da_v2.get_funnel_summary(available, passing)
-        assert (result["% Decisions without Actions"] >= 0).all()
-        assert (result["% Decisions without Actions"] <= 100.1).all()  # rounding tolerance
+        assert result["% Decisions without Actions"].min() == 0.0
+        assert result["% Decisions without Actions"].max() == pytest.approx(94.7, abs=0.2)
 
 
 # ---------------------------------------------------------------------------
@@ -505,14 +515,14 @@ class TestSensitivity:
 
     def test_v2_sensitivity_returns_factors(self, da_v2):
         df = da_v2.get_sensitivity(win_rank=1).collect()
-        assert df.height > 0
+        assert df.height == 5
         assert "Factor" in df.columns
         assert "Influence" in df.columns
 
     def test_sensitivity_influence_non_negative_for_global(self, da_v1):
         """Global sensitivity should have non-negative influence values."""
         df = da_v1.get_sensitivity(win_rank=1).collect()
-        assert (df["Influence"] >= 0).all()
+        assert df["Influence"].min() == 29
 
 
 # ---------------------------------------------------------------------------
@@ -523,7 +533,7 @@ class TestSensitivity:
 class TestWinLoss:
     def test_v1_win_loss_returns_data(self, da_v1):
         df = da_v1.get_win_loss_distribution_data(level="Issue", win_rank=1).collect()
-        assert df.height > 0
+        assert df.height == 10
         assert "Status" in df.columns
 
     def test_win_loss_has_wins_and_losses(self, da_v1):
@@ -692,10 +702,10 @@ class TestSelectedGroupRankBoundariesWinLoss:
         win_result = winning_from.collect()
         loss_result = losing_to.collect()
 
-        assert win_result.height > 0
+        assert win_result.height == 2
         assert "Action" in win_result.columns
         assert "Decisions" in win_result.columns
-        assert loss_result.height > 0
+        assert loss_result.height == 1
         assert "Action" in loss_result.columns
         assert "Decisions" in loss_result.columns
 
@@ -793,6 +803,9 @@ class TestBoxplotPointCapAndSampling:
         )
         assert isinstance(df, pl.DataFrame)
         assert "segment" in df.columns
+        # Cannot assert exact height: prio_factor_boxplots mutates sample_size as a side
+        # effect when called by the preceding test, so the sample size seen here is
+        # non-deterministic.  See da-test-tightening-bugs.md for the bug report.
 
     def test_prio_factor_boxplots_sampling_caps_rows(self, da_v1):
         first_action = da_v1.decision_data.select("Action").first().collect().item()
@@ -874,10 +887,10 @@ class TestOverviewStats:
         assert expected_keys.issubset(stats.keys())
 
     def test_overview_actions_positive(self, da_v1):
-        assert da_v1.overview_stats["Actions"] > 0
+        assert da_v1.overview_stats["Actions"] == 152
 
     def test_overview_decisions_positive(self, da_v1):
-        assert da_v1.overview_stats["Decisions"] > 0
+        assert da_v1.overview_stats["Decisions"] == 100
 
 
 # ---------------------------------------------------------------------------
@@ -888,13 +901,13 @@ class TestOverviewStats:
 class TestTrendData:
     def test_v1_trend_returns_data(self, da_v1):
         df = da_v1.get_trend_data(stage="Arbitration", scope="Issue").collect()
-        assert df.height > 0
+        assert df.height == 35
         assert "day" in df.columns
         assert "Decisions" in df.columns
 
     def test_v2_trend_returns_data(self, da_v2):
         df = da_v2.get_trend_data(stage="Arbitration", scope="Issue").collect()
-        assert df.height > 0
+        assert df.height == 14
 
 
 # ---------------------------------------------------------------------------
@@ -905,7 +918,7 @@ class TestTrendData:
 class TestActionVariation:
     def test_v1_action_variation_at_arbitration(self, da_v1):
         df = da_v1.get_action_variation_data(stage="Arbitration").collect()
-        assert df.height > 0
+        assert df.height == 153
         assert "ActionIndex" in df.columns
         assert "DecisionsFraction" in df.columns
 
@@ -922,7 +935,7 @@ class TestActionVariation:
 
     def test_action_variation_with_color_by(self, da_v1):
         df = da_v1.get_action_variation_data(stage="Arbitration", color_by="Channel/Direction").collect()
-        assert df.height > 0
+        assert df.height == 153
         assert "Channel/Direction" in df.columns
         assert "ActionIndex" in df.columns
         assert "DecisionsFraction" in df.columns
@@ -944,7 +957,7 @@ class TestActionVariation:
 class TestReRank:
     def test_v1_rerank_returns_data(self, da_v1):
         df = da_v1.re_rank().collect()
-        assert df.height > 0
+        assert df.height == 7297
 
     def test_rerank_has_component_ranks(self, da_v1):
         df = da_v1.re_rank()
@@ -955,7 +968,7 @@ class TestReRank:
 
     def test_rerank_with_filters(self, da_v1):
         df = da_v1.re_rank(additional_filters=pl.col("Stage Group").is_in(da_v1.stages_from_arbitration_down)).collect()
-        assert df.height > 0
+        assert df.height == 7297
 
 
 # ---------------------------------------------------------------------------
@@ -967,7 +980,7 @@ class TestWinDistribution:
     def test_baseline_distribution(self, da_v1):
         lever_cond = pl.col("Issue") == da_v1.decision_data.select(pl.col("Issue").first()).collect().item()
         result = da_v1.get_win_distribution_data(lever_condition=lever_cond)
-        assert result.height > 0
+        assert result.height == 152
         assert "original_win_count" in result.columns
         assert "selected_action" in result.columns
 
@@ -990,17 +1003,17 @@ class TestWinDistribution:
 class TestOptionality:
     def test_v1_optionality_data(self, da_v1):
         df = da_v1.get_optionality_data(da_v1.sample).collect()
-        assert df.height > 0
+        assert df.height == 25
         assert "nOffers" in df.columns
         assert "Interactions" in df.columns
 
     def test_v2_optionality_data(self, da_v2):
         df = da_v2.get_optionality_data(da_v2.sample).collect()
-        assert df.height > 0
+        assert df.height == 123
 
     def test_optionality_with_trend(self, da_v1):
         df = da_v1.get_optionality_data(by_day=True).collect()
-        assert df.height > 0
+        assert df.height == 73
         assert "day" in df.columns
 
 
@@ -1015,7 +1028,7 @@ class TestFilterComponents:
         if "Component Name" not in da_v2.decision_data.collect_schema().names():
             pytest.skip("No pxComponentName in this dataset")
         df = da_v2.get_filter_component_data(top_n=5)
-        assert df.height > 0
+        assert df.height == 8
         assert "Component Name" in df.columns
 
     def test_v2_filter_component_data_includes_component_type(self, da_v2):
@@ -1038,7 +1051,7 @@ class TestComponentActionImpact:
         if "Component Name" not in da_v2.decision_data.collect_schema().names():
             pytest.skip("No pxComponentName in this dataset")
         df = da_v2.get_component_action_impact(top_n=5)
-        assert df.height > 0
+        assert df.height == 289
         assert "Component Name" in df.columns
         assert "Action" in df.columns
         assert "Filtered Decisions" in df.columns
@@ -1073,8 +1086,8 @@ class TestComponentDrilldown:
     def test_v2_component_drilldown(self, da_v2):
         if "Component Name" not in da_v2.decision_data.collect_schema().names():
             pytest.skip("No pxComponentName in this dataset")
-        # Pick the first available component
-        components = (
+        # Sort for deterministic selection
+        components = sorted(
             da_v2.decision_data.filter(pl.col("Record Type") == "FILTERED_OUT")
             .select("Component Name")
             .unique()
@@ -1085,14 +1098,14 @@ class TestComponentDrilldown:
         if not components:
             pytest.skip("No filtered components in dataset")
         df = da_v2.get_component_drilldown(component_name=components[0])
-        assert df.height > 0
+        assert df.height == 3
         assert "Action" in df.columns
         assert "Filtered Decisions" in df.columns
 
     def test_component_drilldown_sorted_descending(self, da_v2):
         if "Component Name" not in da_v2.decision_data.collect_schema().names():
             pytest.skip("No pxComponentName in this dataset")
-        components = (
+        components = sorted(
             da_v2.decision_data.filter(pl.col("Record Type") == "FILTERED_OUT")
             .select("Component Name")
             .unique()
@@ -1116,7 +1129,7 @@ class TestComponentDrilldown:
         """Drilldown should include avg score columns when scoring data exists."""
         if "Component Name" not in da_v2.decision_data.collect_schema().names():
             pytest.skip("No pxComponentName in this dataset")
-        components = (
+        components = sorted(
             da_v2.decision_data.filter(pl.col("Record Type") == "FILTERED_OUT")
             .select("Component Name")
             .unique()
@@ -1127,19 +1140,18 @@ class TestComponentDrilldown:
         if not components:
             pytest.skip("No filtered components in dataset")
         df = da_v2.get_component_drilldown(component_name=components[0])
-        # At least one avg_* column should be present if scoring data exists
         avg_cols = [c for c in df.columns if c.startswith("avg_")]
         available_scores = {"Priority", "Value", "Propensity"}.intersection(
             da_v2.decision_data.collect_schema().names()
         )
         if available_scores:
-            assert len(avg_cols) > 0
+            assert len(avg_cols) == 3
 
     def test_drilldown_respects_scope(self, da_v2):
         """Drilldown should group at the requested scope level."""
         if "Component Name" not in da_v2.decision_data.collect_schema().names():
             pytest.skip("No pxComponentName in this dataset")
-        components = (
+        components = sorted(
             da_v2.decision_data.filter(pl.col("Record Type") == "FILTERED_OUT")
             .select("Component Name")
             .unique()
@@ -1268,12 +1280,12 @@ class TestScopeHelpers:
 
     def test_available_fields_for_filtering(self, da_v1):
         fields = da_v1.get_available_fields_for_filtering()
-        assert len(fields) > 0
+        assert len(fields) == 6
         assert "Action" in fields
 
     def test_available_categorical_fields(self, da_v1):
         fields = da_v1.get_available_fields_for_filtering(categoricalOnly=True)
-        assert len(fields) > 0
+        assert len(fields) == 5
 
 
 # ---------------------------------------------------------------------------
@@ -1329,7 +1341,7 @@ class TestStageMethods:
         result = da_v1.arbitration_stage
         assert isinstance(result, pl.LazyFrame)
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 7297
 
     def test_arbitration_stage_only_contains_arbitration_stages(self, da_v1):
         df = da_v1.arbitration_stage.collect()
@@ -1341,7 +1353,7 @@ class TestStageMethods:
         result = da_v2.arbitration_stage
         assert isinstance(result, pl.LazyFrame)
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 21133
 
 
 # ---------------------------------------------------------------------------
@@ -1359,7 +1371,7 @@ class TestDataAccess:
     def test_get_possible_stage_values_v2(self, da_v2):
         stages = da_v2.get_possible_stage_values()
         assert isinstance(stages, list)
-        assert len(stages) >= 2
+        assert len(stages) == 5
         assert "Arbitration" in stages
 
     def test_stage_to_group_mapping_at_stage_group_level(self, da_v2):
@@ -1376,9 +1388,8 @@ class TestDataAccess:
         da_v2.set_level("Stage")
         mapping = da_v2.stage_to_group_mapping
         assert isinstance(mapping, dict)
-        assert len(mapping) > 0
-        # Values should be stage group names
-        assert "Arbitration" in mapping.values() or len(mapping) > 0
+        assert len(mapping) == 7
+        assert "Arbitration" in mapping.values()
         # Restore
         da_v2.set_level(original_level)
 
@@ -1397,7 +1408,7 @@ class TestAnalysisMethods:
     def test_get_optionality_funnel_v1(self, da_v1):
         result = da_v1.get_optionality_funnel()
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 4
         assert "available_actions" in df.columns
         assert "Interactions" in df.columns
         assert da_v1.level in df.columns
@@ -1405,7 +1416,7 @@ class TestAnalysisMethods:
     def test_get_optionality_funnel_v2(self, da_v2):
         result = da_v2.get_optionality_funnel()
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 28
         assert "available_actions" in df.columns
 
     def test_get_ab_test_results_no_crash(self, da_v2):
@@ -1427,7 +1438,7 @@ class TestAnalysisMethods:
     def test_get_thresholding_data_propensity(self, da_v1):
         result = da_v1.get_thresholding_data(fld="Propensity")
         assert isinstance(result, pl.DataFrame)
-        assert result.height > 0
+        assert result.height == 9
         assert "Decile" in result.columns
         assert "Threshold" in result.columns
         assert "Count" in result.columns
@@ -1436,12 +1447,12 @@ class TestAnalysisMethods:
     def test_get_thresholding_data_priority(self, da_v2):
         result = da_v2.get_thresholding_data(fld="Priority")
         assert isinstance(result, pl.DataFrame)
-        assert result.height > 0
+        assert result.height == 9
 
     def test_get_thresholding_data_custom_quantile_range(self, da_v1):
         result = da_v1.get_thresholding_data(fld="Propensity", quantile_range=range(20, 100, 20))
         assert isinstance(result, pl.DataFrame)
-        assert result.height > 0
+        assert result.height == 4
 
     def test_get_thresholding_data_caches_result(self, da_v1):
         """Calling with same args should return cached result."""
@@ -1470,7 +1481,7 @@ class TestFilteringAndScoping:
         result = da_v2.priority_component_distribution(component=component, granularity="Issue", stage="Arbitration")
         assert isinstance(result, pl.LazyFrame)
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 21133
         assert "Issue" in df.columns
         assert component in df.columns
 
@@ -1481,19 +1492,19 @@ class TestFilteringAndScoping:
             pytest.skip("Propensity not available")
         result = da_v2.priority_component_distribution(component=component, granularity="Action", stage=None)
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 816372
 
     def test_all_components_distribution_v2(self, da_v2):
         result = da_v2.all_components_distribution(granularity="Issue", stage="Arbitration")
         assert isinstance(result, pl.LazyFrame)
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 21133
         assert "Issue" in df.columns
 
     def test_all_components_distribution_no_stage(self, da_v2):
         result = da_v2.all_components_distribution(granularity="Group", stage=None)
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 816372
         assert "Group" in df.columns
 
     def test_remaining_at_stage_none(self, da_v2):
@@ -1501,14 +1512,14 @@ class TestFilteringAndScoping:
         result = da_v2._remaining_at_stage(stage=None)
         assert isinstance(result, pl.LazyFrame)
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 816372
         # All rows should have non-null Priority
         assert df["Priority"].null_count() == 0
 
     def test_remaining_at_stage_arbitration(self, da_v2):
         result = da_v2._remaining_at_stage(stage="Arbitration")
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 21133
         stages = df[da_v2.level].unique().to_list()
         for s in stages:
             assert s in da_v2.stages_from_arbitration_down
@@ -1517,7 +1528,7 @@ class TestFilteringAndScoping:
         result = da_v2.filtered_action_counts(groupby_cols=[da_v2.level])
         assert isinstance(result, pl.LazyFrame)
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 5
         assert "no_of_offers" in df.columns
 
     def test_filtered_action_counts_with_thresholds(self, da_v2):
@@ -1527,7 +1538,7 @@ class TestFilteringAndScoping:
             priorityTH=0.5,
         )
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 5
         assert "no_of_offers" in df.columns
         assert "good_offers" in df.columns
         assert "poor_propensity_offers" in df.columns
@@ -1537,7 +1548,7 @@ class TestFilteringAndScoping:
     def test_filtered_action_counts_by_interaction(self, da_v1):
         result = da_v1.filtered_action_counts(groupby_cols=["Interaction ID"])
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 100
         assert "Interaction ID" in df.columns
 
     def test_filtered_action_counts_missing_col_raises(self, da_v1):
@@ -1557,7 +1568,7 @@ class TestWinDistributionExtended:
         lever_cond = pl.col("Issue") == first_issue
         result = da_v2.get_win_distribution_data(lever_condition=lever_cond)
         assert isinstance(result, pl.DataFrame)
-        assert result.height > 0
+        assert result.height == 71
         assert "original_win_count" in result.columns
         assert "selected_action" in result.columns
         # Should have both Selected and Rest
@@ -1621,15 +1632,17 @@ class TestOfferQualityAnalysis:
         """Test that stages_with_propensity detects stages with propensity scores."""
         stages = da_v2.stages_with_propensity
         assert isinstance(stages, list)
-        assert len(stages) > 0
-        # Should include arbitration-related stages
-        assert any("arbitration" in s.lower() or "output" in s.lower() for s in stages)
+        assert len(stages) == 5
+        assert "Arbitration" in stages
+        assert "Output" in stages
 
     def test_stages_with_propensity_v1(self, da_v1):
         """Test stages_with_propensity on v1 data."""
         stages = da_v1.stages_with_propensity
         assert isinstance(stages, list)
-        assert len(stages) > 0
+        assert len(stages) == 2
+        assert "Arbitration" in stages
+        assert "Output" in stages
 
     def test_get_offer_quality_basic(self, da_v2):
         """Test get_offer_quality returns expected structure."""
@@ -1639,7 +1652,7 @@ class TestOfferQualityAnalysis:
         )
         result = da_v2.get_offer_quality(action_counts, group_by="Interaction ID")
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 25190
         # Check for offer quality category columns
         assert "has_no_offers" in df.columns
         assert "atleast_one_relevant_action" in df.columns
@@ -1654,14 +1667,14 @@ class TestOfferQualityAnalysis:
         )
         result = da_v2.get_offer_quality(action_counts, group_by="Interaction ID")
         df = result.collect()
-        assert df.height > 0
+        assert df.height == 25190
         # At least one category should have non-zero counts
         has_counts = (
             df.select("has_no_offers", "atleast_one_relevant_action", "only_irrelevant_actions", "atleast_one_action")
             .sum()
             .row(0)
         )
-        assert sum(has_counts) > 0
+        assert sum(has_counts) == 25190
 
     def test_get_offer_quality_includes_all_customers(self, da_v2):
         """Test that get_offer_quality includes customers even if they have no actions."""
@@ -1674,7 +1687,7 @@ class TestOfferQualityAnalysis:
         df = result.collect()
 
         # Should have customers with no offers
-        assert df.filter(pl.col("has_no_offers") > 0).height > 0
+        assert df.filter(pl.col("has_no_offers") > 0).height == 11655
 
         # Total unique customers should match first stage customer count
         first_stage = da_v2.AvailableNBADStages[0]
@@ -2061,7 +2074,7 @@ class TestMinimalSensitivity:
 
     def test_influence_values_non_negative(self, da_minimal):
         df = da_minimal.get_sensitivity(win_rank=1).collect()
-        assert (df["Influence"] >= 0).all()
+        assert df["Influence"].min() == 1
 
 
 class TestMinimalWinLoss:
@@ -2344,7 +2357,8 @@ class TestMinimalComponentDrilldown:
     def test_drilldown_includes_avg_score_columns(self, da_minimal):
         df = da_minimal.get_component_drilldown(component_name="ContactPolicyRule")
         avg_cols = [c for c in df.columns if c.startswith("avg_")]
-        assert len(avg_cols) > 0
+        assert len(avg_cols) == 3
+        assert set(avg_cols) == {"avg_Priority", "avg_Value", "avg_Propensity"}
 
     def test_drilldown_respects_scope_issue(self, da_minimal):
         """At Issue scope, ContactPolicyRule should show 2 rows (Sales, Retention)."""

--- a/python/tests/test_data_read_utils.py
+++ b/python/tests/test_data_read_utils.py
@@ -53,11 +53,7 @@ class TestReadGzippedData:
         gz_bytes = _make_ndjson_gz(SAMPLE_RECORDS)
         result = read_gzipped_data(BytesIO(gz_bytes))
         assert result is not None
-        # The function returns .lazy(), so it's actually a LazyFrame
-        if isinstance(result, pl.LazyFrame):
-            df = result.collect()
-        else:
-            df = result
+        df = result.collect()
         assert df.shape == (3, 2)
         assert df["col_a"].to_list() == [1, 2, 3]
         assert df["col_b"].to_list() == ["x", "y", "z"]
@@ -302,9 +298,8 @@ class TestReadNestedZipFiles:
         outer_buf.seek(0)
 
         result = read_nested_zip_files(outer_buf)
-        # Result should be a DataFrame (concat of all parts)
-        if isinstance(result, pl.LazyFrame):
-            result = result.collect()
+        # Function returns LazyFrame; collect for assertions
+        result = result.collect()
         assert isinstance(result, pl.DataFrame)
         assert result.shape == (3, 2)
         assert sorted(result["a"].to_list()) == [1, 2, 3]
@@ -321,8 +316,7 @@ class TestReadNestedZipFiles:
         outer_buf.seek(0)
 
         result = read_nested_zip_files(outer_buf)
-        if isinstance(result, pl.LazyFrame):
-            result = result.collect()
+        result = result.collect()
         assert isinstance(result, pl.DataFrame)
         assert result.shape == (1, 2)
         assert result["a"].to_list() == [1]
@@ -340,6 +334,5 @@ class TestReadNestedZipFiles:
         outer_buf.seek(0)
 
         result = read_nested_zip_files(outer_buf)
-        if isinstance(result, pl.LazyFrame):
-            result = result.collect()
+        result = result.collect()
         assert result.shape == (1, 2)


### PR DESCRIPTION
## Summary

Three loosely-coupled but related improvements bundled together:

1. **Type-ignore cleanup across the `decision_analyzer/` module** —
   removed all 19 `# type: ignore` comments. One latent bug fell out
   of this work (signatures in `data_read_utils.py` were lying about
   their return type and callers had defensive workarounds; both are
   fixed).
2. **Test-quality sweep on `test_DecisionAnalyzer.py`** — replaced
   ~68 weak structural assertions with exact-value assertions.
3. **AGENTS.md additions** — codified conventions from recent PRs