### PR TITLE
refactor(utils): tighten typing and modernise annotations

### DIFF
--- a/python/pdstools/utils/cdh_utils.py
+++ b/python/pdstools/utils/cdh_utils.py
@@ -154,7 +154,7 @@ def default_predictor_categorization(
 
     Parameters
     ----------
-    x: Union[str, pl.Expr], default = pl.col('PredictorName')
+    x: str | pl.Expr, default = pl.col('PredictorName')
         The column to parse
 
     """
@@ -202,7 +202,7 @@ def _extract_keys(
 
     Parameters
     ----------
-    df: Union[pl.DataFrame, pl.LazyFrame]
+    df: pl.DataFrame | pl.LazyFrame
         The dataframe to extract the keys from
     key: str
         The column with embedded JSON
@@ -731,7 +731,7 @@ def from_prpc_date_time(
 
     Returns
     -------
-    Union[datetime.datetime, str]
+    datetime.datetime | str
         The converted date in datetime format or string.
 
     Examples
@@ -1419,9 +1419,9 @@ def process_files_to_bytes(
 
     Parameters
     ----------
-    file_paths : list[Union[str, Path]]
+    file_paths : list[str | Path]
         A list of file paths to process. Can be empty, contain a single path, or multiple paths.
-    base_file_name : Union[str, Path]
+    base_file_name : str | Path
         The base name to use for the output file. For a single file, this name is returned as is.
         For multiple files, this is used as part of the generated zip file name.
 
@@ -1494,7 +1494,7 @@ def setup_logger():
             return logger, existing_buffer
     log_buffer = StringIO()
     handler = logging.StreamHandler(log_buffer)
-    handler._pdstools_buffer = log_buffer  # type: ignore[attr-defined]
+    handler._pdstools_buffer = log_buffer
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%S",

--- a/python/pdstools/utils/datasets.py
+++ b/python/pdstools/utils/datasets.py
@@ -11,7 +11,7 @@ def cdh_sample(query: QUERY | None = None) -> ADMDatamart:
 
     Parameters
     ----------
-    query : Optional[QUERY], optional
+    query : QUERY | None, optional
         An optional query to apply to the data, by default None
 
     Returns
@@ -56,7 +56,7 @@ def sample_value_finder(threshold: float | None = None) -> ValueFinder:
 
     Parameters
     ----------
-    threshold : Optional[float], optional
+    threshold : float | None, optional
         Optional override of the propensity threshold in the system, by default None
 
     Returns

--- a/python/pdstools/utils/metric_limits.py
+++ b/python/pdstools/utils/metric_limits.py
@@ -12,7 +12,7 @@ values in tables.
 
 import difflib
 import re
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 from collections.abc import Callable
 
 import polars as pl
@@ -43,12 +43,13 @@ def _normalize_name(name: str) -> str:
 class MetricLimits:
     """Singleton for accessing metric limits from MetricLimits.csv."""
 
-    _instance: Optional["MetricLimits"] = None
+    _instance: "MetricLimits | None" = None
+    _limits_df: pl.DataFrame | None
 
     def __new__(cls) -> "MetricLimits":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
-            cls._instance._limits_df = None  # type: ignore[attr-defined]
+            cls._instance._limits_df = None
         return cls._instance
 
     @classmethod
@@ -63,8 +64,8 @@ class MetricLimits:
         by checking if all defined limit values are either 0.0 or 1.0.
         """
         instance = cls()
-        if getattr(instance, "_limits_df", None) is not None:
-            return instance._limits_df  # type: ignore[return-value]
+        if instance._limits_df is not None:
+            return instance._limits_df
 
         limits_df = pl.read_csv(source=get_metric_limits_path()).filter(
             pl.col("MetricID").is_not_null() & (pl.col("MetricID") != ""),
@@ -167,7 +168,7 @@ class MetricLimits:
 
         Returns
         -------
-        Optional[RAGValue]
+        RAGValue | None
             "RED", "AMBER", "GREEN", or None if metric not found or value is None.
 
         Raises

--- a/python/pdstools/utils/plot_utils.py
+++ b/python/pdstools/utils/plot_utils.py
@@ -8,7 +8,7 @@ facet-title cleanup, dynamic facet sizing, and report-layout adjustments.
 
 import logging
 import math
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import polars as pl
 
@@ -19,8 +19,12 @@ logger = logging.getLogger(__name__)
 
 # A ``go.Figure`` alias that survives the optional-plotly import path.
 # Modules use this in annotations (and as a runtime alias) so they can be
-# imported without plotly being installed.
-Figure = Union[Any, "_Figure"]
+# imported without plotly being installed. At runtime it resolves to ``Any``
+# so importers don't need plotly; type checkers see the real ``Figure``.
+if TYPE_CHECKING:  # pragma: no cover
+    Figure: TypeAlias = "_Figure"
+else:
+    Figure = Any
 
 
 # Color map used by all bin-lift plots (BinAggregator + ADM Plots).
@@ -68,7 +72,7 @@ def get_colorscale(
 
     Returns
     -------
-    Union[list[tuple[float, str]], list[str]]
+    list[tuple[float, str]] | list[str]
         A Plotly-compatible colorscale (list of (position, color) tuples or list of colors).
 
     Examples

--- a/python/pdstools/utils/report_utils.py
+++ b/python/pdstools/utils/report_utils.py
@@ -10,6 +10,7 @@ import subprocess
 import traceback
 import zipfile
 from pathlib import Path
+from typing import Any
 
 
 import polars as pl
@@ -794,7 +795,7 @@ def create_metric_itable(
     styled_df = pdf.style.apply(style_row, axis=1).format(format_dict, na_rep="")
 
     # Set default itable options
-    default_kwargs = {
+    default_kwargs: dict[str, Any] = {
         "paging": False,
         "allow_html": True,  # Required for styled DataFrames
         "classes": "compact",
@@ -820,7 +821,7 @@ def create_metric_itable(
             )
         default_kwargs["columnDefs"] = default_kwargs.get("columnDefs", []) + sort_defs
 
-    return show(styled_df, **default_kwargs)  # type: ignore[arg-type]
+    return show(styled_df, **default_kwargs)
 
 
 def create_metric_gttable(
@@ -1132,12 +1133,12 @@ def deserialize_query(serialized_query: dict | None) -> QUERY | None:
 
     Parameters
     ----------
-    serialized_query : Optional[dict]
+    serialized_query : dict | None
         A serialized query dictionary created by serialize_query
 
     Returns
     -------
-    Optional[QUERY]
+    QUERY | None
         The deserialized query
 
     """

--- a/python/pdstools/utils/show_versions.py
+++ b/python/pdstools/utils/show_versions.py
@@ -39,7 +39,7 @@ def show_versions(
 
     Returns
     -------
-    Optional[str]
+    str | None
         Version information as a string if print_output is False, else None.
 
     Examples


### PR DESCRIPTION
Strip unjustified `# type: ignore` comments, modernise PEP-604 unions, PEP-585 builtin generics, and tighten Any → concrete types where straightforward. Mirror of the typing-aggregates and typing-adm-plots sweeps.