### PR TITLE
feat(api)!: tighten subpackage __init__ surface for v5

### DIFF
--- a/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
+++ b/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
@@ -15,7 +15,6 @@ from pdstools.decision_analyzer.plots import (
 from pdstools.utils.streamlit_utils import (
     _apply_sidebar_logo,
     ensure_session_data,
-    get_current_index,  # noqa: F401 — re-exported for backward compat
     get_data_path,
 )
 

--- a/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
@@ -5,12 +5,12 @@ from da_streamlit_utils import (
     collect_page_filters,
     contextual_filters,
     ensure_data,
-    get_current_index,
     stage_level_selector,
     stage_selectbox,
     st_component_overview,
     st_priority_component_distribution,
 )
+from pdstools.utils.streamlit_utils import get_current_index
 
 from pdstools.decision_analyzer.utils import PRIO_COMPONENTS
 

--- a/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
@@ -4,11 +4,11 @@ import streamlit as st
 from da_streamlit_utils import (
     collect_page_filters,
     contextual_filters,
-    get_current_index,
     ensure_data,
     stage_level_selector,
     stage_selectbox,
 )
+from pdstools.utils.streamlit_utils import get_current_index
 
 
 # st.set_option("global.showWarningOnDirectExecution", False)

--- a/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
+++ b/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
@@ -6,11 +6,11 @@ from da_streamlit_utils import (
     contextual_filters,
     ensure_data,
     ensure_funnel,
-    get_current_index,
     polars_lazyframe_hashing,
     stage_level_selector,
     stage_selectbox,
 )
+from pdstools.utils.streamlit_utils import get_current_index
 
 "# Action Funnel"
 

--- a/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
+++ b/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
@@ -1,6 +1,7 @@
 import polars as pl
 import streamlit as st
-from da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data, get_current_index
+from da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data
+from pdstools.utils.streamlit_utils import get_current_index
 
 from pdstools.decision_analyzer.utils import apply_filter
 

--- a/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
@@ -4,10 +4,10 @@ from da_streamlit_utils import (
     collect_page_filters,
     contextual_filters,
     ensure_data,
-    get_current_index,
     get_data_filters,
     show_filtered_counts,
 )
+from pdstools.utils.streamlit_utils import get_current_index
 
 from pdstools.decision_analyzer.utils import (
     apply_filter,

--- a/python/pdstools/decision_analyzer/__init__.py
+++ b/python/pdstools/decision_analyzer/__init__.py
@@ -1,9 +1,4 @@
-import sys
-
 from . import plots, utils
 from .DecisionAnalyzer import DecisionAnalyzer
 
-if "streamlit" in sys.modules:
-    from ..app.decision_analyzer import da_streamlit_utils
-
-__all__ = ["DecisionAnalyzer", "da_streamlit_utils", "plots", "utils"]
+__all__ = ["DecisionAnalyzer", "plots", "utils"]

--- a/python/pdstools/pega_io/__init__.py
+++ b/python/pdstools/pega_io/__init__.py
@@ -1,5 +1,6 @@
 from .Anonymization import Anonymization
-from .API import _read_client_credential_file, get_token
+from .API import _read_client_credential_file as _read_client_credential_file
+from .API import get_token
 from .File import (
     cache_to_file,
     find_files,
@@ -15,7 +16,6 @@ from .S3 import S3Data
 __all__ = [
     "Anonymization",
     "S3Data",
-    "_read_client_credential_file",
     "cache_to_file",
     "find_files",
     "get_latest_file",

--- a/python/pdstools/utils/__init__.py
+++ b/python/pdstools/utils/__init__.py
@@ -1,1 +1,10 @@
-# from . import cdh_utils, datasets, errors, hds_utils, CDHLimits
+"""Internal utility modules for pdstools.
+
+Submodules (``cdh_utils``, ``datasets``, ``streamlit_utils``,
+``show_versions``, ``polars_ext`` …) are imported on demand via their
+fully-qualified path. Nothing is re-exported at the package level — the
+``utils`` namespace is intentionally kept empty so that helpers stay
+namespaced and don't leak into the public API surface.
+"""
+
+__all__: list[str] = []

--- a/python/pdstools/valuefinder/__init__.py
+++ b/python/pdstools/valuefinder/__init__.py
@@ -1,0 +1,3 @@
+from .ValueFinder import ValueFinder
+
+__all__ = ["ValueFinder"]

--- a/python/tests/test_subpackage_init.py
+++ b/python/tests/test_subpackage_init.py
@@ -1,0 +1,34 @@
+"""Smoke tests for the v5 subpackage ``__init__`` surface.
+
+These pin the contract documented in ``docs/migration-v4-to-v5.md`` so
+regressions to the public-import paths are caught immediately.
+"""
+
+import pdstools
+from pdstools import decision_analyzer, pega_io, valuefinder
+from pdstools.utils import __all__ as utils_all
+
+
+def test_valuefinder_reexports_class():
+    from pdstools.valuefinder import ValueFinder
+
+    assert ValueFinder is pdstools.ValueFinder
+    assert valuefinder.__all__ == ["ValueFinder"]
+
+
+def test_utils_namespace_is_empty():
+    assert utils_all == []
+
+
+def test_pega_io_does_not_publicly_export_private_helper():
+    assert "_read_client_credential_file" not in pega_io.__all__
+    # …but the private name is still importable for callers that opt in.
+    from pdstools.pega_io import _read_client_credential_file  # noqa: F401
+
+
+def test_decision_analyzer_init_surface():
+    assert set(decision_analyzer.__all__) == {"DecisionAnalyzer", "plots", "utils"}
+    assert "da_streamlit_utils" not in decision_analyzer.__all__
+    assert not hasattr(decision_analyzer, "da_streamlit_utils")
+    # Internal sys import must not leak either.
+    assert not hasattr(decision_analyzer, "sys")


### PR DESCRIPTION
BREAKING CHANGES (v5 only):

- pdstools.decision_analyzer no longer conditionally re-exports da_streamlit_utils based on whether streamlit was already imported. Import it from pdstools.app.decision_analyzer directly. The unused 'import sys' is gone with it.
- pdstools.app.decision_analyzer.da_streamlit_utils no longer re-exports get_current_index. Import from pdstools.utils.streamlit_utils. The five Decision Analyzer pages that used the re-export are updated.
- pdstools.pega_io.__all__ no longer lists _read_client_credential_file. The function is still importable (private name with underscore) but is no longer a documented entry point.

ADDITIVE:

- pdstools.valuefinder.__init__ now re-exports ValueFinder (was empty), so 'from pdstools.valuefinder import ValueFinder' works alongside the existing top-level export.
- pdstools.utils.__init__ becomes an explicitly empty namespace (docstring + __all__ = []). Submodule imports keep working.
- New CHANGELOG.md and docs/migration-v4-to-v5.md scoped to these changes; later v5 PRs will append.
- New test_subpackage_init.py pins the contract.