### PR TITLE
refactor(ih): tighten typing and modernise annotations

### DIFF
--- a/python/pdstools/ih/Aggregates.py
+++ b/python/pdstools/ih/Aggregates.py
@@ -1,5 +1,6 @@
 """Aggregation methods for Interaction History analysis."""
 
+from collections.abc import Sequence
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -58,7 +59,7 @@ class Aggregates(LazyNamespace):
 
     def summarize_by_interaction(
         self,
-        by: str | list[str] | pl.Expr | None = None,
+        by: str | Sequence[str | pl.Expr] | pl.Expr | None = None,
         every: str | timedelta | None = None,
         query: QUERY | None = None,
         debug: bool = False,
@@ -113,10 +114,14 @@ class Aggregates(LazyNamespace):
         else:
             source = self.ih.data
 
-        if not isinstance(by, list):
-            by = [by] if by is not None else []  # type: ignore[list-item]
-        by_pl_exprs: list[str | pl.Expr] = [x for x in by if isinstance(x, pl.Expr)]
-        by_non_pl_exprs = [x for x in by if not isinstance(x, pl.Expr)]
+        if by is None:
+            by_seq: list[str | pl.Expr] = []
+        elif isinstance(by, (str, pl.Expr)):
+            by_seq = [by]
+        else:
+            by_seq = list(by)
+        by_pl_exprs: list[str | pl.Expr] = [x for x in by_seq if isinstance(x, pl.Expr)]
+        by_non_pl_exprs = [x for x in by_seq if not isinstance(x, pl.Expr)]
         group_by_clause = cdh_utils.safe_flatten_list(
             by_non_pl_exprs + (["OutcomeTime"] if every is not None else []),
             by_pl_exprs,
@@ -228,7 +233,7 @@ class Aggregates(LazyNamespace):
 
     def summary_success_rates(
         self,
-        by: str | list[str] | pl.Expr | None = None,
+        by: str | Sequence[str | pl.Expr] | pl.Expr | None = None,
         every: str | timedelta | None = None,
         query: QUERY | None = None,
         debug: bool = False,
@@ -285,10 +290,14 @@ class Aggregates(LazyNamespace):
         >>> ih.aggregates.summary_success_rates(by="Channel", every="1w").collect()
 
         """
-        if not isinstance(by, list):
-            by = [by] if by is not None else []  # type: ignore[list-item]
-        by_pl_exprs: list[str] = [x.meta.output_name() for x in by if isinstance(x, pl.Expr)]  # type: ignore[attr-defined]
-        by_non_pl_exprs = [x for x in by if not isinstance(x, pl.Expr)]
+        if by is None:
+            by_seq: list[str | pl.Expr] = []
+        elif isinstance(by, (str, pl.Expr)):
+            by_seq = [by]
+        else:
+            by_seq = list(by)
+        by_pl_exprs: list[str] = [x.meta.output_name() for x in by_seq if isinstance(x, pl.Expr)]
+        by_non_pl_exprs = [x for x in by_seq if not isinstance(x, pl.Expr)]
         group_by_clause = cdh_utils.safe_flatten_list(
             by_pl_exprs + by_non_pl_exprs + (["OutcomeTime"] if every is not None else []),
         )
@@ -346,7 +355,7 @@ class Aggregates(LazyNamespace):
 
     def summary_outcomes(
         self,
-        by: str | list[str] | pl.Expr | None = None,
+        by: str | Sequence[str | pl.Expr] | pl.Expr | None = None,
         every: str | timedelta | None = None,
         query: QUERY | None = None,
     ) -> pl.LazyFrame:
@@ -388,10 +397,14 @@ class Aggregates(LazyNamespace):
         else:
             source = self.ih.data
 
-        if not isinstance(by, list):
-            by = [by] if by is not None else []  # type: ignore[list-item]
-        by_pl_exprs: list[str | pl.Expr] = [x for x in by if isinstance(x, pl.Expr)]
-        by_non_pl_exprs = [x for x in by if not isinstance(x, pl.Expr)]
+        if by is None:
+            by_seq: list[str | pl.Expr] = []
+        elif isinstance(by, (str, pl.Expr)):
+            by_seq = [by]
+        else:
+            by_seq = list(by)
+        by_pl_exprs: list[str | pl.Expr] = [x for x in by_seq if isinstance(x, pl.Expr)]
+        by_non_pl_exprs = [x for x in by_seq if not isinstance(x, pl.Expr)]
         group_by_clause = cdh_utils.safe_flatten_list(
             ["Outcome"] + by_non_pl_exprs + (["OutcomeTime"] if every is not None else []),
             by_pl_exprs,

--- a/python/pdstools/ih/IH.py
+++ b/python/pdstools/ih/IH.py
@@ -120,9 +120,9 @@ class IH:
 
         Parameters
         ----------
-        ih_filename : Union[os.PathLike, str]
+        ih_filename : os.PathLike or str
             Path to the dataset export file (parquet, csv, ndjson, or zip).
-        query : Optional[QUERY], optional
+        query : QUERY, optional
             Polars expression to filter the data. Default is None.
 
         Returns
@@ -555,7 +555,7 @@ class IH:
 
         Returns
         -------
-        dict[tuple[str, ...], Union[float, dict]]
+        dict[tuple[str, ...], float | dict]
             PMI scores for sequences:
             - Bigrams: Direct PMI value (float)
             - N-grams (n≥3): dict with 'average_pmi' and 'links' (constituent bigram PMIs)
@@ -630,7 +630,7 @@ class IH:
 
         Parameters
         ----------
-        ngrams_pmi : dict[tuple[str, ...], Union[float, dict]]
+        ngrams_pmi : dict[tuple[str, ...], float | dict]
             PMI scores from :meth:`calculate_pmi`.
         count_sequences : list[defaultdict]
             Sequence frequency counts from :meth:`get_sequences`.
@@ -669,8 +669,10 @@ class IH:
         freq_all = count_sequences[1] | count_sequences[2]
 
         for seq, pmi_val in ngrams_pmi.items():
-            if len(seq) > 2:
-                pmi_val = pmi_val["average_pmi"]  # type: ignore[index]
+            if isinstance(pmi_val, dict):
+                avg_pmi: float = pmi_val["average_pmi"]
+            else:
+                avg_pmi = pmi_val
 
             count = freq_all.get(seq, 0)
 
@@ -681,10 +683,10 @@ class IH:
                 {
                     "Sequence": seq,
                     "Length": len(seq),
-                    "Avg PMI": pmi_val,
+                    "Avg PMI": avg_pmi,
                     "Frequency": count,
                     "Unique freq": count_sequences[3][seq],
-                    "Score": pmi_val * math.log(count),  # type: ignore[operator]
+                    "Score": avg_pmi * math.log(count),
                 },
             )
 

--- a/python/pdstools/ih/Plots.py
+++ b/python/pdstools/ih/Plots.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import polars as pl
 
@@ -83,7 +83,7 @@ class Plots(LazyNamespace):
 
         Parameters
         ----------
-        condition : Union[str, pl.Expr]
+        condition : str or pl.Expr
             Column to condition on (e.g., "Experiment", "Issue").
         metric : str, default "Engagement"
             Metric to display: "Engagement", "Conversion", or "OpenRate".
@@ -111,7 +111,7 @@ class Plots(LazyNamespace):
         from plotly.subplots import make_subplots
 
         plot_data = self.ih.aggregates.summary_success_rates(
-            by=[condition, by],  # type: ignore[list-item]
+            by=[condition, by],
             query=query,
         )
 
@@ -126,9 +126,9 @@ class Plots(LazyNamespace):
         df = plot_data.collect()
 
         cols = df[by].unique().shape[0]  # TODO can be None
-        rows = (
-            df[condition].unique().shape[0]  # type: ignore[index]
-        )  # TODO generalize to support pl expression, see ADM plots, eg facet in bubble chart
+        # TODO generalize to support pl expression, see ADM plots, eg facet in bubble chart
+        condition_col = cast(str, condition)
+        rows = df[condition_col].unique().shape[0]
 
         fig = make_subplots(
             rows=rows,
@@ -171,7 +171,7 @@ class Plots(LazyNamespace):
                 number={"valueformat": ",.2%"},
                 value=row[f"SuccessRate_{metric}"],
                 delta={"reference": ref_value, "valueformat": ",.2%"},
-                title={"text": f"{row[by]}: {row[condition]}"},  # type: ignore[index]
+                title={"text": f"{row[by]}: {row[condition_col]}"},
                 gauge=gauge,
             )
             r, c = divmod(index, cols)
@@ -387,7 +387,7 @@ class Plots(LazyNamespace):
 
         """
         plot_data = self.ih.aggregates.summary_outcomes(
-            by=[by, color, facet],  # type: ignore[list-item]
+            by=[c for c in [by, color, facet] if c is not None],
             query=query,
         )
 


### PR DESCRIPTION
Strip unjustified `# type: ignore` comments, modernise PEP-604 unions and PEP-585 builtin generics, and tighten by-parameter typing in Aggregates. Mirror of typing-utils-cleanup and typing-explanations-cleanup.