### PR TITLE
refactor(impactanalyzer): align with gold-standard pattern

### DIFF
--- a/python/pdstools/impactanalyzer/ImpactAnalyzer.py
+++ b/python/pdstools/impactanalyzer/ImpactAnalyzer.py
@@ -1,24 +1,27 @@
 import json
+import logging
 import os
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, Optional, Union, overload
-from collections.abc import Callable
+from typing import Literal, overload
 
 import polars as pl
 import polars.selectors as cs
 
 from ..pega_io.File import read_ds_export
-from ..utils.pega_outcomes import resolve_outcome_labels as _resolve_outcome_labels
 from ..utils.cdh_utils import (
     _apply_query,
     _polars_capitalize,
     parse_pega_date_time_formats,
     weighted_average_polars,
 )
+from ..utils.pega_outcomes import resolve_outcome_labels as _resolve_outcome_labels
 from ..utils.types import QUERY
 from .Plots import Plots
+from .Schema import REQUIRED_IA_COLUMNS
+
+logger = logging.getLogger(__name__)
 
 
 class ImpactAnalyzer:
@@ -146,21 +149,36 @@ class ImpactAnalyzer:
 
         """
         self.plot = Plots(ia=self)
-
-        required_cols = [
-            "SnapshotTime",
-            "ControlGroup",
-            "Impressions",
-            "Accepts",
-            "ValuePerImpression",
-            "Channel",
-        ]
-        missing_cols = set(required_cols).difference(raw_data.collect_schema().names())
-        if len(missing_cols) > 0:
-            raise ValueError(f"Missing required columns: {missing_cols}")
-
-        self.ia_data = raw_data
+        self.ia_data = self._validate_ia_data(raw_data)
         self.outcome_labels_used = None
+
+    @staticmethod
+    def _validate_ia_data(df: pl.LazyFrame) -> pl.LazyFrame:
+        """Validate that the input frame has the required Impact Analyzer columns.
+
+        Mirrors the ``_validate_*_data`` pattern used by
+        :class:`pdstools.adm.ADMDatamart`.
+
+        Parameters
+        ----------
+        df : pl.LazyFrame
+            Pre-processed experiment data.
+
+        Returns
+        -------
+        pl.LazyFrame
+            The same frame, unchanged, once validation passes.
+
+        Raises
+        ------
+        ValueError
+            If any column listed in
+            :data:`pdstools.impactanalyzer.Schema.REQUIRED_IA_COLUMNS` is absent.
+        """
+        missing_cols = set(REQUIRED_IA_COLUMNS).difference(df.collect_schema().names())
+        if missing_cols:
+            raise ValueError(f"Missing required columns: {missing_cols}")
+        return df
 
     # When return_wide_df=True, always returns LazyFrame
     @classmethod
@@ -208,7 +226,7 @@ class ImpactAnalyzer:
         query: QUERY | None = None,
         return_wide_df: bool = False,
         return_df: bool = False,
-    ) -> Union["ImpactAnalyzer", pl.LazyFrame]:
+    ) -> "ImpactAnalyzer | pl.LazyFrame":
         """Create an ImpactAnalyzer instance from PDC JSON export(s).
 
         Loads pre-aggregated experiment data from Pega Decision Central JSON exports.
@@ -346,7 +364,7 @@ class ImpactAnalyzer:
         *,
         outcome_labels: dict | None = None,
         return_df: bool = False,
-    ) -> Union["ImpactAnalyzer", pl.LazyFrame, None]:
+    ) -> "ImpactAnalyzer | pl.LazyFrame | None":
         """Create an ImpactAnalyzer instance from VBD data.
 
         Processes VBD Actuals or Scenario Planner Actuals data to reconstruct
@@ -487,7 +505,7 @@ class ImpactAnalyzer:
     def from_ih(
         cls,
         ih_source: os.PathLike | str,
-    ) -> Optional["ImpactAnalyzer"]: ...
+    ) -> "ImpactAnalyzer | None": ...
 
     @classmethod
     def from_ih(
@@ -495,7 +513,7 @@ class ImpactAnalyzer:
         ih_source: os.PathLike | str,
         *,
         return_df: bool = False,
-    ) -> Union["ImpactAnalyzer", pl.LazyFrame, None]:
+    ) -> "ImpactAnalyzer | pl.LazyFrame | None":
         """Create an ImpactAnalyzer instance from Interaction History data.
 
         .. note::
