### PR TITLE
perf(plots): lazy-import plotly across explanations/valuefinder/ih/im pactanalyzer

### DIFF
--- a/python/pdstools/explanations/Plots.py
+++ b/python/pdstools/explanations/Plots.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = ["Plots"]
 
 import logging
@@ -16,13 +18,9 @@ from .ExplanationsUtils import (
 
 logger = logging.getLogger(__name__)
 
-
-try:
+if TYPE_CHECKING:  # pragma: no cover
     import plotly.graph_objects as go
-except ImportError as e:
-    logger.debug("Failed to import optional dependencies: %s", e)
 
-if TYPE_CHECKING:
     from .Explanations import Explanations
 
 
@@ -254,6 +252,8 @@ class Plots(LazyNamespace):
         y_title: str = Y_AXIS_TITLE_DEFAULT,
         context: ContextInfo | None = None,
     ) -> go.Figure:
+        import plotly.graph_objects as go
+
         title = "Overall average predictor contributions for "
         if context is None:
             title += "the whole model"
@@ -297,6 +297,8 @@ class Plots(LazyNamespace):
         x_title: str = X_AXIS_TITLE_DEFAULT,
         y_title: str = Y_AXIS_TITLE_DEFAULT,
     ) -> list[go.Figure]:
+        import plotly.graph_objects as go
+
         df_with_frequency_pct = self.aggregate.add_frequency_pct_to_df(
             df, group_by=[_COL.PREDICTOR_NAME.value, _COL.PREDICTOR_TYPE.value]
         )
@@ -339,6 +341,8 @@ class Plots(LazyNamespace):
 
     @staticmethod
     def _plot_context_table(context_info: ContextInfo) -> go.Figure:
