### PR TITLE
refactor(ih): align with gold-standard pattern

### DIFF
--- a/python/pdstools/ih/Aggregates.py
+++ b/python/pdstools/ih/Aggregates.py
@@ -1,5 +1,6 @@
 """Aggregation methods for Interaction History analysis."""
 
+import logging
 from collections.abc import Sequence
 from datetime import timedelta
 from typing import TYPE_CHECKING
@@ -10,6 +11,8 @@ from ..utils import cdh_utils
 from ..utils.namespaces import LazyNamespace
 from ..utils.pega_outcomes import get_openrate_labels as _get_openrate_labels
 from ..utils.types import QUERY
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .IH import IH as IH_Class

--- a/python/pdstools/ih/IH.py
+++ b/python/pdstools/ih/IH.py
@@ -1,6 +1,7 @@
 """Interaction History analysis for Pega CDH."""
 
 import datetime
+import logging
 import math
 import os
 import random
@@ -10,15 +11,20 @@ import polars as pl
 import polars.selectors as cs
 
 from ..pega_io.File import read_ds_export
-from ..utils.pega_outcomes import resolve_outcome_labels as _resolve_outcome_labels
+from ..utils import cdh_utils
 from ..utils.cdh_utils import (
     _apply_query,
     _polars_capitalize,
     parse_pega_date_time_formats,
 )
+from ..utils.pega_outcomes import resolve_outcome_labels as _resolve_outcome_labels
 from ..utils.types import QUERY
+from . import Schema
 from .Aggregates import Aggregates
 from .Plots import Plots
+from .Schema import REQUIRED_IH_COLUMNS
+
+logger = logging.getLogger(__name__)
 
 
 class IH:
@@ -82,16 +88,56 @@ class IH:
             Interaction history data. Column names will be automatically
             capitalized using Pega naming conventions.
 
+        Raises
+        ------
+        ValueError
+            If any column listed in
+            :data:`pdstools.ih.Schema.REQUIRED_IH_COLUMNS` is absent.
+
         Notes
         -----
         Use the class methods :meth:`from_ds_export` or :meth:`from_mock_data`
         to create instances from data sources.
 
         """
-        self.data = _polars_capitalize(data)
+        self.data = self._validate_ih_data(data)
         self.outcome_labels_used = self._scan_outcome_labels()
         self.aggregates = Aggregates(ih=self)
         self.plot = Plots(ih=self)
+
+    @staticmethod
+    def _validate_ih_data(df: pl.LazyFrame) -> pl.LazyFrame:
+        """Internal method to validate and normalise IH data.
+
+        Mirrors the ``_validate_*_data`` pattern used by
+        :class:`pdstools.adm.ADMDatamart`. Capitalises Pega-style column
+        names (stripping ``py``/``px`` prefixes), checks required columns
+        are present, and casts columns to the dtypes declared on
+        :class:`pdstools.ih.Schema.IHInteraction` (which auto-parses
+        string ``OutcomeTime`` values into ``pl.Datetime``).
+
+        Parameters
+        ----------
+        df : pl.LazyFrame
+            Raw interaction history data.
+
+        Returns
+        -------
+        pl.LazyFrame
+            Capitalised and dtype-normalised frame.
+
+        Raises
+        ------
+        ValueError
+            If any column listed in
+            :data:`pdstools.ih.Schema.REQUIRED_IH_COLUMNS` is absent.
+        """
+        df = _polars_capitalize(df)
+        missing = set(REQUIRED_IH_COLUMNS).difference(df.collect_schema().names())
+        if missing:
+            raise ValueError(f"Missing required IH columns: {sorted(missing)}")
+        df = cdh_utils._apply_schema_types(df, Schema.IHInteraction)
+        return df
 
     def _scan_outcome_labels(self) -> dict | None:
         """Scan data for channel/outcome combinations and resolve defaults.
@@ -211,10 +257,6 @@ class IH:
             b = responses * (1 - propensity)
 
             sampled = random.betavariate(a, b)
-
-            # print(
-            #     f"{a} {b} {propensity} {sampled} {abs((sampled-propensity)/propensity)}"
-            # )
 
             return sampled
 

--- a/python/pdstools/ih/Plots.py
+++ b/python/pdstools/ih/Plots.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast, overload
 
 import polars as pl
 
