### PR TITLE
docs(examples): add external model score predictors section to Example_ADM_Analysis

### DIFF
--- a/examples/datamart/Example_ADM_Analysis.ipynb
+++ b/examples/datamart/Example_ADM_Analysis.ipynb
@@ -323,6 +323,121 @@
     ")\n",
     "fig.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### External model scores as ADM predictors\n",
+    "\n",
+    "When you integrate scores from third-party ML models or custom scoring pipelines\n",
+    "as ADM predictors, you may want to analyse their contribution separately from\n",
+    "native customer-profile or interaction-history predictors.\n",
+    "\n",
+    "The `apply_predictor_categorization` method lets you supply your own mapping so\n",
+    "that downstream plots automatically colour-code predictors by that label.  The\n",
+    "simplest form is a dictionary: keys become category labels and values are\n",
+    "substrings (or regular expressions when `use_regexp=True`) matched against\n",
+    "`PredictorName`.\n",
+    "\n",
+    "> **Note – simulated data:** The CDH sample dataset does not contain predictors\n",
+    "> with an external-score naming convention, so the example below re-tags the\n",
+    "> `IH` (interaction-history) predictors as *External Model Score* to illustrate\n",
+    "> the workflow.  In a real deployment you would replace `\"IH\"` with whatever\n",
+    "> prefix or pattern your external-score predictors use, for example\n",
+    "> `\"ExtScore_\"` or `\"ModelOutput.\"`, and add as many additional categories as\n",
+    "> needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Tag predictors whose names contain \"IH\" as External Model Scores.\n",
+    "# In production, replace \"IH\" with your actual naming pattern, e.g. \"ExtScore_\".\n",
+    "CDHSample.apply_predictor_categorization(\n",
+    "    categorization={\"External Model Score\": [\"IH\"]},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Feature importance: external scores vs. native predictors\n",
+    "\n",
+    "`plot.predictor_performance` renders a box-plot of predictor performance across\n",
+    "models and colours each predictor by its `PredictorCategory`, so external model\n",
+    "scores are immediately visually distinguished from native `Customer` or\n",
+    "`Primary` predictors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = CDHSample.plot.predictor_performance(top_n=20)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Lift contribution by predictor category\n",
+    "\n",
+    "`plot.predictor_contribution` shows what fraction of the overall lift each\n",
+    "category contributes per ADM configuration.  This lets you answer the question\n",
+    "*\"how much of our model's predictive power comes from external scores versus\n",
+    "our own data?\"*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = CDHSample.plot.predictor_contribution()\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Interpreting the results\n",
+    "\n",
+    "**Predictor performance** measures how well a single predictor separates\n",
+    "positives from negatives within an individual model (AUC on a 0.5–1.0 scale).\n",
+    "An external model score with performance ≥ 0.6 is already a meaningful signal;\n",
+    "above 0.7 it is a strong one.  Compare it to the native predictors in the same\n",
+    "box-plot: if the external score sits at the top, it is the dominant driver of\n",
+    "propensity for those models.\n",
+    "\n",
+    "**Lift contribution** (the bar chart) normalises performance across all active\n",
+    "predictors within a configuration and expresses each category's share as a\n",
+    "percentage.  A large *External Model Score* bar means those third-party scores\n",
+    "are carrying a disproportionate amount of the model's lift — which is fine if\n",
+    "the scores are stable and monitored, but worth flagging if data freshness or\n",
+    "availability could be a risk.\n",
+    "\n",
+    "Typical action items:\n",
+    "\n",
+    "* **High contribution, high performance** — the external score is providing\n",
+    "  real value; ensure it is refreshed regularly and has a fallback strategy for\n",
+    "  missing values.\n",
+    "* **High contribution, mediocre performance** — the native predictors are weak;\n",
+    "  consider enriching the customer profile before reducing reliance on external\n",
+    "  scores.\n",
+    "* **Low contribution** — the external score is not being used by the models;\n",
+    "  check whether it is actually active and whether the feature engineering\n",
+    "  (binning, scaling) is appropriate."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Closes #615.

Adds a new section at the end of the notebook demonstrating how to tag predictors as 'External Model Score' using apply_predictor_categorization (dict syntax), then visualise feature importance via predictor_performance (box-plot coloured by PredictorCategory) and lift contribution via predictor_contribution. Includes an interpretation guide explaining what high vs low contribution/performance means for external scores. The CDH sample data is used throughout; IH predictors are temporarily re-labelled as 'External Model Score' to simulate the workflow, with a clear note that real deployments should substitute their own naming pattern.