### PR TITLE
refactor(decision-analyzer)!: align with gold-standard checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,16 @@ guide.
   remaining `components.html` usage (Decision Analyzer "Single Decision"
   tree-grid) is now documented as the only place without a Streamlit-native
   alternative.
-
+- `DecisionAnalyzer.__init__` keyword arguments are now keyword-only
+  (`level`, `sample_size`, `mandatory_expr`, `additional_columns`,
+  `num_samples`). Positional usage now raises `TypeError`.
+- `DecisionAnalyzer.from_explainability_extract` /
+  `from_decision_analyzer` now have explicit keyword-only parameters
+  instead of `**kwargs`, matching `__init__`.
+- `DecisionAnalyzer.get_available_fields_for_filtering` parameter
+  renamed `categoricalOnly` → `categorical_only` (now keyword-only).
+- `DecisionAnalyzer.cleanup_raw_data` made private:
+  `_cleanup_raw_data`. It was always called internally from `__init__`.
 ### Added
 
 - `pdstools.valuefinder.__init__` now re-exports `ValueFinder` (was empty).

--- a/docs/migration-v4-to-v5.md
+++ b/docs/migration-v4-to-v5.md
@@ -150,6 +150,44 @@ parameters matching the documented constructor signature.
 Previously `**filter_kwargs`. Now uses explicit parameters per
 `docs/plans/explanations/typed-filter-kwargs.md`.
 
+### `DecisionAnalyzer.__init__` and `from_*` classmethods
+
+Previously accepted positional arguments and `**kwargs`. Now all
+configuration is keyword-only and the `from_*` classmethods spell out
+each parameter explicitly (no more silent `**kwargs` drop-through).
+
+```python
+# Before (v4.x):
+da = DecisionAnalyzer(raw_data, "Stage Group", 50_000)
+da = DecisionAnalyzer.from_decision_analyzer(
+    "data.parquet", sample_size=10_000, foo="ignored-silently"
+)
+
+# After (v5):
+da = DecisionAnalyzer(raw_data, level="Stage Group", sample_size=50_000)
+da = DecisionAnalyzer.from_decision_analyzer(
+    "data.parquet", sample_size=10_000  # unknown kwargs now raise TypeError
+)
+```
+
+### `DecisionAnalyzer.get_available_fields_for_filtering`
+
+Parameter renamed and made keyword-only.
+
+```python
+# Before:
+da.get_available_fields_for_filtering(categoricalOnly=True)
+
+# After (v5):
+da.get_available_fields_for_filtering(categorical_only=True)
+```
+
+### `DecisionAnalyzer.cleanup_raw_data` is now private
+
+It was only ever called from `__init__` — no public callers in the
+ecosystem. Renamed to `_cleanup_raw_data`. If you were calling it
+externally, build a new `DecisionAnalyzer` instead.
+
 ---
 
 ## Behaviour changes (no API change, may affect output)

--- a/docs/plans/decision-analyzer/rename-propensity-priority-th-args.md
+++ b/docs/plans/decision-analyzer/rename-propensity-priority-th-args.md
@@ -1,0 +1,17 @@
+# Rename `propensityTH` / `priorityTH` to snake_case
+
+**Priority:** P3
+**Touches:** `python/pdstools/decision_analyzer/DecisionAnalyzer.py`,
+`python/pdstools/decision_analyzer/plots.py`, Streamlit pages 2 & 8, tests.
+
+`DecisionAnalyzer.filtered_action_counts` (and the matching `plots.py`
+helpers) take `propensityTH` and `priorityTH`. These violate
+PEP 8 / our snake_case naming convention. They were left in place during
+the v5 gold-standard pass to keep the diff focused — renaming forces
+plots.py changes (held back for a separate split agent) plus updates to
+Streamlit pages and ~15 test call sites.
+
+## Approach
+
+Rename to `propensity_threshold` / `priority_threshold` once the
+plots.py split lands. Update all callers in the same PR.

