### PR TITLE
fix(decision_analyzer/plots): stop mutating self.sample_size in prio_…

### DIFF
--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -755,9 +755,9 @@ class DecisionAnalyzer:
             .item()
         )
         logger.debug("Sampling from %d total interactions", total_interaction_count)
-        # Set num_sample_interactions attribute - use sample_size if we have more interactions than sample_size
-        self.sample_size = min(total_interaction_count, self.sample_size)
-        target_sample_size = self.sample_size
+        effective_sample_size = min(total_interaction_count, self.sample_size)
+        self._num_sample_interactions = effective_sample_size
+        target_sample_size = effective_sample_size
         sample_rate = min(1.0, target_sample_size / max(1, total_interaction_count))
 
         # Use hash-based sampling for efficiency - this is deterministic per interaction ID

--- a/python/tests/test_DecisionAnalyzer.py
+++ b/python/tests/test_DecisionAnalyzer.py
@@ -803,9 +803,9 @@ class TestBoxplotPointCapAndSampling:
         )
         assert isinstance(df, pl.DataFrame)
         assert "segment" in df.columns
-        # Cannot assert exact height: prio_factor_boxplots mutates sample_size as a side
-        # effect when called by the preceding test, so the sample size seen here is
-        # non-deterministic.  See da-test-tightening-bugs.md for the bug report.
+        # The sample data has more arbitration-stage rows than sample_size (5000),
+        # so the result is capped to exactly sample_size by the point cap logic.
+        assert df.height == da_v1.sample_size
 
     def test_prio_factor_boxplots_sampling_caps_rows(self, da_v1):
         first_action = da_v1.decision_data.select("Action").first().collect().item()


### PR DESCRIPTION
…factor_boxplots

Closes #668.

The `sample` cached property in DecisionAnalyzer.py (line 759) wrote back to `self.sample_size` via:

    self.sample_size = min(total_interaction_count, self.sample_size)

This permanently reduced `sample_size` on the first access to `sample` (or any property that triggers it, including `arbitration_stage`). Every subsequent operation—plots, exports, repeated analyses—then silently used the smaller value.

Fix: replace the instance mutation with two local operations:
- `effective_sample_size = min(total_interaction_count, self.sample_size)` (local variable, never written back to `self`)
- `self._num_sample_interactions = effective_sample_size` (correctly populates the lazily-set attribute that `num_sample_interactions` property reads; the old code set `self.sample_size` instead, leaving `_num_sample_interactions` permanently unset)

Audit of decision_analyzer/plots.py:
- No `self._decision_data.<attr> =` or `self.<obj>.<attr> =` mutations found.
- Only instance assignments are `self._decision_data = decision_data` in `__init__` and a dict-key write—both correct and expected.
- The sole mutation was in DecisionAnalyzer.py's `sample` cached property.

Restore exact-height assertion in test_prio_factor_boxplots_return_df.