@@ -745,7 +763,7 @@ class ImpactAnalyzer:
         sheet_name: str | int | None = None,
         query: QUERY | None = None,
         return_df: bool = False,
-    ) -> Union["ImpactAnalyzer", pl.LazyFrame]:
+    ) -> "ImpactAnalyzer | pl.LazyFrame":
         """Create an ImpactAnalyzer instance from a PDC Excel export.
 
         Reads a wide-format Excel file produced by Pega Decision Central and
@@ -965,10 +983,10 @@ class ImpactAnalyzer:
         """
         if by is None:
             group_by: list[str | pl.Expr] = []
-        elif isinstance(by, (list, tuple)):
-            group_by = list(by)
+        elif isinstance(by, (str, pl.Expr)):
+            group_by = [by]
         else:
-            group_by = [by]  # type: ignore[list-item]
+            group_by = list(by)
 
         agg_exprs = [
             pl.sum("Impressions", "Accepts"),

--- a/python/pdstools/impactanalyzer/Plots.py
+++ b/python/pdstools/impactanalyzer/Plots.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 import polars as pl
 
@@ -116,6 +116,28 @@ class Plots(LazyNamespace):
             return {"facet_col": facet, "facet_col_wrap": 2}
         return {"facet_col": facet, "facet_col_wrap": 3}
 
+    @overload
+    def overview(
+        self,
+        *,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        metric: str = ...,
+        facet: str | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def overview(
+        self,
+        *,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        metric: str = ...,
+        facet: str | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
+
     def overview(
         self,
         *,
@@ -209,6 +231,30 @@ class Plots(LazyNamespace):
 
         return fig
 
+    @overload
+    def control_groups_trend(
+        self,
+        *,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        metric: str = ...,
+        facet: str | None = ...,
+        every: str | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def control_groups_trend(
+        self,
+        *,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        metric: str = ...,
+        facet: str | None = ...,
+        every: str | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
+
     def control_groups_trend(
         self,
         *,
@@ -257,10 +303,11 @@ class Plots(LazyNamespace):
         >>> ia.plot.control_groups_trend(facet="Channel", every="1mo")
 
         """
+        grouping_columns: list[str | pl.Expr]
         if every is not None:
             grouping_columns = [pl.col("SnapshotTime").dt.truncate(every)] + ([facet] if facet is not None else [])
         else:
-            grouping_columns: list[str | pl.Expr] = ["SnapshotTime"] + ([facet] if facet is not None else [])  # type: ignore[no-redef]
+            grouping_columns = ["SnapshotTime"] + ([facet] if facet is not None else [])
 
         plot_data = self.ia.summarize_control_groups(by=grouping_columns).filter(
             pl.col(metric).is_not_null() & pl.col(metric).is_finite(),
@@ -305,6 +352,30 @@ class Plots(LazyNamespace):
         fig.update_xaxes(title="")
 
         return fig
+
+    @overload
+    def trend(
+        self,
+        *,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        metric: str = ...,
+        facet: str | None = ...,
+        every: str | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def trend(
+        self,
+        *,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        metric: str = ...,
+        facet: str | None = ...,
+        every: str | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
 
     def trend(
         self,
@@ -353,10 +424,11 @@ class Plots(LazyNamespace):
         >>> ia.plot.trend(facet="Channel", every="1mo")
 
         """
+        grouping_columns: list[str | pl.Expr]
         if every is not None:
             grouping_columns = [pl.col("SnapshotTime").dt.truncate(every)] + ([facet] if facet is not None else [])
         else:
-            grouping_columns: list[str | pl.Expr] = ["SnapshotTime"] + ([facet] if facet is not None else [])  # type: ignore[no-redef]
+            grouping_columns = ["SnapshotTime"] + ([facet] if facet is not None else [])
 
         plot_data = self.ia.summarize_experiments(by=grouping_columns).filter(
             pl.col(metric).is_not_null() & pl.col(metric).is_finite(),

--- a/python/pdstools/impactanalyzer/Schema.py
+++ b/python/pdstools/impactanalyzer/Schema.py
@@ -1,0 +1,57 @@
+"""Schema definitions for Impact Analyzer experiment data.
+
+These classes mirror the convention used by ``pdstools.adm.Schema`` and document
+the columns expected by :class:`ImpactAnalyzer`. Required columns are validated
+in :meth:`ImpactAnalyzer._validate_ia_data`; optional columns (e.g. those
+prefixed with ``Pega_``) are populated only by some data sources.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+class ImpactAnalyzerData:
+    """Normalised long-format experiment data consumed by :class:`ImpactAnalyzer`.
+
+    Required columns
+    ----------------
+    SnapshotTime : pl.Datetime | pl.Date
+        Snapshot date for the row.
+    ControlGroup : pl.Utf8
+        Control / test group identifier (e.g. ``"NBA"``, ``"PropensityPriority"``).
+    Impressions : numeric
+        Impression count.
+    Accepts : numeric
+        Accept count.
+    ValuePerImpression : pl.Float64
+        Average per-impression value (may be null for PDC data).
+    Channel : pl.Utf8
+        Channel name (or ``Channel/Direction`` for VBD data).
+
+    Optional columns
+    ----------------
+    Pega_ValueLift, Pega_ValueLiftInterval : pl.Float64
+        Pre-computed lift values present only in PDC exports.
+    """
+
+    SnapshotTime = pl.Datetime
+    ControlGroup = pl.Utf8
+    Impressions = pl.Float64
+    Accepts = pl.Float64
+    ValuePerImpression = pl.Float64
+    Channel = pl.Utf8
+
+    Pega_ValueLift = pl.Float64
+    Pega_ValueLiftInterval = pl.Float64
+
+
+REQUIRED_IA_COLUMNS: tuple[str, ...] = (
+    "SnapshotTime",
+    "ControlGroup",
+    "Impressions",
+    "Accepts",
+    "ValuePerImpression",
+    "Channel",
+)
+"""Columns that must be present on the LazyFrame passed to :class:`ImpactAnalyzer`."""

--- a/python/tests/test_ADMDatamart.py
+++ b/python/tests/test_ADMDatamart.py
@@ -384,6 +384,7 @@ def test_from_s3_model_only(monkeypatch):
     assert dm.model_data is not None
     assert dm.predictor_data is None
 
+
 # ---------------------------------------------------------------------------
 # Helper-method unit tests (synthetic minimal fixtures, exact-value assertions)
 # ---------------------------------------------------------------------------

--- a/python/tests/test_ImpactAnalyzer.py
+++ b/python/tests/test_ImpactAnalyzer.py
@@ -768,3 +768,107 @@ def test_from_excel_query_filter():
 def test_from_excel_outcome_labels_unused(excel_ia):
     """Excel (PDC-equivalent) data has no raw outcome labels — outcome_labels_used is None."""
     assert excel_ia.outcome_labels_used is None
+
+
+# ---------------------------------------------------------------------------
+# Schema validation helpers (gold-standard alignment)
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_ia_lf() -> pl.LazyFrame:
+    """Build a minimal valid Impact Analyzer LazyFrame for validation tests."""
+    import datetime as _dt
+
+    return pl.LazyFrame(
+        {
+            "SnapshotTime": [_dt.datetime(2024, 1, 1)],
+            "ControlGroup": ["NBA"],
+            "Impressions": [100.0],
+            "Accepts": [10.0],
+            "ValuePerImpression": [1.5],
+            "Channel": ["Web"],
+        }
+    )
+
+
+def test_validate_ia_data_accepts_valid_frame():
+    """_validate_ia_data returns the frame unchanged when all required cols are present."""
+    lf = _make_minimal_ia_lf()
+    result = ImpactAnalyzer._validate_ia_data(lf)
+    assert result is lf
+    # Round-trip preserves the row count and column set exactly.
+    df = result.collect()
+    assert df.height == 1
+    assert set(df.columns) == {
+        "SnapshotTime",
+        "ControlGroup",
+        "Impressions",
+        "Accepts",
+        "ValuePerImpression",
+        "Channel",
+    }
+
+
+def test_validate_ia_data_missing_single_column():
+    """Missing a single required column is reported in the error message."""
+    lf = _make_minimal_ia_lf().drop("Channel")
+    with pytest.raises(ValueError) as exc:
+        ImpactAnalyzer._validate_ia_data(lf)
+    assert "Channel" in str(exc.value)
+    assert "Missing required columns" in str(exc.value)
+
+
+def test_validate_ia_data_missing_multiple_columns():
+    """All missing required columns are listed in the error."""
+    lf = _make_minimal_ia_lf().drop("Channel", "Accepts")
+    with pytest.raises(ValueError) as exc:
+        ImpactAnalyzer._validate_ia_data(lf)
+    msg = str(exc.value)
+    assert "Channel" in msg
+    assert "Accepts" in msg
+
+
+def test_init_invokes_validation():
+    """ImpactAnalyzer(...) raises when required columns are missing."""
+    lf = _make_minimal_ia_lf().drop("ValuePerImpression")
+    with pytest.raises(ValueError, match="ValuePerImpression"):
+        ImpactAnalyzer(lf)
+
+
+def test_init_pure_no_extra_columns_added():
+    """__init__ stores the raw LazyFrame unchanged — no implicit IO or rewrites."""
+    lf = _make_minimal_ia_lf()
+    ia = ImpactAnalyzer(lf)
+    # No extra columns should have been injected by __init__.
+    assert ia.ia_data.collect().columns == lf.collect().columns
+    assert ia.outcome_labels_used is None
+
+
+def test_required_columns_constant_matches_init_check():
+    """REQUIRED_IA_COLUMNS is the single source of truth used by validation."""
+    from pdstools.impactanalyzer.Schema import REQUIRED_IA_COLUMNS
+
+    assert set(REQUIRED_IA_COLUMNS) == {
+        "SnapshotTime",
+        "ControlGroup",
+        "Impressions",
+        "Accepts",
+        "ValuePerImpression",
+        "Channel",
+    }
+
+
+def test_summarize_control_groups_with_single_str_by(simple_ia):
+    """A single string `by=` (the branch that previously needed `# type: ignore`) works."""
+    result = simple_ia.summarize_control_groups(by="Channel").collect()
+    assert "Channel" in result.columns
+    assert "ControlGroup" in result.columns
+    # Each (Channel, ControlGroup) pair should appear exactly once.
+    assert result.height == result.select("Channel", "ControlGroup").unique().height
+
+
+def test_summarize_control_groups_with_pl_expr_by(simple_ia):
+    """A single pl.Expr `by=` is correctly wrapped into a list."""
+    result = simple_ia.summarize_control_groups(by=pl.col("Channel")).collect()
+    assert "Channel" in result.columns
+    assert "ControlGroup" in result.columns


### PR DESCRIPTION
Bring impactanalyzer/ in line with the ADMDatamart gold-standard checklist documented in AGENTS.md.

- New Schema.py declaring ImpactAnalyzerData column types and the REQUIRED_IA_COLUMNS tuple, mirroring adm/Schema.py.
- Extract column validation from ImpactAnalyzer.__init__ into a new static helper _validate_ia_data(), driven by REQUIRED_IA_COLUMNS. __init__ stays pure (no I/O); validation is reusable and testable.
- Add module-level logger = logging.getLogger(__name__) to ImpactAnalyzer.py (Plots.py already had one).
- Drop # type: ignore[list-item] in summarize_control_groups by reordering the isinstance branch so the str|pl.Expr case is matched before the iterable case (the previous order forced an unsafe wrap).
- Drop two # type: ignore[no-redef] markers in Plots.py by hoisting the grouping_columns annotation above the if/else.
- Add @overload stubs for return_df: Literal[True]/Literal[False] on Plots.overview / control_groups_trend / trend so callers get the correct narrowed return type (Figure vs pl.LazyFrame).
- Replace remaining typing.Optional / typing.Union usages in code signatures with PEP 604 unions; remove the now-unused imports.
- Add 8 exact-value unit tests covering _validate_ia_data, the REQUIRED_IA_COLUMNS contract, __init__ purity, and the previously type-ignored single-str / single-Expr by= branches in summarize_control_groups.

41 tests pass (33 previously, 8 new).