--- a/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
@@ -78,7 +78,7 @@ with st.session_state["sidebar"]:
     comparison_filter_columns = [
         c
         for c in st.session_state.decision_data.get_available_fields_for_filtering(
-            categoricalOnly=True,
+            categorical_only=True,
         )
         if c not in {"Stage", "Channel", "Direction"}
     ]

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -81,7 +81,12 @@ class DecisionAnalyzer:
     def from_explainability_extract(
         cls,
         source: str | os.PathLike,
-        **kwargs,
+        *,
+        level: str = "Stage Group",
+        sample_size: int = DEFAULT_SAMPLE_SIZE,
+        mandatory_expr: pl.Expr | None = None,
+        additional_columns: dict[str, pl.DataType] | None = None,
+        num_samples: int = 1,
     ) -> "DecisionAnalyzer":
         """Create a DecisionAnalyzer from an Explainability Extract (v1) file.
 
@@ -89,9 +94,8 @@ class DecisionAnalyzer:
         ----------
         source : str | os.PathLike
             Path to the Explainability Extract parquet file, or a URL.
-        **kwargs
-            Additional keyword arguments passed to ``__init__`` (e.g.
-            ``sample_size``, ``mandatory_expr``, ``additional_columns``).
+        level, sample_size, mandatory_expr, additional_columns, num_samples
+            See :meth:`__init__` for details.
 
         Returns
         -------
@@ -104,13 +108,25 @@ class DecisionAnalyzer:
         raw_data = read_ds_export(str(source))
         if raw_data is None:
             raise ValueError(f"Could not read data from {source}")
-        return cls(raw_data, **kwargs)
+        return cls(
+            raw_data,
+            level=level,
+            sample_size=sample_size,
+            mandatory_expr=mandatory_expr,
+            additional_columns=additional_columns,
+            num_samples=num_samples,
+        )
 
     @classmethod
     def from_decision_analyzer(
         cls,
         source: str | os.PathLike,
-        **kwargs,
+        *,
+        level: str = "Stage Group",
+        sample_size: int = DEFAULT_SAMPLE_SIZE,
+        mandatory_expr: pl.Expr | None = None,
+        additional_columns: dict[str, pl.DataType] | None = None,
+        num_samples: int = 1,
     ) -> "DecisionAnalyzer":
         """Create a DecisionAnalyzer from a Decision Analyzer / EEV2 (v2) file.
 
@@ -118,9 +134,8 @@ class DecisionAnalyzer:
         ----------
         source : str | os.PathLike
             Path to the Decision Analyzer parquet file, or a URL.
-        **kwargs
-            Additional keyword arguments passed to ``__init__`` (e.g.
-            ``sample_size``, ``mandatory_expr``, ``additional_columns``).
+        level, sample_size, mandatory_expr, additional_columns, num_samples
+            See :meth:`__init__` for details.
 
         Returns
         -------
@@ -133,7 +148,14 @@ class DecisionAnalyzer:
         raw_data = read_ds_export(str(source))
         if raw_data is None:
             raise ValueError(f"Could not read data from {source}")
-        return cls(raw_data, **kwargs)
+        return cls(
+            raw_data,
+            level=level,
+            sample_size=sample_size,
+            mandatory_expr=mandatory_expr,
+            additional_columns=additional_columns,
+            num_samples=num_samples,
+        )
 
     # Preferred fields for data filtering, in display order.
     # Subsetting to actual available columns happens in __init__.
@@ -153,8 +175,9 @@ class DecisionAnalyzer:
     def __init__(
         self,
         raw_data: pl.LazyFrame,
-        level="Stage Group",
-        sample_size=DEFAULT_SAMPLE_SIZE,
+        *,
+        level: str = "Stage Group",
+        sample_size: int = DEFAULT_SAMPLE_SIZE,
         mandatory_expr: pl.Expr | None = None,
         additional_columns: dict[str, pl.DataType] | None = None,
         num_samples: int = 1,
@@ -209,7 +232,7 @@ class DecisionAnalyzer:
         Notes
         -----
         The ranking function orders actions by: is_mandatory (desc) → Priority (desc) →
-        StageOrder (desc) → pyIssue → pyGroup → pyName.
+        StageOrder (desc) → Issue → Group → Action.
 
         If mandatory_expr is None, mandatory rows are auto-detected from
         ``Priority`` using :data:`MANDATORY_PRIORITY_THRESHOLD`. If the
@@ -250,7 +273,7 @@ class DecisionAnalyzer:
         self.validation_error = validation_error if not validation_result else None
         if not validation_result and validation_error is not None:
             warnings.warn(validation_error, UserWarning)
-        # Bail out early if critical columns are missing — cleanup_raw_data
+        # Bail out early if critical columns are missing — _cleanup_raw_data
         # would crash with an opaque ColumnNotFoundError otherwise.
         # Check using display names; account for both raw keys and display
         # names already present in the data (rename hasn't happened yet).
@@ -278,7 +301,7 @@ class DecisionAnalyzer:
             )
         else:
             raw_data = raw_data.with_columns(is_mandatory=pl.lit(0))
