### PR TITLE
refactor(streamlit): audit and align all apps with AGENTS.md rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ guide.
 ### Changed
 
 - (To be populated by the v5 cleanup PRs.)
+- Streamlit apps audited and aligned with `AGENTS.md` "Streamlit apps"
+  rules: every page now calls `standard_page_config(...)` before any other
+  Streamlit output (Decision Analyzer pages 2–10 + both Health Check
+  sub-pages were missing it). Removed deprecated `use_container_width=True`
+  / `width="stretch"` arguments (now Streamlit defaults). The single
+  remaining `components.html` usage (Decision Analyzer "Single Decision"
+  tree-grid) is now documented as the only place without a Streamlit-native
+  alternative.
 
 ### Added
 

--- a/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
@@ -13,6 +13,9 @@ from da_streamlit_utils import (
 )
 
 from pdstools.decision_analyzer.utils import PRIO_COMPONENTS
+from pdstools.utils.streamlit_utils import standard_page_config
+
+standard_page_config(page_title="Arbitration Distribution · Decision Analysis")
 
 
 "# Arbitration Distribution"

--- a/python/pdstools/app/decision_analyzer/pages/11_Single_Decision.py
+++ b/python/pdstools/app/decision_analyzer/pages/11_Single_Decision.py
@@ -432,6 +432,12 @@ if pvcl_factors:
 n_all_rows = len(grid_rows)
 estimated_height = 300 + n_all_rows * 45
 
