### PR TITLE
fix(adm/ADMTrees): if/elif dispatch + thread-safe warn-once

### DIFF
--- a/python/pdstools/adm/ADMTrees.py
+++ b/python/pdstools/adm/ADMTrees.py
@@ -27,6 +27,7 @@ import logging
 import math
 import multiprocessing
 import re
+import threading
 import warnings
 import zlib
 from dataclasses import dataclass
@@ -534,13 +535,15 @@ class ADMTreesModel:
             to_decode = list(encoder["encoder"].values())[0]
             if variable_type == "quantileArray":
                 val = quantile_decoder(to_decode, int(splitval))
-            if variable_type == "stringTranslator":
+            elif variable_type == "stringTranslator":
                 val = string_decoder(to_decode, int(splitval), sign=sign)
                 if val == "Missing":
                     sign, val = "is", "Missing"
                 else:
                     val = "{ " + val + " }"
                     sign = "in"
+            else:
+                raise ValueError(f"Unsupported encoder variable_type: {variable_type!r}")
             logger.debug("Decoded split: %s %s %s", variable, sign, val)
             return f"{variable} {sign} {val}"
 
@@ -622,6 +625,7 @@ class ADMTreesModel:
 
     # Class-level dedupe so repeated per-row scoring failures don't spam logs.
     _safe_eval_seen_errors: set[tuple[str, str]] = set()
+    _safe_eval_lock: threading.Lock = threading.Lock()
 
     @staticmethod
     def _safe_condition_evaluate(
@@ -649,19 +653,20 @@ class ADMTreesModel:
             raise ValueError(f"Unsupported operator: {operator}")
         except (ValueError, TypeError) as e:
             key = (operator, type(e).__name__)
-            if key in ADMTreesModel._safe_eval_seen_errors:
-                logger.debug("Safe evaluation failed (%s %s): %s — returning False", operator, type(e).__name__, e)
-            else:
-                ADMTreesModel._safe_eval_seen_errors.add(key)
-                logger.info(
-                    "Safe scoring evaluation failed for %r %s %r: %s — returning "
-                    "False. Subsequent failures with the same operator/error "
-                    "type will be logged at DEBUG only.",
-                    value,
-                    operator,
-                    comparison_set,
-                    e,
-                )
+            with ADMTreesModel._safe_eval_lock:
+                if key in ADMTreesModel._safe_eval_seen_errors:
+                    logger.debug("Safe evaluation failed (%s %s): %s — returning False", operator, type(e).__name__, e)
+                else:
+                    ADMTreesModel._safe_eval_seen_errors.add(key)
+                    logger.info(
+                        "Safe scoring evaluation failed for %r %s %r: %s — returning "
+                        "False. Subsequent failures with the same operator/error "
+                        "type will be logged at DEBUG only.",
+                        value,
+                        operator,
+                        comparison_set,
+                        e,
+                    )
             return False
 
     # ------------------------------------------------------------------

--- a/python/tests/test_ADMTrees.py
+++ b/python/tests/test_ADMTrees.py
@@ -821,3 +821,72 @@ def test_agb_get_agb_models_with_last_uses_aggregates(agb_datamart_stub, monkeyp
     agb = AGB(agb_datamart_stub)
     agb.get_agb_models(last=True, n_threads=1)
     assert calls == ["model_data"]
+
+
+# --- Issue #659 fixes -------------------------------------------------------
+
+
+def test_decode_split_unknown_encoder_type_raises():
+    """_decode_trees raises ValueError for unknown encoder variable_type (Fix 1)."""
+    # Minimal model with one encoder of unknown type and one split referencing it.
+    # Booster path: model.boosters[0].trees  (matches _BOOSTER_PATHS[0])
+    # Encoder path: model.inputsEncoder.encoders  (fallback path in _decode_trees)
+    model_data = {
+        "model": {
+            "boosters": [{"trees": [{"split": "0 LT 1"}]}],
+            "inputsEncoder": {
+                "encoders": [
+                    {
+                        "key": "predictor_A",
+                        "value": {
+                            "index": 0,
+                            "encoder": {"unknownType": {}},
+                        },
+                    }
+                ]
+            },
+        }
+    }
+    m = ADMTreesModel.from_dict(model_data)
+    with pytest.raises(ValueError, match="Unsupported encoder variable_type: 'unknownType'"):
+        m._decode_trees()
+
+
+def test_safe_eval_warn_once_thread_safe():
+    """warn-once in _safe_condition_evaluate fires exactly once under concurrency (Fix 2)."""
+    import concurrent.futures
+    import logging
+
+    # Reset class state so this test is independent.
+    ADMTreesModel._safe_eval_seen_errors.clear()
+
+    warn_count = 0
+
+    class _CountingHandler(logging.Handler):
+        def emit(self, record):
+            nonlocal warn_count
+            if record.levelno == logging.INFO and "Safe scoring evaluation failed" in record.getMessage():
+                warn_count += 1
+
+    handler = _CountingHandler()
+    logger = logging.getLogger("pdstools.adm.ADMTrees")
+    logger.addHandler(handler)
+    original_level = logger.level
+    logger.setLevel(logging.DEBUG)
+
+    try:
+
+        def trigger():
+            # "not_a_number" can't be cast to float → TypeError/ValueError
+            ADMTreesModel._safe_condition_evaluate("not_a_number", "<", 1.0)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=20) as ex:
+            futs = [ex.submit(trigger) for _ in range(50)]
+            for f in futs:
+                f.result()
+
+        assert warn_count == 1, f"Expected exactly 1 INFO log, got {warn_count}"
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(original_level)
+        ADMTreesModel._safe_eval_seen_errors.clear()


### PR DESCRIPTION
Closes #659.

1. _get_encoder_info now raises ValueError for unknown variable_type instead of UnboundLocalError on first use.
2. _safe_eval_seen_errors check-and-add is now wrapped in a Lock so warn-once isn't flaky under concurrent scoring.