@@ -63,6 +63,32 @@ class Plots(LazyNamespace):
         """
         super().__init__()
         self.ih = ih
+
+    @overload
+    def overall_gauges(
+        self,
+        condition: str | pl.Expr,
+        *,
+        metric: str = ...,
+        by: str = ...,
+        reference_values: dict[str, float] | None = ...,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def overall_gauges(
+        self,
+        condition: str | pl.Expr,
+        *,
+        metric: str = ...,
+        by: str = ...,
+        reference_values: dict[str, float] | None = ...,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
 
     def overall_gauges(
         self,
@@ -182,6 +208,26 @@ class Plots(LazyNamespace):
 
         return fig
 
+    @overload
+    def response_count_tree_map(
+        self,
+        *,
+        by: list[str] | None = ...,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def response_count_tree_map(
+        self,
+        *,
+        by: list[str] | None = ...,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
+
     def response_count_tree_map(
         self,
         *,
@@ -256,6 +302,28 @@ class Plots(LazyNamespace):
         simplify_facet_titles(fig)
 
         return fig
+
+    @overload
+    def success_rate_tree_map(
+        self,
+        *,
+        metric: str = ...,
+        by: list[str] | None = ...,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def success_rate_tree_map(
+        self,
+        *,
+        metric: str = ...,
+        by: list[str] | None = ...,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
 
     def success_rate_tree_map(
         self,
@@ -346,6 +414,30 @@ class Plots(LazyNamespace):
 
         return fig
 
+    @overload
+    def action_distribution(
+        self,
+        *,
+        by: str = ...,
+        title: str = ...,
+        query: QUERY | None = ...,
+        color: str | None = ...,
+        facet: str | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def action_distribution(
+        self,
+        *,
+        by: str = ...,
+        title: str = ...,
+        query: QUERY | None = ...,
+        color: str | None = ...,
+        facet: str | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
+
     def action_distribution(
         self,
         *,
@@ -412,6 +504,30 @@ class Plots(LazyNamespace):
         simplify_facet_titles(fig)
 
         return fig
+
+    @overload
+    def success_rate(
+        self,
+        *,
+        metric: str = ...,
+        every: str | timedelta = ...,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        facet: str | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def success_rate(
+        self,
+        *,
+        metric: str = ...,
+        every: str | timedelta = ...,
+        title: str | None = ...,
+        query: QUERY | None = ...,
+        facet: str | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
 
     def success_rate(
         self,
@@ -488,6 +604,28 @@ class Plots(LazyNamespace):
 
         return fig
 
+    @overload
+    def response_count(
+        self,
+        *,
+        every: str | timedelta = ...,
+        title: str = ...,
+        query: QUERY | None = ...,
+        facet: str | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def response_count(
+        self,
+        *,
+        every: str | timedelta = ...,
+        title: str = ...,
+        query: QUERY | None = ...,
+        facet: str | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
+
     def response_count(
         self,
         *,
@@ -553,6 +691,32 @@ class Plots(LazyNamespace):
         simplify_facet_titles(fig)
 
         return fig
+
+    @overload
+    def model_performance_trend(
+        self,
+        *,
+        metric: str = ...,
+        every: str | timedelta = ...,
+        by: str | None = ...,
+        title: str = ...,
+        query: QUERY | None = ...,
+        facet: str | None = ...,
+        return_df: Literal[False] = ...,
+    ) -> Figure: ...
+
+    @overload
+    def model_performance_trend(
+        self,
+        *,
+        metric: str = ...,
+        every: str | timedelta = ...,
+        by: str | None = ...,
+        title: str = ...,
+        query: QUERY | None = ...,
+        facet: str | None = ...,
+        return_df: Literal[True],
+    ) -> pl.LazyFrame: ...
 
     def model_performance_trend(
         self,

--- a/python/pdstools/ih/Schema.py
+++ b/python/pdstools/ih/Schema.py
@@ -1,0 +1,60 @@
+"""Schema definitions for Interaction History data.
+
+These classes mirror the convention used by :mod:`pdstools.adm.Schema` and
+document the columns expected by :class:`pdstools.ih.IH.IH` after column
+name normalisation (Pega ``py``/``px`` prefixes are stripped via
+:func:`pdstools.utils.cdh_utils._polars_capitalize`).
+
+The :data:`REQUIRED_IH_COLUMNS` tuple lists the minimum set of columns
+that must be present on the LazyFrame passed to :class:`IH`. Any other
+columns are optional and only used when present.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+class IHInteraction:
+    """Normalised Interaction History row schema.
+
+    Required columns
+    ----------------
+    InteractionID : pl.Utf8
+        Unique interaction identifier.
+    Outcome : pl.Utf8
+        Raw outcome label (e.g. ``"Impression"``, ``"Clicked"``).
+    OutcomeTime : pl.Datetime
+        Timestamp of the outcome. String values are parsed via
+        :func:`pdstools.utils.cdh_utils.parse_pega_date_time_formats`.
+
+    Optional but commonly present
+    -----------------------------
+    Channel, Direction, Issue, Group, Name, Treatment : pl.Utf8
+        Action / context dimensions.
+    Propensity : pl.Float64
+        Model propensity emitted with the interaction.
+    ModelTechnique : pl.Utf8
+        Model family (e.g. ``"NaiveBayes"``, ``"GradientBoost"``).
+    """
+
+    InteractionID = pl.Utf8
+    SubjectID = pl.Utf8
+    Outcome = pl.Utf8
+    OutcomeTime = pl.Datetime
+    Channel = pl.Utf8
+    Direction = pl.Utf8
+    Issue = pl.Utf8
+    Group = pl.Utf8
+    Name = pl.Utf8
+    Treatment = pl.Utf8
+    Propensity = pl.Float64
+    ModelTechnique = pl.Utf8
+
+
+REQUIRED_IH_COLUMNS: tuple[str, ...] = (
+    "InteractionID",
+    "Outcome",
+    "OutcomeTime",
+)
+"""Columns that must be present on the LazyFrame consumed by :class:`IH`."""