+# components.html with custom JS is used here intentionally: this renders a
+# multi-level expand/collapse tree-grid with per-cell colouring (pass / filtered
+# / skipped / empty) for every (action, stage) pair. Streamlit's native
+# st.dataframe / st.data_editor do not support hierarchical row expansion or
+# custom cell styling at this granularity, so there is no Streamlit-native
+# alternative that preserves the drill-down UX. See AGENTS.md "Streamlit apps".
 components.html(
     f"""
     <style>

--- a/python/pdstools/app/decision_analyzer/pages/2_Overview.py
+++ b/python/pdstools/app/decision_analyzer/pages/2_Overview.py
@@ -1,11 +1,11 @@
-# python/pdstools/app/decision_analyzer/pages/3_Overview.py
 import polars as pl
 import streamlit as st
 from da_streamlit_utils import collect_page_filters, ensure_data, polars_lazyframe_hashing
-from pdstools.decision_analyzer.plots import offer_quality_single_pie
 
-# Backlog for this page is tracked in docs/plans/decision-analyzer-TODO.md
-# (Streamlit Pages → Page 2 — Overview), incl. the first-use perf item.
+from pdstools.decision_analyzer.plots import offer_quality_single_pie
+from pdstools.utils.streamlit_utils import standard_page_config
+
+standard_page_config(page_title="Overview · Decision Analysis")
 
 ensure_data()
 st.session_state["sidebar"] = st.sidebar

--- a/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
@@ -10,11 +10,10 @@ from da_streamlit_utils import (
     stage_selectbox,
 )
 
+from pdstools.utils.streamlit_utils import standard_page_config
 
-# st.set_option("global.showWarningOnDirectExecution", False)
+standard_page_config(page_title="Action Distribution · Decision Analysis")
 
-# Backlog for this page is tracked in docs/plans/decision-analyzer-TODO.md
-# (Streamlit Pages → Page 3 — Action Distribution).
 
 """
 # Action Distribution

--- a/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
+++ b/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
@@ -12,6 +12,10 @@ from da_streamlit_utils import (
     stage_selectbox,
 )
 
+from pdstools.utils.streamlit_utils import standard_page_config
+
+standard_page_config(page_title="Action Funnel · Decision Analysis")
+
 "# Action Funnel"
 
 """

--- a/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
+++ b/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
@@ -3,6 +3,9 @@ import streamlit as st
 from da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data, get_current_index
 
 from pdstools.decision_analyzer.utils import apply_filter
+from pdstools.utils.streamlit_utils import standard_page_config
+
+standard_page_config(page_title="Global Sensitivity · Decision Analysis")
 
 # Backlog for this page is tracked in docs/plans/decision-analyzer-TODO.md
 # (Streamlit Pages → Page 5 — Global Sensitivity).

--- a/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
@@ -13,6 +13,9 @@ from pdstools.decision_analyzer.utils import (
     apply_filter,
     get_first_level_stats,
 )
+from pdstools.utils.streamlit_utils import standard_page_config
+
+standard_page_config(page_title="Win/Loss · Decision Analysis")
 
 MAX_COMPARISON_LABEL_LEN = 80
 

--- a/python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
@@ -9,6 +9,10 @@ from da_streamlit_utils import (
     stage_selectbox,
 )
 
+from pdstools.utils.streamlit_utils import standard_page_config
+
+standard_page_config(page_title="Optionality · Decision Analysis")
+
 # Backlog for this page is tracked in docs/plans/decision-analyzer-TODO.md
 # (Streamlit Pages → Page 7 — Optionality Analysis).
 

--- a/python/pdstools/app/decision_analyzer/pages/8_Offer_Quality_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/8_Offer_Quality_Analysis.py
@@ -10,6 +10,10 @@ from da_streamlit_utils import (
     stage_level_selector,
     stage_selectbox,
 )
+from pdstools.utils.streamlit_utils import standard_page_config
+
+standard_page_config(page_title="Offer Quality · Decision Analysis")
+
 # Backlog for this page is tracked in docs/plans/decision-analyzer-TODO.md
 # (Streamlit Pages → Page 8 — Offer Quality Analysis).
 

--- a/python/pdstools/app/decision_analyzer/pages/9_Thresholding_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/9_Thresholding_Analysis.py
@@ -7,6 +7,9 @@ import streamlit as st
 
 from da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data
 from pdstools.decision_analyzer.utils import apply_filter
+from pdstools.utils.streamlit_utils import standard_page_config
+
+standard_page_config(page_title="Thresholding · Decision Analysis")
 
 "# Thresholding Analysis"
 

--- a/python/pdstools/app/health_check/pages/1_Data_Filters.py
+++ b/python/pdstools/app/health_check/pages/1_Data_Filters.py
@@ -5,12 +5,12 @@ import streamlit as st
 
 from pdstools.utils.cdh_utils import _apply_query
 from pdstools.utils.streamlit_utils import (
-    _apply_sidebar_logo,
     filter_dataframe,
     model_and_row_counts,
+    standard_page_config,
 )
 
-_apply_sidebar_logo()
+standard_page_config(page_title="Data Filters · ADM Health Check")
 
 """# Add custom filters"""
 

--- a/python/pdstools/app/health_check/pages/2_Reports.py
+++ b/python/pdstools/app/health_check/pages/2_Reports.py
@@ -10,12 +10,12 @@ from pdstools import ADMDatamart
 from pdstools.utils.cdh_utils import _apply_query
 from pdstools.utils.show_versions import show_versions
 from pdstools.utils.streamlit_utils import (
-    _apply_sidebar_logo,
     get_full_embed,
     model_selection_df,
+    standard_page_config,
 )
 
-_apply_sidebar_logo()
+standard_page_config(page_title="Reports · ADM Health Check")
 
 if "dm" not in st.session_state:
     st.warning("Please configure your files in the `data import` tab.")
@@ -169,7 +169,6 @@ if st.session_state["dm"].predictor_data is not None:
             edited_df = st.data_editor(
                 st.session_state["model_selection_df"],
                 disabled=st.session_state["dm"].context_keys + ["Name"],
-                use_container_width=True,
             )
             st.session_state["only_active_predictors"] = st.checkbox(
                 label="Show only active predictors",

--- a/python/pdstools/app/impact_analyzer/pages/1_Overall_Summary.py
+++ b/python/pdstools/app/impact_analyzer/pages/1_Overall_Summary.py
@@ -35,4 +35,4 @@ with st.container(border=True):
     st.caption("Tabular view of lift metrics with exact values. Use this for detailed analysis and reporting.")
 
     table = ia.plot.overview(metric=metric, facet=facet, return_df=True).collect()
-    st.dataframe(table, width="stretch")
+    st.dataframe(table)

--- a/python/pdstools/app/impact_analyzer/pages/2_Trend.py
+++ b/python/pdstools/app/impact_analyzer/pages/2_Trend.py
@@ -62,4 +62,4 @@ with st.container(border=True):
         every=granularity,
         return_df=True,
     ).collect()
-    st.dataframe(table, width="stretch")
+    st.dataframe(table)


### PR DESCRIPTION
Audit and clean up the three Streamlit apps (health_check, decision_analyzer, impact_analyzer) so every page conforms to the AGENTS.md "Streamlit apps" rules.

Findings and fixes:

* standard_page_config missing on 11 pages — added before any other Streamlit output (rule #1):
  - decision_analyzer/pages/{2_Overview,3_Action_Distribution, 4_Action_Funnel,5_Global_Sensitivity,6_Win_Loss_Analysis, 7_Optionality_Analysis,8_Offer_Quality_Analysis, 9_Thresholding_Analysis,10_Arbitration_Distribution}.py
  - health_check/pages/{1_Data_Filters,2_Reports}.py (these were calling _apply_sidebar_logo() directly)
* Removed deprecated use_container_width=True from health_check Reports page (st.data_editor — now default).
* Removed redundant width="stretch" from impact_analyzer pages 1 and 2 (st.dataframe — now default).
* Documented why the Single Decision page legitimately needs components.html with custom JS (multi-level expand/collapse tree-grid with per-cell coloring — no Streamlit-native equivalent).

No changes to da_streamlit_utils.py (owned by in-flight v5 PR). No experimental_* APIs found. Filter session-state already correctly prefixed with filter_type. CLI env vars already accessed via streamlit_utils helpers (no direct os.environ reads in pages). About pages already use show_about_page().

Tests: full suite passes (1688 passed, 11 skipped). All three apps import cleanly via streamlit run smoke test.