### PR TITLE
refactor(decision_analyzer): decouple filtered_sample from st.session_state

### DIFF
--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -784,31 +784,6 @@ class DecisionAnalyzer:
 
         return df
 
-    @property
-    def filtered_sample(self):
-        """Deprecated: use `filtered(filters)` and pass filters explicitly.
-
-        Kept as a thin alias that returns the unfiltered sample. Apps that
-        need page-level filtering should collect the relevant Polars
-        expressions in the app layer (see
-        ``pdstools.app.decision_analyzer.da_streamlit_utils.collect_page_filters``)
-        and call :meth:`filtered` instead.
-
-        Returns
-        -------
-        pl.LazyFrame
-            The unfiltered sample. Equivalent to ``self.sample``.
-        """
-        import warnings
-
-        warnings.warn(
-            "DecisionAnalyzer.filtered_sample is deprecated; "
-            "call filtered(filters) with explicit page filters instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.sample
-
     def filtered(self, filters: list[pl.Expr] | pl.Expr | None = None) -> pl.LazyFrame:
         """Return ``self.sample`` with the given filter expressions applied.
 
@@ -982,8 +957,6 @@ class DecisionAnalyzer:
 
         return distribution_data
 
-    # import streamlit as st
-    # @st.cache_data
     def get_funnel_data(
         self, scope, additional_filters: pl.Expr | list[pl.Expr] | None = None
     ) -> tuple[pl.LazyFrame, pl.DataFrame, pl.DataFrame]:

--- a/python/tests/test_decision_analyzer_filtered_sample.py
+++ b/python/tests/test_decision_analyzer_filtered_sample.py
@@ -55,13 +55,6 @@ def test_filtered_with_list_of_expressions(mock_decision_analyzer):
     assert result["Action"][0] == "A1"
 
 
-def test_filtered_sample_is_deprecated(mock_decision_analyzer, sample_data_v2):
-    """The legacy ``filtered_sample`` alias should warn but still return the sample."""
-    with pytest.warns(DeprecationWarning, match="filtered_sample is deprecated"):
-        result = mock_decision_analyzer.filtered_sample
-    assert result.collect().equals(sample_data_v2.lazy().collect())
-
-
 def test_filtered_does_not_import_streamlit(mock_decision_analyzer, monkeypatch):
     """``filtered`` must not look at Streamlit state even when it's set."""
     from pdstools.app.decision_analyzer import da_streamlit_utils


### PR DESCRIPTION
Replace the hidden st.session_state lookup in DecisionAnalyzer.filtered_sample with an explicit `extra_expr` parameter. Streamlit pages now read the page- level channel expression from session_state themselves and pass it in. The library layer no longer imports streamlit.

Closes #648.