### PR TITLE
typing(adm/Aggregates): introduce `_require_*` helpers; remove all 7 `type:ignore`s

### DIFF
--- a/docs/plans/adm-TODO.md
+++ b/docs/plans/adm-TODO.md
@@ -35,41 +35,30 @@ Priority levels: P1 = high, P2 = medium, P3 = nice-to-have.
 
 ### DRY-ups
 
-- [ ] **P2 — Extract `_require_model_data()` / `_require_predictor_data()`
-  helpers.** Multiple sites in `Plots.py` and `Aggregates.py` carry
-  `# type: ignore[union-attr]` because `model_data` is typed
-  `pl.LazyFrame | None`. A small helper that returns the LazyFrame
-  or raises a clear `ValueError("Model data not available — …")`
-  eliminates the type:ignores and replaces silent `None`-propagation
-  with an actionable error.
 - [ ] **P3 — Factor out Performance auto-rescale.** The
   `50–100 → 0.5–1.0` rescale block is duplicated verbatim in
   `_validate_model_data` and `_validate_predictor_data`
   (`ADMDatamart.py:474-479` and `:512-518`). Pull into a single
   `_normalize_performance_scale(df)` helper.
-- [ ] **P3 — DRY-up the `unique_*` cached properties.** The five
-  `cached_property` lookups (`unique_channels`,
-  `unique_configurations`, `unique_channel_direction`,
-  `unique_configuration_channel_direction`,
-  `unique_predictor_categories`) are all the same shape:
-  `.select(pl.col(X).unique().sort()).collect()[X].to_list()`. A
-  generic `_unique_sorted(col_or_expr)` helper compresses all five
-  into one-liners while keeping the cached_properties as the public
-  surface.
 
 ### Pre-existing typing debt (out of scope until DA sweep is merged)
 
-- [ ] **P2 — `ADMDatamart.py:737, 759` mypy errors.** "Item 'None' of
-  'LazyFrame | None' has no attribute 'select'". Resolved
-  automatically once `_require_model_data()` helper above is in
-  place.
 - [ ] **P2 — `Plots.py` pre-existing mypy errors** at lines 751, 1144,
   1573, 1596, 1604 (arg-type / assignment). Triage as part of the
   planned `typing-adm-plots` PR.
 
 ## Done
 
-(none yet — file initialized 2026-04-21)
+- [x] **P2 — Extract `_require_*` helpers** — added
+  `_require_model_data`, `_require_predictor_data`, and
+  `_require_first_action_dates` on `ADMDatamart`. Eliminates
+  `# type: ignore[union-attr]` across `Aggregates.py` and gives users
+  an actionable `ValueError` instead of an `AttributeError` on `None`.
+- [x] **P3 — DRY-up the `unique_*` cached properties** — collapsed all
+  five (`unique_channels`, `unique_configurations`, etc.) onto a
+  single `_unique_sorted_from_model_data(expr, alias)` helper.
+- [x] **P2 — Resolved `ADMDatamart.py:737, 759` mypy errors** — gone
+  with the `_require_*` helpers above.
 
 ---
 

--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -156,6 +156,46 @@ class ADMDatamart:
             return df
         return df.group_by("Name").agg(ActionFirstSnapshotTime=pl.col("SnapshotTime").min()).sort("Name")
 
