### PR TITLE
refactor(decision_analyzer/explanations): tighten typing and modernise annotations

### DIFF
--- a/python/pdstools/explanations/Aggregate.py
+++ b/python/pdstools/explanations/Aggregate.py
@@ -2,7 +2,7 @@ __all__ = ["Aggregate"]
 
 import logging
 import pathlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import polars as pl
 
@@ -40,12 +40,14 @@ class Aggregate(LazyNamespace):
     def get_df_contextual(self) -> pl.LazyFrame:
         """Get the contextual dataframe, loading it if not already loaded."""
         self._load_data()
-        return self.df_contextual  # type: ignore[return-value]
+        assert self.df_contextual is not None
+        return self.df_contextual
 
     def get_df_overall(self) -> pl.LazyFrame:
         """Get the overall dataframe, loading it if not already loaded."""
         self._load_data()
-        return self.df_overall  # type: ignore[return-value]
+        assert self.df_overall is not None
+        return self.df_overall
 
     def get_predictor_contributions(
         self,
@@ -56,7 +58,7 @@ class Aggregate(LazyNamespace):
         """Get the top-n predictor contributions for a given context or overall.
 
         Args:
-            context (Optional[dict[str, str]]):
+            context (dict[str, str] | None):
                 The context to filter contributions by.
                 If None, contributions for all contexts will be returned.
             top_n (int):
@@ -87,7 +89,7 @@ class Aggregate(LazyNamespace):
         self._load_data()
 
         return self._get_predictor_contributions(
-            contexts=[context] if context else None,  # type: ignore[list-item]
+            contexts=cast("list[ContextInfo]", [context]) if context else None,
             limit=top_n,
             **resolved,
         )
@@ -104,7 +106,7 @@ class Aggregate(LazyNamespace):
         Args:
             predictors (list[str]): Required.
                 list of predictors to get the contributions for.
-            context (Optional[dict[str, str]]):
+            context (dict[str, str] | None):
                 The context to filter contributions by.
                 If None, contributions for all contexts will be returned.
             top_k (int):
@@ -135,7 +137,7 @@ class Aggregate(LazyNamespace):
         self._load_data()
 
         return self._get_predictor_value_contributions(
-            contexts=[context] if context else None,  # type: ignore[list-item]
+            contexts=cast("list[ContextInfo]", [context]) if context else None,
             predictors=predictors,
             limit=top_k,
             **resolved,
@@ -487,10 +489,12 @@ class Aggregate(LazyNamespace):
     ) -> pl.LazyFrame:
         if self.df_overall is None or self.df_contextual is None:
             self._load_data()
+        assert self.df_overall is not None
+        assert self.df_contextual is not None
 
         if df_filtered_contexts is None:
-            return self.df_overall  # type: ignore[return-value]
-        return self.df_contextual.join(  # type: ignore[attr-defined]
+            return self.df_overall
+        return self.df_contextual.join(
             df_filtered_contexts.lazy(),
             on=_COL.PARTITON.value,
             how="inner",

--- a/python/pdstools/explanations/ExplanationsUtils.py
+++ b/python/pdstools/explanations/ExplanationsUtils.py
@@ -19,7 +19,7 @@ import polars as pl
 from ..utils.namespaces import LazyNamespace
 
 
-def validate(top_n: int | None = None, top_k: int | None = None):
+def validate(top_n: int | None = None, top_k: int | None = None) -> None:
     """Validate the parameters for top_n and top_k."""
     if top_n:
         if not isinstance(top_n, int) or top_n <= 1:
@@ -172,8 +172,8 @@ class ContextOperations(LazyNamespace):
     Attributes
     ----------
         aggregate (Aggregate): The aggregate object.
-        _df (Optional[pl.DataFrame]): DataFrame containing context information.
-        _context_keys (Optional[list[str]]): list of context keys.
+        _df (pl.DataFrame | None): DataFrame containing context information.
+        _context_keys (list[str] | None): list of context keys.
         initialized (bool): Flag indicating if the context operations have been initialized.
 
     Methods
@@ -222,7 +222,7 @@ class ContextOperations(LazyNamespace):
 
         super().__init__()
 
-    def _load(self):
+    def _load(self) -> None:
         if self.initialized:
             return
 
@@ -243,8 +243,9 @@ class ContextOperations(LazyNamespace):
 
         self.initialized = True
 
-    def get_context_keys(self):
+    def get_context_keys(self) -> list[str]:
         self._load()
+        assert self._context_keys is not None
         return self._context_keys
 
     def get_df(
@@ -254,10 +255,11 @@ class ContextOperations(LazyNamespace):
     ) -> pl.DataFrame:
         """Get the DataFrame filtered by the provided context information."""
         self._load()
-        df = self._df if with_partition_col else self._get_clean_df(self._df)  # type: ignore[arg-type]
+        assert self._df is not None
+        df = self._df if with_partition_col else self._get_clean_df(self._df)
 
         if context_infos is None or len(context_infos) == 0:
-            return df  # type: ignore[return-value]
+            return df
 
         return self._filter_df_by_context_infos(df, context_infos)
 
@@ -274,7 +276,11 @@ class ContextOperations(LazyNamespace):
             df.unique().to_dicts(),
         )
 
-    def _filter_df_by_context_infos(self, df, context_infos):
+    def _filter_df_by_context_infos(
+        self,
+        df: pl.DataFrame,
+        context_infos: list[ContextInfo],
+    ) -> pl.DataFrame:
         ret_df = pl.DataFrame()
 
         filter_expressions = self._get_filter_expression(context_infos)
@@ -283,10 +289,14 @@ class ContextOperations(LazyNamespace):
         return ret_df
 
     @staticmethod
-    def _get_filter_expression(context_infos):
-        expressions = []
+    def _get_filter_expression(
+        context_infos: list[ContextInfo],
+    ) -> list[list[pl.Expr]]:
+        expressions: list[list[pl.Expr]] = []
         for context_info in context_infos:
-            expr = [pl.col(column_name) == column_value for column_name, column_value in context_info.items()]
+            expr: list[pl.Expr] = [
+                pl.col(column_name).eq(column_value) for column_name, column_value in context_info.items()
+            ]
             expressions.append(expr)
         return expressions
 

--- a/python/pdstools/explanations/FilterWidget.py
+++ b/python/pdstools/explanations/FilterWidget.py
@@ -63,7 +63,7 @@ class FilterWidget(LazyNamespace):
         """Set the selected context information.
 
         Args:
-            context_info (Optional[ContextInfo]):
+            context_info (ContextInfo | None):
                 If None, initializes the selected context with 'Any' for all keys.
                 i.e overall model contributions
                 If provided, sets the selected context to the given context information.
@@ -163,7 +163,7 @@ class FilterWidget(LazyNamespace):
         ctx_options = {
             ctx_key_name: [self._ANY_CONTEXT]
             + sorted(
-                set(context_info[ctx_key_name] for context_info in self._filtered_list),  # type: ignore[literal-required]
+                set(cast("dict[str, str]", context_info)[ctx_key_name] for context_info in self._filtered_list),
             )
             for ctx_key_name in (self._selected_context_key or {}).keys()
         }
@@ -262,9 +262,9 @@ class FilterWidget(LazyNamespace):
         options = [self._ANY_CONTEXT] if with_any_option else []
 
         options_list_sorted = sorted(
-            set(context_info[name] for context_info in self._filtered_list),  # type: ignore[literal-required]
+            set(cast("dict[str, str]", context_info)[name] for context_info in self._filtered_list),
         )
-        options += cast("list[str]", options_list_sorted)
+        options += options_list_sorted
         return options
 
     def _get_options_for_context_selector(
@@ -281,8 +281,9 @@ class FilterWidget(LazyNamespace):
     def _filter_contexts_by_selected(self) -> list[ContextInfo]:
         filtered_context_infos = []
         for context_info in self._raw_list:
+            ctx_dict = cast("dict[str, str]", context_info)
             if all(
-                value == self._ANY_CONTEXT or context_info[key] == value  # type: ignore[literal-required]
+                value == self._ANY_CONTEXT or ctx_dict[key] == value
                 for key, value in (self._selected_context_key or {}).items()
             ):
                 filtered_context_infos.append(context_info)

--- a/python/pdstools/explanations/Plots.py
+++ b/python/pdstools/explanations/Plots.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 __all__ = ["Plots"]
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import polars as pl
 
@@ -181,14 +181,14 @@ class Plots(LazyNamespace):
             **resolved,
         )
 
-        header_fig = self._plot_context_table(context)  # type: ignore[arg-type]
+        header_fig = self._plot_context_table(cast("ContextInfo", context))
 
         overall_fig = self._plot_overall_contributions(
             df_context,
             x_col=display_by.value,
             y_col=_COL.PREDICTOR_NAME.value,
             x_title=display_by.alt,
-            context=context,  # type: ignore[arg-type]
+            context=cast("ContextInfo", context),
         )
 
         predictors_figs = self._plot_predictor_contributions(

--- a/python/pdstools/explanations/Preprocess.py
+++ b/python/pdstools/explanations/Preprocess.py
@@ -218,8 +218,9 @@ class Preprocess(LazyNamespace):
     def _agg_in_batches(self, predictor_type: _PREDICTOR_TYPE):
         if self.contexts is None:
             self._get_contexts(predictor_type=predictor_type)
+        assert self.contexts is not None
 
-        for file_batch_nb, query_batches in self.contexts.items():  # type: ignore[union-attr]
+        for file_batch_nb, query_batches in self.contexts.items():
             self._parquet_in_batches(file_batch_nb, query_batches, predictor_type)
 
         logger.info("Processed all batches for %s", predictor_type)
@@ -469,7 +470,9 @@ class Preprocess(LazyNamespace):
 
         try:
             df = read_ds_export(filename=filename, path=base_path)
-            df.collect().write_parquet(local_path)  # type: ignore[union-attr]
+            if df is None:
+                raise ValueError(f"Failed to download file from {file_url}: no data returned")
+            df.collect().write_parquet(local_path)
             self.selected_files = [str(local_path)]
             logger.info("Downloaded file:= \n %s", self.selected_files)
         except Exception as e:

--- a/python/pdstools/explanations/Reports.py
+++ b/python/pdstools/explanations/Reports.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import yaml  # type: ignore[import-untyped]
+import yaml  # type: ignore[import-untyped]  # types-PyYAML not in project deps
 
 from ..utils.namespaces import LazyNamespace
 from ..utils.report_utils import (


### PR DESCRIPTION
Strip unjustified `# type: ignore` comments, modernise PEP-604 unions and PEP-585 builtin generics, tighten Any → concrete types where straightforward. Mirror of the typing-aggregates and typing-adm-plots sweeps.