### PR TITLE
refactor(explanations): align with gold-standard pattern

### DIFF
--- a/docs/plans/explanations/README.md
+++ b/docs/plans/explanations/README.md
@@ -1,0 +1,13 @@
+# Explanations module — TODO
+
+This directory holds one Markdown file per open follow-up item for the
+`python/pdstools/explanations/` module.
+
+When you resolve an item, `git rm` the file in the same PR. The deletion
+is the audit trail.
+
+## Listing open items
+
+```
+ls docs/plans/explanations/
+```

--- a/docs/plans/explanations/contextops-own-module.md
+++ b/docs/plans/explanations/contextops-own-module.md
@@ -1,0 +1,23 @@
+# Move `ContextOperations` to its own module
+
+**Priority:** P3
+**Files:** `python/pdstools/explanations/ExplanationsUtils.py` (split),
+new `python/pdstools/explanations/ContextOperations.py`
+
+## Problem
+
+`ContextOperations` is a stateful `LazyNamespace` subclass with ~80
+lines of behaviour, currently buried in `ExplanationsUtils.py`
+alongside enums, `TypedDict`s, and kwarg-resolver helpers. The grab-bag
+module mixes types/utility functions with a class that has its own
+lifecycle. This makes `ExplanationsUtils.py` harder to navigate and
+hides the existence of the class from imports.
+
+## Proposed approach
+
+1. Move `ContextOperations` (and the `ContextInfo` `TypedDict` it uses)
+   into `python/pdstools/explanations/ContextOperations.py`.
+2. Keep `_COL`, `_PREDICTOR_TYPE`, `_TABLE_NAME`, `_CONTRIBUTION_TYPE`,
+   `_SPECIAL`, and the `_resolve_*_filter_kwargs` helpers in
+   `ExplanationsUtils.py` (or split enums into `Schema.py`-style file).
+3. Re-export from `ExplanationsUtils` for one release for back-compat.

--- a/docs/plans/explanations/io-out-of-init.md
+++ b/docs/plans/explanations/io-out-of-init.md
@@ -1,0 +1,35 @@
+# Move IO out of `Explanations.__init__` into `from_<source>` classmethods
+
+**Priority:** P2
+**Files:** `python/pdstools/explanations/Explanations.py`,
+`python/pdstools/explanations/Preprocess.py`
+
+## Problem
+
+`Explanations(...)` triggers `Preprocess(explanations=self)` from its
+`__init__`, which immediately runs `self.generate()` — scanning the
+parquet folder, opening DuckDB, and writing aggregate parquet files.
+This violates the gold-standard rule "I/O lives in classmethods, not
+`__init__`" (see `AGENTS.md`).
+
+Side effects:
+
+- Cannot construct the object cheaply for testing or reflection.
+- The class is hard to drive from already-loaded `pl.LazyFrame`s.
+- `data_file` / `data_folder` arguments do double duty (config +
+  IO trigger), making it unclear when work happens.
+
+## Proposed approach
+
+1. Make `__init__` pure — accept already-prepared aggregates (or `None`)
+   plus configuration (`from_date`, `to_date`, `model_name`).
+2. Add classmethods mirroring `ADMDatamart.from_ds_export` /
+   `from_s3` patterns:
+   - `Explanations.from_explanations_folder(data_folder, ...)` —
+     current default behaviour.
+   - `Explanations.from_explanation_file(data_file, ...)` — current
+     `data_file` path.
+   - `Explanations.from_aggregates(aggregates_dir, ...)` — bypass
+     preprocessing entirely (re-open an already-aggregated dir).
+3. Keep the legacy constructor signature working with a deprecation
+   warning for one release.

--- a/docs/plans/explanations/typed-filter-kwargs.md
+++ b/docs/plans/explanations/typed-filter-kwargs.md
@@ -1,0 +1,33 @@
+# Replace `**filter_kwargs` with explicit typed parameters
+
+**Priority:** P3
+**Files:** `python/pdstools/explanations/Plots.py`,
+`python/pdstools/explanations/Aggregate.py`,
+`python/pdstools/explanations/Reports.py`,
+`python/pdstools/explanations/ExplanationsUtils.py`
+
+## Problem
+
+Public methods (`Plots.contributions`,
+`Aggregate.get_predictor_contributions`,
+`Aggregate.get_predictor_value_contributions`,
+`Reports.generate`) all accept `**filter_kwargs` and dispatch through
+`_resolve_agg_filter_kwargs` / `_resolve_plot_filter_kwargs` for
+validation. This:
+
+- Hides the parameter list from IDE tooltips, sphinx, and overload
+  type-checking.
+- Pushes validation into a runtime helper instead of the function
+  signature itself.
+- Makes refactoring fragile — adding a new key requires editing the
+  resolver, the docstring on every method, and chasing all callers.
+
+## Proposed approach
+
+Promote the resolved keys
+(`sort_by`, `display_by`, `descending`, `missing`, `remaining`,
+`include_numeric_single_bin`) to explicit keyword-only parameters with
+literal defaults on each public method, per the AGENTS.md "keep
+parameter surfaces small" / "use Python's built-in defaults" rules.
+Drop the resolver helpers and validate `sort_by`/`display_by` with a
+small `Literal[...]` type alias plus an inline check.