+        import plotly.graph_objects as go
+
         fig = go.Figure(
             data=[
                 go.Table(

--- a/python/pdstools/ih/Plots.py
+++ b/python/pdstools/ih/Plots.py
@@ -1,8 +1,10 @@
 """Plotting utilities for Interaction History visualization."""
 
+from __future__ import annotations
+
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import polars as pl
 
@@ -13,14 +15,8 @@ from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .IH import IH as IH_Class
-
-try:
-    import plotly.express as px
-    import plotly.graph_objects as go
-except ImportError as e:  # pragma: no cover
-    logger.debug(f"Failed to import optional dependencies: {e}")
 
 
 class Plots(LazyNamespace):
@@ -78,7 +74,7 @@ class Plots(LazyNamespace):
         title: str | None = None,
         query: QUERY | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create gauge charts showing success rates by condition and dimension.
 
         Generates a grid of gauge charts displaying success rates for combinations
@@ -121,6 +117,8 @@ class Plots(LazyNamespace):
 
         if return_df:
             return plot_data
+
+        import plotly.graph_objects as go
 
         if title is None:
             title = f"{metric} Overall Rates"
@@ -191,7 +189,7 @@ class Plots(LazyNamespace):
         title: str | None = None,
         query: QUERY | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create a treemap of response count distribution.
 
         Displays hierarchical response counts across dimensions, allowing
@@ -239,6 +237,8 @@ class Plots(LazyNamespace):
         if return_df:
             return plot_data
 
+        import plotly.express as px
+
         fig = px.treemap(
             plot_data.collect(),
             path=[px.Constant("ALL")] + ["Outcome"] + by,
@@ -265,7 +265,7 @@ class Plots(LazyNamespace):
         title: str | None = None,
         query: QUERY | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create a treemap colored by success rates.
 
         Displays hierarchical success rates across dimensions, with color
@@ -311,6 +311,8 @@ class Plots(LazyNamespace):
         if return_df:
             return plot_data
 
+        import plotly.express as px
+
         if title is None:
             title = f"{metric} Rates for All Actions"
 
@@ -353,7 +355,7 @@ class Plots(LazyNamespace):
         color: str | None = None,
         facet: str | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create a bar chart of action distribution.
 
         Displays action counts across categories, optionally colored and
@@ -392,6 +394,8 @@ class Plots(LazyNamespace):
         if return_df:
             return plot_data
 
+        import plotly.express as px
+
         fig = px.bar(
             plot_data.collect(),
             x="Count",
@@ -418,7 +422,7 @@ class Plots(LazyNamespace):
         query: QUERY | None = None,
         facet: str | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create a line chart of success rates over time.
 
         Displays success rate trends for the specified metric, optionally
@@ -463,6 +467,8 @@ class Plots(LazyNamespace):
         if return_df:
             return plot_data
 
+        import plotly.express as px
+
         if title is None:
             title = f"Success Rates Trend of {metric}"
 
@@ -490,7 +496,7 @@ class Plots(LazyNamespace):
         query: QUERY | None = None,
         facet: str | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create a bar chart of response counts over time.
 
         Displays response counts colored by outcome type, optionally
@@ -532,6 +538,8 @@ class Plots(LazyNamespace):
         if return_df:
             return plot_data.lazy()
 
+        import plotly.express as px
+
         fig = px.bar(
             plot_data,
             x="OutcomeTime",
@@ -556,7 +564,7 @@ class Plots(LazyNamespace):
         query: QUERY | None = None,
         facet: str | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create a line chart of model AUC over time.
 
         Displays model performance (Area Under the ROC Curve) calculated from
@@ -617,6 +625,8 @@ class Plots(LazyNamespace):
 
         if return_df:
             return plot_data
+
+        import plotly.express as px
 
         fig = px.line(
             plot_data.collect(),

--- a/python/pdstools/impactanalyzer/Plots.py
+++ b/python/pdstools/impactanalyzer/Plots.py
@@ -1,7 +1,9 @@
 """Plotting utilities for Impact Analyzer visualization."""
 
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import polars as pl
 
@@ -12,13 +14,8 @@ from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .ImpactAnalyzer import ImpactAnalyzer as ImpactAnalyzer_Class
-
-try:
-    import plotly.express as px
-except ImportError as e:  # pragma: no cover
-    logger.debug(f"Failed to import optional dependencies: {e}")
 
 
 class Plots(LazyNamespace):
@@ -127,7 +124,7 @@ class Plots(LazyNamespace):
         metric: str = "CTR_Lift",
         facet: str | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create a bar chart comparing experiment performance.
 
         Displays a horizontal bar chart comparing Impact Analyzer experiments
@@ -177,6 +174,8 @@ class Plots(LazyNamespace):
         if return_df:
             return plot_data
 
+        import plotly.express as px
+
         collected_data = plot_data.collect()
         facet_config = self._get_facet_config(collected_data, facet)
 
@@ -219,7 +218,7 @@ class Plots(LazyNamespace):
         facet: str | None = None,
         every: str | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create a line chart of control group metrics over time.
 
         Displays how different control groups perform over time for
@@ -273,6 +272,8 @@ class Plots(LazyNamespace):
         if return_df:
             return plot_data
 
+        import plotly.express as px
+
         collected_data = plot_data.collect()
         facet_config = self._get_facet_config(collected_data, facet)
 
@@ -314,7 +315,7 @@ class Plots(LazyNamespace):
         facet: str | None = None,
         every: str | None = None,
         return_df: bool = False,
-    ) -> Union["Figure", pl.LazyFrame]:
+    ) -> Figure | pl.LazyFrame:
         """Create a line chart of experiment lift metrics over time.
 
         Displays how different experiments' lift metrics evolve over time.
@@ -366,6 +367,8 @@ class Plots(LazyNamespace):
 
         if return_df:
             return plot_data
+
+        import plotly.express as px
 
         collected_data = plot_data.collect()
         facet_config = self._get_facet_config(collected_data, facet)

--- a/python/pdstools/valuefinder/Plots.py
+++ b/python/pdstools/valuefinder/Plots.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterable
 from typing import (
@@ -17,15 +19,6 @@ from ..utils.plot_utils import Figure
 from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
-
-try:
-    import plotly.express as px
-    import plotly.graph_objects as go
-    from plotly.subplots import make_subplots
-
-    from ..utils import pega_template as pega_template
-except ImportError as e:  # pragma: no cover
-    logger.debug(f"Failed to import optional dependencies: {e}")
 
 if TYPE_CHECKING:  # pragma: no cover
     from .ValueFinder import ValueFinder
@@ -77,6 +70,8 @@ class Plots(LazyNamespace):
         if return_df:
             return df
 
+        import plotly.express as px
+
         fig = px.funnel(
             df.with_columns(pl.col(pl.Categorical).cast(pl.Utf8)).collect(),
             y="Count",
@@ -93,6 +88,8 @@ class Plots(LazyNamespace):
 
     def propensity_distribution(self, sample_size: int = 10_000) -> Figure:
         import plotly.figure_factory as ff
+        import plotly.graph_objects as go
+        from plotly.subplots import make_subplots
 
         i = 0
         figs = make_subplots(
@@ -147,6 +144,8 @@ class Plots(LazyNamespace):
         stage="Eligibility",
     ) -> Figure:
         import plotly.figure_factory as ff
+        import plotly.graph_objects as go
+        from plotly.subplots import make_subplots
 
         colors = ["#001F5F", "#10A5AC", "#F76923"]
         propensities = ["FinalPropensity", "Propensity", "ModelPropensity"]
@@ -242,6 +241,9 @@ class Plots(LazyNamespace):
         quantiles: Iterable[float] | None = None,
         rounding: int = 3,
     ):
+        import plotly.graph_objects as go
+        from plotly.subplots import make_subplots
+
         thresholds = self._get_thresholds(thresholds, quantiles)
         df = pl.concat(
             [
@@ -340,6 +342,10 @@ class Plots(LazyNamespace):
         quantiles: Iterable[float] | None = None,
         rounding: int = 3,
     ):
+        import plotly.express as px
+
+        from ..utils import pega_template as pega_template  # noqa: F401
+
         thresholds = self._get_thresholds(
             thresholds,
             quantiles,


### PR DESCRIPTION
Follow-on to #677 (adm-lazy-plotly). Apply the same module-level try/except plotly → inline import pattern, so data-only paths (return_df=True) and modules that aren't rendering plots don't pay the plotly import cost.

Benchmarks (before → after):
  pdstools (top-level):    0.332s → 0.308s  (−7%)
  pdstools.explanations:   0.521s → 0.511s  (−2%)
  pdstools.valuefinder:    0.328s → 0.285s  (−13%)
  pdstools.ih:             0.316s → 0.274s  (−13%)
  pdstools.impactanalyzer: 0.309s → 0.282s  (−9%)

Also:
- Adds `from __future__ import annotations` to all four files
- Replaces `Union[X, Y]` with `X | Y` in ih and impactanalyzer
- pega_template side-effect import moved inline to distribution_per_threshold (the only valuefinder method using template="pega")

1574 tests pass.