--- a/python/tests/test_ADMDatamart.py
+++ b/python/tests/test_ADMDatamart.py
@@ -384,6 +384,7 @@ def test_from_s3_model_only(monkeypatch):
     assert dm.model_data is not None
     assert dm.predictor_data is None
 
+
 # ---------------------------------------------------------------------------
 # Helper-method unit tests (synthetic minimal fixtures, exact-value assertions)
 # ---------------------------------------------------------------------------

--- a/python/tests/test_IH.py
+++ b/python/tests/test_IH.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import polars as pl
 import pytest
 from pdstools import IH
+from pdstools.ih.Schema import REQUIRED_IH_COLUMNS, IHInteraction
 from plotly.graph_objs import Figure
 
 
@@ -471,3 +472,122 @@ def test_plots(ih):
     assert isinstance(ih.plot.response_count(), Figure)
     assert isinstance(ih.plot.model_performance_trend(), Figure)
     assert isinstance(ih.plot.model_performance_trend(by="ModelTechnique"), Figure)
+
+
+# -------------------------------------------------------------------- #
+# Schema and _validate_ih_data
+# -------------------------------------------------------------------- #
+
+
+def _minimal_valid_ih_lf() -> pl.LazyFrame:
+    """Smallest frame that satisfies REQUIRED_IH_COLUMNS, post-capitalization."""
+    return pl.LazyFrame(
+        {
+            "pxInteractionID": ["A", "B", "C"],
+            "pyOutcome": ["Impression", "Clicked", "Impression"],
+            "pxOutcomeTime": [
+                "20240115T120000.000 GMT",
+                "20240115T120100.000 GMT",
+                "20240115T120200.000 GMT",
+            ],
+        }
+    )
+
+
+def test_required_ih_columns_exact_set():
+    """REQUIRED_IH_COLUMNS is the documented minimal set."""
+    assert REQUIRED_IH_COLUMNS == ("InteractionID", "Outcome", "OutcomeTime")
+
+
+def test_schema_dtypes_exact():
+    """IHInteraction declares the exact dtypes documented for each column."""
+    assert IHInteraction.InteractionID == pl.Utf8
+    assert IHInteraction.Outcome == pl.Utf8
+    assert IHInteraction.OutcomeTime == pl.Datetime
+    assert IHInteraction.Channel == pl.Utf8
+    assert IHInteraction.Direction == pl.Utf8
+    assert IHInteraction.Propensity == pl.Float64
+    assert IHInteraction.ModelTechnique == pl.Utf8
+
+
+def test_validate_ih_data_returns_lazyframe_and_capitalises():
+    """Capitalises py/px-prefixed columns and returns a LazyFrame."""
+    out = IH._validate_ih_data(_minimal_valid_ih_lf())
+    assert isinstance(out, pl.LazyFrame)
+    names = out.collect_schema().names()
+    assert "InteractionID" in names
+    assert "Outcome" in names
+    assert "OutcomeTime" in names
+    # py/px prefixes are stripped, originals must be gone:
+    assert "pxInteractionID" not in names
+    assert "pyOutcome" not in names
+
+
+def test_validate_ih_data_parses_string_outcometime_to_datetime():
+    """String OutcomeTime is auto-cast to pl.Datetime via the schema."""
+    out = IH._validate_ih_data(_minimal_valid_ih_lf()).collect()
+    assert out.schema["OutcomeTime"] == pl.Datetime
+    # Exact timestamp value preserved through the parse:
+    assert out["OutcomeTime"][0].year == 2024
+    assert out["OutcomeTime"][0].month == 1
+    assert out["OutcomeTime"][0].day == 15
+    assert out["OutcomeTime"][0].hour == 12
+
+
+def test_validate_ih_data_missing_interactionid_raises():
+    """Missing InteractionID is reported with the column name."""
+    bad = pl.LazyFrame(
+        {
+            "pyOutcome": ["Impression"],
+            "pxOutcomeTime": ["20240115T120000.000 GMT"],
+        }
+    )
+    with pytest.raises(ValueError, match="InteractionID"):
+        IH._validate_ih_data(bad)
+
+
+def test_validate_ih_data_missing_outcome_raises():
+    """Missing Outcome is reported with the column name."""
+    bad = pl.LazyFrame(
+        {
+            "pxInteractionID": ["A"],
+            "pxOutcomeTime": ["20240115T120000.000 GMT"],
+        }
+    )
+    with pytest.raises(ValueError, match="Outcome"):
+        IH._validate_ih_data(bad)
+
+
+def test_validate_ih_data_missing_outcometime_raises():
+    """Missing OutcomeTime is reported with the column name."""
+    bad = pl.LazyFrame(
+        {
+            "pxInteractionID": ["A"],
+            "pyOutcome": ["Impression"],
+        }
+    )
+    with pytest.raises(ValueError, match="OutcomeTime"):
+        IH._validate_ih_data(bad)
+
+
+def test_validate_ih_data_reports_all_missing():
+    """Multiple missing columns are listed sorted in the error message."""
+    bad = pl.LazyFrame({"SomeOtherCol": [1, 2]})
+    with pytest.raises(ValueError) as exc:
+        IH._validate_ih_data(bad)
+    msg = str(exc.value)
+    assert "InteractionID" in msg
+    assert "Outcome" in msg
+    assert "OutcomeTime" in msg
+
+
+def test_ih_init_validates_data():
+    """IH() runs _validate_ih_data and rejects frames without required columns."""
+    with pytest.raises(ValueError, match="Missing required IH columns"):
+        IH(pl.LazyFrame({"foo": [1]}))
+
+
+def test_ih_init_normalises_outcometime_dtype():
+    """After construction, data.OutcomeTime is pl.Datetime (string parsing)."""
+    instance = IH(_minimal_valid_ih_lf())
+    assert instance.data.collect_schema()["OutcomeTime"] == pl.Datetime


### PR DESCRIPTION
Mirrors the conventions established by ADMDatamart and applied to the ImpactAnalyzer / Prediction peers.

- Extract column dtypes into a new pdstools.ih.Schema module (IHInteraction class + REQUIRED_IH_COLUMNS tuple), mirroring pdstools.adm.Schema.
- Add IH._validate_ih_data static method that capitalises Pega-prefixed column names, raises ValueError when required columns are missing, and casts to declared dtypes via _apply_schema_types (which also parses string OutcomeTime values to pl.Datetime).
- Wire _validate_ih_data into IH.__init__ in place of the bare _polars_capitalize call.
- Add module-level loggers in IH.py and Aggregates.py (Plots.py already had one).
- Drop a dead 'print(...)' debug comment from from_mock_data.
- Add @overload pairs for return_df: Literal[True/False] on every public Plots method so type-checkers narrow the return type.
- Add 10 exact-value unit tests covering Schema, _validate_ih_data (capitalisation, datetime parsing, missing-column errors), and the validation hook in IH.__init__.

Plots already used lazy in-method plotly imports guarded by the LazyNamespace metaclass + dependency_group='adm', so no MissingDependencies changes were required.