--- a/python/pdstools/explanations/Plots.py
+++ b/python/pdstools/explanations/Plots.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 __all__ = ["Plots"]
 
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast, overload
 
 import polars as pl
 
@@ -40,6 +40,8 @@ class Plots(LazyNamespace):
         self,
         top_n: int = 20,
         top_k: int = 20,
+        *,
+        return_df: bool = False,
         **filter_kwargs,
     ):
         """Plots contributions for the overall model or a selected context.
@@ -49,6 +51,11 @@ class Plots(LazyNamespace):
                 Number of top predictors to display.
             top_k (int):
                 Number of top unique values for each categorical predictor to display.
+            return_df (bool, keyword-only):
+                If True, skip plotting and return the underlying dataframes instead.
+                When a context is selected, returns
+                ``(predictor_df, predictor_value_df)``; otherwise returns the same
+                pair computed against the overall model.
             **filter_kwargs:
                 Optional filtering, sorting, and display controls. Valid keys:
 
@@ -72,6 +79,14 @@ class Plots(LazyNamespace):
 
         """
         if self.explanations.filter.is_context_selected():
+            if return_df:
+                return self.plot_contributions_by_context(
+                    context=self.explanations.filter.get_selected_context(),
+                    top_n=top_n,
+                    top_k=top_k,
+                    return_df=True,
+                    **filter_kwargs,
+                )
             context_plot, overall_plot, predictor_plots = self.plot_contributions_by_context(
                 context=self.explanations.filter.get_selected_context(),
                 top_n=top_n,
@@ -85,8 +100,17 @@ class Plots(LazyNamespace):
 
             return context_plot, plots
 
-        print(
-            "No context selected, plotting overall contributions. Use explanations.filter.interative() to select a context.",
+        if return_df:
+            return self.plot_contributions_for_overall(
+                top_n=top_n,
+                top_k=top_k,
+                return_df=True,
+                **filter_kwargs,
+            )
+
+        logger.info(
+            "No context selected, plotting overall contributions. "
+            "Use explanations.filter.interactive() to select a context.",
         )
 
         overall_plot, predictor_plots = self.plot_contributions_for_overall(
@@ -101,12 +125,34 @@ class Plots(LazyNamespace):
 
         return None, plots
 
+    @overload
+    def plot_contributions_for_overall(
+        self,
+        top_n: int = ...,
+        top_k: int = ...,
+        *,
+        return_df: Literal[False] = ...,
+        **filter_kwargs,
+    ) -> tuple[go.Figure, list[go.Figure]]: ...
+
+    @overload
+    def plot_contributions_for_overall(
+        self,
+        top_n: int = ...,
+        top_k: int = ...,
+        *,
+        return_df: Literal[True],
+        **filter_kwargs,
+    ) -> tuple[pl.DataFrame, pl.DataFrame]: ...
+
     def plot_contributions_for_overall(
         self,
         top_n: int = 20,
         top_k: int = 20,
+        *,
+        return_df: bool = False,
         **filter_kwargs,
-    ) -> tuple[go.Figure, list[go.Figure]]:
+    ) -> tuple[go.Figure, list[go.Figure]] | tuple[pl.DataFrame, pl.DataFrame]:
         display_by, resolved = self._resolve_kwargs(**filter_kwargs)
 
         df = self.aggregate.get_predictor_contributions(
@@ -128,6 +174,9 @@ class Plots(LazyNamespace):
             **resolved,
         )
 
+        if return_df:
+            return df, df_predictors
+
         overall_fig = self._plot_overall_contributions(
             df,
             x_col=display_by.value,
@@ -143,13 +192,37 @@ class Plots(LazyNamespace):
 
         return overall_fig, predictors_figs
 
+    @overload
+    def plot_contributions_by_context(
+        self,
+        context: dict[str, str],
+        top_n: int = ...,
+        top_k: int = ...,
+        *,
+        return_df: Literal[False] = ...,
+        **filter_kwargs,
+    ) -> tuple[go.Figure, go.Figure, list[go.Figure]]: ...
+
+    @overload
+    def plot_contributions_by_context(
+        self,
+        context: dict[str, str],
+        top_n: int = ...,
+        top_k: int = ...,
+        *,
+        return_df: Literal[True],
+        **filter_kwargs,
+    ) -> tuple[pl.DataFrame, pl.DataFrame]: ...
+
     def plot_contributions_by_context(
         self,
         context: dict[str, str],
         top_n: int = 20,
         top_k: int = 20,
+        *,
+        return_df: bool = False,
         **filter_kwargs,
-    ) -> tuple[go.Figure, go.Figure, list[go.Figure]]:
+    ) -> tuple[go.Figure, go.Figure, list[go.Figure]] | tuple[pl.DataFrame, pl.DataFrame]:
         display_by, resolved = self._resolve_kwargs(**filter_kwargs)
 
         df_context = self.aggregate.get_predictor_contributions(
@@ -180,6 +253,9 @@ class Plots(LazyNamespace):
             top_k=top_k,
             **resolved,
         )
+
+        if return_df:
+            return df_context, df
 
         header_fig = self._plot_context_table(cast("ContextInfo", context))
 

--- a/python/tests/explanations/test_ExplanationsPlots.py
+++ b/python/tests/explanations/test_ExplanationsPlots.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import plotly.graph_objects as go
+import polars as pl
 import pytest
 from pdstools.explanations import Explanations
 from pdstools.explanations.ExplanationsUtils import _SPECIAL
@@ -209,6 +210,61 @@ def test_plot_contributions_by_context_with_invalid_contribution_type(plots):
             context=selected_context,
             sort_by="invalid",
         )
+
+
+def test_plot_contributions_for_overall_return_df(plots):
+    """return_df=True must skip plotting and yield the underlying frames."""
+    overall_df, predictors_df = plots.plot_contributions_for_overall(
+        top_n=5,
+        top_k=5,
+        return_df=True,
+    )
+
+    assert isinstance(overall_df, pl.DataFrame)
+    assert isinstance(predictors_df, pl.DataFrame)
+
+    fig_overall, _ = plots.plot_contributions_for_overall(top_n=5, top_k=5)
+    fig_overall_y = list(fig_overall.data[0].y)
+
+    # Predictor names plotted on the figure must match the names in the returned df.
+    assert sorted(fig_overall_y) == sorted(overall_df["predictor_name"].to_list())
+
+
+def test_plot_contributions_by_context_return_df(plots):
+    """return_df=True for the context variant returns (context_df, value_df)."""
+    selected_context = {
+        "pyChannel": "PegaBatch",
+        "pyDirection": "E2E Test",
+        "pyGroup": "E2E Test",
+        "pyIssue": "Batch",
+        "pyName": "P1",
+    }
+    context_df, value_df = plots.plot_contributions_by_context(
+        context=selected_context,
+        top_n=3,
+        top_k=3,
+        return_df=True,
+    )
+
+    assert isinstance(context_df, pl.DataFrame)
+    assert isinstance(value_df, pl.DataFrame)
+    # context keys must be filtered out of the predictor frame
+    assert not context_df["predictor_name"].is_in(list(selected_context)).any()
+
+
+def test_contributions_no_context_logs_instead_of_print(plots, caplog, monkeypatch):
+    """The fallback "no context selected" message must be a log record, not a print."""
+    import logging
+
+    monkeypatch.setattr(plots.explanations.filter, "is_context_selected", lambda: False)
+    # avoid actually opening browser windows from .show()
+    monkeypatch.setattr(go.Figure, "show", lambda self, *a, **kw: None)
+    with caplog.at_level(logging.INFO, logger="pdstools.explanations.Plots"):
+        plots.contributions(top_n=3, top_k=3)
+
+    assert any("No context selected" in rec.message and "interactive()" in rec.message for rec in caplog.records), [
+        rec.message for rec in caplog.records
+    ]
 
 
 def _assert_fig_bar_data_predictors_special_bins(

--- a/python/tests/test_ADMDatamart.py
+++ b/python/tests/test_ADMDatamart.py
@@ -384,6 +384,7 @@ def test_from_s3_model_only(monkeypatch):
     assert dm.model_data is not None
     assert dm.predictor_data is None
 
+
 # ---------------------------------------------------------------------------
 # Helper-method unit tests (synthetic minimal fixtures, exact-value assertions)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Plots.contributions: replace stray print() with logger.info() (per AGENTS.md 'no print() in library code') and fix a typo in the user-facing message ('interative' -> 'interactive').
- Plots: add 'return_df: bool = False' kw-only parameter to contributions, plot_contributions_for_overall, and plot_contributions_by_context, with @overload signatures so type checkers know which return shape applies. Mirrors the gold-standard ADMDatamart.plot.* convention from AGENTS.md.
- Tests: add three exact-value unit tests covering the new return_df paths and the logger.info fallback.
- docs/plans/explanations/: new plan directory with three follow-up items (move IO out of __init__ into from_<source> classmethods; split ContextOperations to its own module; replace **filter_kwargs with explicit typed parameters).