### PR TITLE
test(decision_analyzer): scope DA fixtures to function to fix xdist flakiness

### DIFF
--- a/python/tests/test_DecisionAnalyzer.py
+++ b/python/tests/test_DecisionAnalyzer.py
@@ -38,14 +38,14 @@ pytestmark = pytest.mark.filterwarnings("ignore:The following default columns ar
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def da_v1():
     """DecisionAnalyzer from Explainability Extract (v1) sample data."""
     raw = pl.scan_parquet(f"{basePath}/data/sample_explainability_extract.parquet")
     return DecisionAnalyzer(raw, sample_size=5000)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def da_v2():
     """DecisionAnalyzer from Decision Analyzer / EEV2 (v2) sample data."""
     raw = pl.scan_parquet(f"{basePath}/data/sample_eev2.parquet")
@@ -549,7 +549,7 @@ class TestWinLoss:
             assert abs(total - 1.0) < 0.01, f"{status} percentages sum to {total}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def da_win_loss_boundary_tiny():
     """Tiny deterministic dataset to verify selected-group rank boundary semantics."""
     tiny_data = pl.LazyFrame(
@@ -1791,7 +1791,7 @@ class TestPropensityValidation:
 # to verify every number.
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def da_minimal():
     """DecisionAnalyzer from the minimal CSV."""
     raw = pl.scan_csv(f"{basePath}/data/da/sample_eev2_minimal.csv")


### PR DESCRIPTION
The da_v1, da_v2, da_minimal, and da_win_loss_boundary_tiny fixtures were module-scoped, so a single DecisionAnalyzer instance was shared across all tests in the file (per worker). Several tests mutate `da.sample_size` (e.g. test_rank_boxplot_sampling_with_low_cap sets it to 10) and prio_factor_boxplots also mutates it as a side effect (see #668). Combined with the @cached_property on `.sample`, once a test triggers `.sample` after sample_size has been shrunk, the cache traps the small size and downstream tests using `.sample` see ~10% of the expected rows.

Locally with single-worker pytest the order is stable so it passes, but xdist's `-n auto` randomises distribution and surfaces the leak intermittently.

Holding action until the underlying mutation in #668 is fixed. Performance impact is negligible (<20 s for the whole file under xdist).