+    def _require_model_data(self) -> pl.LazyFrame:
+        """Return ``model_data`` or raise a clear error if it isn't loaded.
+
+        Use this in any method that fundamentally needs model data — it
+        eliminates ``Optional`` narrowing at every call site and gives the
+        user an actionable error instead of an opaque ``AttributeError``
+        on ``None``.
+        """
+        if self.model_data is None:
+            raise ValueError(
+                "This operation requires model data, but no model_df was provided when constructing this ADMDatamart.",
+            )
+        return self.model_data
+
+    def _require_predictor_data(self) -> pl.LazyFrame:
+        """Return ``predictor_data`` or raise a clear error if it isn't loaded.
+
+        See :meth:`_require_model_data` for rationale.
+        """
+        if self.predictor_data is None:
+            raise ValueError(
+                "This operation requires predictor data, but no predictor_df "
+                "was provided when constructing this ADMDatamart.",
+            )
+        return self.predictor_data
+
+    def _require_first_action_dates(self) -> pl.LazyFrame:
+        """Return ``first_action_dates`` or raise a clear error.
+
+        ``first_action_dates`` is derived from ``model_data`` during
+        construction, so it's only ``None`` when no model data was supplied.
+        """
+        if self.first_action_dates is None:
+            raise ValueError(
+                "This operation requires first action dates, which are derived "
+                "from model data — but no model_df was provided when "
+                "constructing this ADMDatamart.",
+            )
+        return self.first_action_dates
+
     @classmethod
     def from_ds_export(
         cls,
@@ -694,13 +734,23 @@ class ADMDatamart:
 
         return modeldata_cache, predictordata_cache
 
+    def _unique_sorted_from_model_data(self, expr: pl.Expr, alias: str) -> list[str]:
+        """Helper for the ``unique_*`` cached_properties on model data.
+
+        Selects ``expr`` from ``model_data``, deduplicates and sorts it, then
+        materialises to a Python ``list[str]``. Centralises both the
+        ``Optional`` narrowing and the repeated ``select / unique / sort /
+        collect / to_list`` chain.
+        """
+        return self._require_model_data().select(expr.unique().sort().alias(alias)).collect()[alias].to_list()
+
     @cached_property
     def unique_channels(self) -> list[str]:
         """Sorted list of unique channels in the data.
 
         Used for making the color schemes in different plots consistent.
         """
-        return self.model_data.select(pl.col("Channel").unique().sort()).collect()["Channel"].to_list()
+        return self._unique_sorted_from_model_data(pl.col("Channel"), "Channel")
 
     @cached_property
     def unique_configurations(self) -> list[str]:
@@ -708,7 +758,7 @@ class ADMDatamart:
 
         Used for making the color schemes in different plots consistent.
         """
-        return self.model_data.select(pl.col("Configuration").unique().sort()).collect()["Configuration"].to_list()
+        return self._unique_sorted_from_model_data(pl.col("Configuration"), "Configuration")
 
     @cached_property
     def unique_channel_direction(self) -> list[str]:
@@ -716,15 +766,9 @@ class ADMDatamart:
 
         Used for making the color schemes in different plots consistent.
         """
-        return (
-            self.model_data.select(
-                pl.concat_str(pl.col("Channel"), pl.col("Direction"), separator="/")
-                .unique()
-                .sort()
-                .alias("ChannelDirection"),
-            )
-            .collect()["ChannelDirection"]
-            .to_list()
+        return self._unique_sorted_from_model_data(
+            pl.concat_str(pl.col("Channel"), pl.col("Direction"), separator="/"),
+            "ChannelDirection",
         )
 
     @cached_property
@@ -733,20 +777,14 @@ class ADMDatamart:
 
         Used for making the color schemes in different plots consistent.
         """
-        return (
-            self.model_data.select(
-                pl.concat_str(
-                    pl.col("Configuration"),
-                    pl.col("Channel"),
-                    pl.col("Direction"),
-                    separator="/",
-                )
-                .unique()
-                .sort()
-                .alias("ChannelDirection"),
-            )
-            .collect()["ChannelDirection"]
-            .to_list()
+        return self._unique_sorted_from_model_data(
+            pl.concat_str(
+                pl.col("Configuration"),
+                pl.col("Channel"),
+                pl.col("Direction"),
+                separator="/",
+            ),
+            "ChannelDirection",
         )
 
     @cached_property
@@ -756,7 +794,8 @@ class ADMDatamart:
         Used for making the color schemes in different plots consistent.
         """
         return (
-            self.predictor_data.select(pl.col("PredictorCategory").unique().sort())
+            self._require_predictor_data()
+            .select(pl.col("PredictorCategory").unique().sort())
             .filter(pl.col("PredictorCategory").is_not_null())
             .collect()["PredictorCategory"]
             .to_list()

--- a/python/pdstools/adm/Aggregates.py
+++ b/python/pdstools/adm/Aggregates.py
@@ -246,11 +246,11 @@ class Aggregates:
 
     @staticmethod
     def _top_n(
-        df: pl.LazyFrame | pl.DataFrame,
+        df: pl.LazyFrame,
         top_n: int,
         metric: str = "PredictorPerformance",
-        facets: list | None = None,
-    ):
+        facets: list[str] | None = None,
+    ) -> pl.LazyFrame:
         """Subsets DataFrame to contain only top_n predictors.
 
         Parameters
@@ -274,7 +274,7 @@ class Aggregates:
             return df
         if facets:
             return df.join(
-                df.group_by(facets + ["PredictorName"])  # type: ignore[arg-type]
+                df.group_by(facets + ["PredictorName"])
                 .agg(cdh_utils.weighted_average_polars(metric, "ResponseCountBin"))
                 .filter(pl.col(metric).is_not_nan())
                 .group_by(*facets)
@@ -286,7 +286,7 @@ class Aggregates:
             )
 
         return df.join(
-            df.group_by("PredictorName")  # type: ignore[arg-type]
+            df.group_by("PredictorName")
             .agg(cdh_utils.weighted_average_polars(metric, "ResponseCountBin"))
             .filter(pl.col(metric).is_not_nan())
             .sort(metric, descending=True)
@@ -309,15 +309,12 @@ class Aggregates:
         def name_normalizer(x):
             return pl.col(x).cast(pl.Utf8).str.replace_all(r"[ \-_]", "").str.to_uppercase()
 
-        if self.datamart.model_data is None:
-            raise ValueError("Model summaries needs model data")
-
         model_data = cdh_utils._apply_query(
-            self.datamart.model_data,
+            self.datamart._require_model_data(),
             query=query,
             allow_empty=True,
         )
-        grouping = []
+        grouping: list[str] = []
 
         if every:
             model_data = model_data.with_columns(
@@ -367,34 +364,34 @@ class Aggregates:
             )
             grouping += ["Channel", "Direction", "ChannelDirectionGroup"]
 
-        grouping = None if len(grouping) == 0 else grouping  # type: ignore[assignment]
+        grouping_cols: list[str] | None = None if len(grouping) == 0 else grouping
 
         return (
-            self._summarize_meta_info(grouping, model_data, debug=debug)
+            self._summarize_meta_info(grouping_cols, model_data, debug=debug)
             .join(
-                self._summarize_model_analytics(grouping, model_data, debug=debug),
-                on=("literal" if grouping is None else grouping),
+                self._summarize_model_analytics(grouping_cols, model_data, debug=debug),
+                on=("literal" if grouping_cols is None else grouping_cols),
                 nulls_equal=True,
                 how="left",
             )
             .join(
-                self._summarize_action_analytics(grouping, model_data, debug=debug),
-                on=("literal" if grouping is None else grouping),
+                self._summarize_action_analytics(grouping_cols, model_data, debug=debug),
+                on=("literal" if grouping_cols is None else grouping_cols),
                 nulls_equal=True,
                 how="left",
             )
             .join(
                 self._summarize_model_usage(
-                    grouping,
+                    grouping_cols,
                     model_data,
                     debug=debug,
                 ),
-                on=("literal" if grouping is None else grouping),
+                on=("literal" if grouping_cols is None else grouping_cols),
                 nulls_equal=True,
                 how="left",
             )
-            .drop(["literal"] if grouping is None else [])
-            .sort([] if grouping is None else grouping)
+            .drop(["literal"] if grouping_cols is None else [])
+            .sort([] if grouping_cols is None else grouping_cols)
         )
 
     def _summarize_meta_info(
@@ -491,7 +488,7 @@ class Aggregates:
 
         action_summary = (
             model_data.join(
-                self.datamart.first_action_dates,  # type: ignore[arg-type]
+                self.datamart._require_first_action_dates(),
                 on="Name",
                 nulls_equal=True,
             )
@@ -643,16 +640,14 @@ class Aggregates:
 
         """
         start_date, end_date = cdh_utils._get_start_end_date_args(
-            self.datamart.model_data,  # type: ignore[arg-type]
+            self.datamart._require_model_data(),
             start_date,
             end_date,
             window,
         )
 
-        if query is None:
-            query = pl.col("SnapshotTime").is_between(start_date, end_date)
-        else:
-            query = pl.col("SnapshotTime").is_between(start_date, end_date) & query  # type: ignore[operator]
+        date_filter = pl.col("SnapshotTime").is_between(start_date, end_date)
+        query = date_filter if query is None else cdh_utils._combine_queries(query, date_filter)
 
         summary_by_channel = (
             self._adm_model_summary(
@@ -1054,7 +1049,7 @@ class Aggregates:
 
         """
         start_date, end_date = cdh_utils._get_start_end_date_args(
-            self.datamart.model_data,  # type: ignore[arg-type]
+            self.datamart._require_model_data(),
             start_date,
             end_date,
             window,


### PR DESCRIPTION
Knocks out the seven `# type: ignore` comments in `pdstools/adm/Aggregates.py` by fixing the underlying typing problems instead of silencing them — and incidentally fixes one latent runtime bug. See `pr-typing-aggregates.md` for full details