-        self.decision_data = self.cleanup_raw_data(raw_data)
+        self.decision_data = self._cleanup_raw_data(raw_data)
         available_columns = set(self.decision_data.collect_schema().names())
         self.fields_for_data_filtering = [f for f in self._default_filter_fields if f in available_columns]
         self.preaggregation_columns = {
@@ -585,7 +608,7 @@ class DecisionAnalyzer:
         ).row(0, named=True)
 
         # Build warning messages
-        warnings = []
+        messages: list[str] = []
 
         # Check for invalid propensities (> 1.0)
         if stats["invalid_count"] > 0:
@@ -603,7 +626,7 @@ class DecisionAnalyzer:
                 else f"{', '.join(invalid_stages[:3])}, and {len(invalid_stages) - 3} more"
             )
 
-            warnings.append(
+            messages.append(
                 f"⚠️ **Invalid propensity values detected:**\n\n"
                 f"• {stats['invalid_count']:,} records ({invalid_pct:.2f}%) have propensities > 1.0\n\n"
                 f"• Maximum propensity: {stats['max']:.2f}\n\n"
@@ -628,7 +651,7 @@ class DecisionAnalyzer:
                     else f"{', '.join(high_stages[:3])}, and {len(high_stages) - 3} more"
                 )
 
-                warnings.append(
+                messages.append(
                     f"ℹ️ **Unusually high propensities detected:**\n\n"
                     f"• {high_pct:.1f}% of records have propensities > 10%\n\n"
                     f"• 95th percentile propensity: {stats['p95'] * 100:.1f}%\n\n"
@@ -640,7 +663,7 @@ class DecisionAnalyzer:
                     f"Consider reviewing your model configuration if this seems unexpected."
                 )
 
-        return warnings[0] if warnings else None
+        return messages[0] if messages else None
 
     @cached_property
     def arbitration_stage(self) -> pl.LazyFrame:
@@ -853,21 +876,21 @@ class DecisionAnalyzer:
             return self.sample
         return apply_filter(self.sample, filters)
 
-    def get_available_fields_for_filtering(self, categoricalOnly=False) -> list[str]:
+    def get_available_fields_for_filtering(self, *, categorical_only: bool = False) -> list[str]:
         """Return column names available for data filtering.
 
         Parameters
         ----------
-        categoricalOnly : bool, default False
+        categorical_only : bool, default False
             If True, return only string/categorical columns.
         """
-        if not categoricalOnly:
+        if not categorical_only:
             return list(self.fields_for_data_filtering)
 
         string_cols = set(self.decision_data.select(cs.string(include_categorical=True)).collect_schema().keys())
         return [f for f in self.fields_for_data_filtering if f in string_cols]
 
-    def cleanup_raw_data(self, df: pl.LazyFrame):
+    def _cleanup_raw_data(self, df: pl.LazyFrame) -> pl.LazyFrame:
         """This method cleans up the raw data we read from parquet/S3/whatever.
 
         This likely needs to change as and when we get closer to product, to
@@ -927,9 +950,7 @@ class DecisionAnalyzer:
             .with_columns(
                 pl.col(self.level).cast(pl.Categorical),
             )
-            .filter(
-                pl.col("Action").is_not_null()
-            )  # Why do we have null pyName values? this takes too much processing time
+            .filter(pl.col("Action").is_not_null())  # Drop rows with null Action; this takes some processing time
         )
         return preproc_df
 
@@ -1004,7 +1025,7 @@ class DecisionAnalyzer:
         return distribution_data
 
     def get_funnel_data(
-        self, scope, additional_filters: pl.Expr | list[pl.Expr] | None = None
+        self, scope: str, additional_filters: pl.Expr | list[pl.Expr] | None = None
     ) -> tuple[pl.LazyFrame, pl.DataFrame, pl.DataFrame]:
         filtered_df = apply_filter(self.preaggregated_filter_view, additional_filters)
 
@@ -1324,7 +1345,7 @@ class DecisionAnalyzer:
         Returns
         -------
         pl.DataFrame
-            Columns include pxComponentName, StageGroup, scope columns, and
+            Columns include Component Name, StageGroup, scope columns, and
             Filtered Decisions. Sorted by component then descending count.
         """
         filtered_data = apply_filter(self.decision_data, additional_filters).filter(
@@ -1373,7 +1394,7 @@ class DecisionAnalyzer:
         Parameters
         ----------
         component_name : str
-            The pxComponentName to drill into.
+            The Component Name to drill into.
         scope : str, default "Action"
             Granularity level: ``"Issue"``, ``"Group"``, or ``"Action"``.
         additional_filters : pl.Expr or list of pl.Expr, optional
@@ -1728,7 +1749,7 @@ class DecisionAnalyzer:
             dist = dist.with_columns(pl.lit(0.0).alias("Avg per Decision"))
         return dist
 
-    def get_optionality_data(self, df=None, by_day: bool = False) -> pl.LazyFrame:
+    def get_optionality_data(self, df: pl.LazyFrame | None = None, by_day: bool = False) -> pl.LazyFrame:
         """Average number of actions per stage, optionally broken down by day.
 
         Computes per-interaction action counts at each stage using
@@ -1792,7 +1813,7 @@ class DecisionAnalyzer:
 
         return optionality_data
 
-    def get_optionality_funnel(self, df=None) -> pl.LazyFrame:
+    def get_optionality_funnel(self, df: pl.LazyFrame | None = None) -> pl.LazyFrame:
         """Optionality funnel: interaction counts bucketed by available-action count.
 
         Buckets action counts into 0–6 and 7+, then counts interactions per
@@ -1826,7 +1847,11 @@ class DecisionAnalyzer:
         )
         return optionality_funnel
 
-    def get_action_variation_data(self, stage, color_by=None):
+    def get_action_variation_data(
+        self,
+        stage: str,
+        color_by: str | None = None,
+    ) -> pl.LazyFrame:
         """Get action variation data, optionally broken down by a categorical dimension.
 
         Args:
@@ -2041,7 +2066,13 @@ class DecisionAnalyzer:
         self._thresholding_cache[cache_key] = thresholds_long
         return thresholds_long
 
-    def priority_component_distribution(self, component, granularity, stage=None, additional_filters=None):
+    def priority_component_distribution(
+        self,
+        component: str,
+        granularity: str,
+        stage: str | None = None,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+    ) -> pl.LazyFrame:
         """Data for a single component's distribution, grouped by granularity.
 
         Parameters
@@ -2060,7 +2091,12 @@ class DecisionAnalyzer:
         df = self._remaining_at_stage(stage, additional_filters=additional_filters)
         return df.select(cols).sort(granularity)
 
-    def all_components_distribution(self, granularity, stage=None, additional_filters=None):
+    def all_components_distribution(
+        self,
+        granularity: str,
+        stage: str | None = None,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+    ) -> pl.LazyFrame:
         """Data for the overview panel: all prioritization components at once.
 
         Parameters
@@ -2079,7 +2115,11 @@ class DecisionAnalyzer:
         df = self._remaining_at_stage(stage, additional_filters=additional_filters)
         return df.select([granularity] + cols).sort(granularity)
 
-    def _remaining_at_stage(self, stage=None, additional_filters=None):
+    def _remaining_at_stage(
+        self,
+        stage: str | None = None,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+    ) -> pl.LazyFrame:
         """Return sample rows remaining at *stage*.
 
         Uses the ``aggregate_remaining_per_stage`` logic: rows whose stage
@@ -2094,7 +2134,10 @@ class DecisionAnalyzer:
         return base.filter(pl.col(self.level).is_in(remaining_stages))
 
     def aggregate_remaining_per_stage(
-        self, df: pl.LazyFrame, group_by_columns: list[str], aggregations: list | None = None
+        self,
+        df: pl.LazyFrame,
+        group_by_columns: list[str],
+        aggregations: list[pl.Expr] | None = None,
     ) -> pl.LazyFrame:
         """
         Workhorse function to convert the raw Decision Analyzer data (filter view) to
@@ -2136,7 +2179,7 @@ class DecisionAnalyzer:
 
     def filtered_action_counts(
         self,
-        groupby_cols: list,
+        groupby_cols: list[str],
         propensityTH: float | None = None,
         priorityTH: float | None = None,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
@@ -2145,7 +2188,7 @@ class DecisionAnalyzer:
 
         Parameters
         ----------
-        groupby_cols : list
+        groupby_cols : list of str
             Column names to group by.
         propensityTH : float, optional
             Propensity threshold for classifying offers.
@@ -2355,7 +2398,12 @@ class DecisionAnalyzer:
 
         return {k: kpis[k].item() for k in kpis.columns}
 
-    def get_sensitivity(self, win_rank=1, group_filter=None, additional_filters=None):
+    def get_sensitivity(
+        self,
+        win_rank: int = 1,
+        group_filter: pl.Expr | list[pl.Expr] | None = None,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+    ) -> pl.LazyFrame:
         """Global or local sensitivity of the prioritization factors.
 
         Parameters
@@ -2652,7 +2700,7 @@ class DecisionAnalyzer:
         -------
         pl.DataFrame
             DataFrame containing win distribution with columns:
-            - pyIssue, pyGroup, pyName: Action identifiers
+            - Issue, Group, Action: Action identifiers
             - original_win_count: Number of rank-1 wins in baseline scenario
             - new_win_count: Number of rank-1 wins after lever adjustment (only if lever_value provided)
             - n_decisions_survived_to_arbitration: Number of arbitration decisions the action participated in

--- a/python/pdstools/decision_analyzer/data_read_utils.py
+++ b/python/pdstools/decision_analyzer/data_read_utils.py
@@ -1,5 +1,6 @@
 # python/pdstools/decision_analyzer/data_read_utils.py
 import gzip
+import logging
 import zipfile
 from io import BytesIO
 from pathlib import Path
@@ -9,6 +10,8 @@ import polars as pl
 from ..pega_io.File import _is_artifact
 from .column_schema import TableConfig
 from .utils import ColumnResolver
+
+logger = logging.getLogger(__name__)
 
 
 # Decision Analyzer specific data reading utilities
@@ -90,7 +93,7 @@ def read_gzipped_data(data: BytesIO) -> pl.LazyFrame | None:
             file_content = file.read()
             return pl.read_ndjson(BytesIO(file_content)).lazy()
     except Exception as e:
-        print(f"Error reading gzipped data: {e}")
+        logger.warning("Error reading gzipped data: %s", e)
         return None
 
 

--- a/python/pdstools/decision_analyzer/utils.py
+++ b/python/pdstools/decision_analyzer/utils.py
@@ -13,6 +13,8 @@ from .column_schema import (
     ExplainabilityExtract,
 )
 
+logger = logging.getLogger(__name__)
+
 # As long as this is run once, anywhere, it's enabled globally.
 # Putting it here AND in the Home.py file should therefore be enough,
 # because every other file imports from utils.py (hence running this part too.)
@@ -490,8 +492,6 @@ def get_scope_config(
             "plot_title_prefix": "Win Count by Issue",
         }
 
-
-logger = logging.getLogger(__name__)
 
 _INTERACTION_ID_RAW_KEY = "pxInteractionID"
 

--- a/python/tests/test_DecisionAnalyzer.py
+++ b/python/tests/test_DecisionAnalyzer.py
@@ -1368,7 +1368,7 @@ class TestScopeHelpers:
         assert "Action" in fields
 
     def test_available_categorical_fields(self, da_v1):
-        fields = da_v1.get_available_fields_for_filtering(categoricalOnly=True)
+        fields = da_v1.get_available_fields_for_filtering(categorical_only=True)
         assert len(fields) == 5
 
 


### PR DESCRIPTION
Walks the DA library files through the AGENTS.md gold-standard checklist for top-level analyzer classes. Sister change to the recent ADM, Prediction, and Explanations refactors.

Library-side breaking changes (v5):

- DecisionAnalyzer.__init__ keyword arguments are now keyword-only (level, sample_size, mandatory_expr, additional_columns, num_samples). Positional usage now raises TypeError.
- from_explainability_extract / from_decision_analyzer no longer accept **kwargs. They forward an explicit, typed parameter list to __init__, so unknown kwargs surface immediately instead of being silently dropped.
- get_available_fields_for_filtering: parameter renamed categoricalOnly -> categorical_only, made keyword-only.
- cleanup_raw_data made private (_cleanup_raw_data). It was only ever called from __init__; no public callers in the codebase.

Non-breaking gold-standard tightening:

- Replaced print() in data_read_utils with logger.warning().
- Moved module-level logger to the top of utils.py (was buried mid-file at line 494).
- Renamed the local 'warnings' list inside propensity_validation_warning to 'messages' so it no longer shadows the imported 'warnings' module - a latent bug waiting for someone to add a warnings.warn() call inside that branch.
- Added type hints to several public methods that were untyped or partially typed: priority_component_distribution, all_components_distribution, _remaining_at_stage, get_action_variation_data, get_optionality_data, get_optionality_funnel, get_funnel_data, get_sensitivity, filtered_action_counts, aggregate_remaining_per_stage.
- Cleaned Pega raw-key references out of docstrings and comments (pyName, pyIssue, pyGroup, pxComponentName) - the public API uses display names everywhere.

Out of scope (deferred to follow-up PRs):

- plots.py (1698 LOC) - held back for a separate big-file-split agent, so propensityTH/priorityTH renames are deferred too (filed under docs/plans/decision-analyzer/).
- decision_analyzer/__init__.py - owned by another in-flight PR.
- Any namespace-facade split of the 40+ DA methods - too large for this PR, would balloon scope.

Tests: 1688 passed, 11 skipped (full suite minus heavy excludes).

CHANGELOG.md and docs/migration-v4-to-v5.md updated with the breaking changes.