### PR TITLE
refactor(decision-analyzer/app): convert bare imports to absolute (#724)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ guide.
 ### Changed
 
 - (To be populated by the v5 cleanup PRs.)
+- Decision Analyzer Streamlit pages: converted bare
+  `from da_streamlit_utils import ...` imports to absolute
+  `from pdstools.app.decision_analyzer.da_streamlit_utils import ...`,
+  matching the Health Check and Impact Analyzer apps. This removes the
+  dependency on `streamlit run`'s `sys.path` mutation and unblocks
+  testing DA pages with `streamlit.testing.v1.AppTest` (#724).
 - Decision Analyzer plot helpers: renamed `propensityTH` / `priorityTH`
   keyword arguments to `propensity_th` / `priority_th` on
   `DecisionAnalyzer.get_offer_quality`,

--- a/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
@@ -1,7 +1,7 @@
 # python/pdstools/app/decision_analyzer/pages/11_Arbitration_Distribution.py
 import polars as pl
 import streamlit as st
-from da_streamlit_utils import (
+from pdstools.app.decision_analyzer.da_streamlit_utils import (
     collect_page_filters,
     contextual_filters,
     ensure_data,

--- a/python/pdstools/app/decision_analyzer/pages/11_Single_Decision.py
+++ b/python/pdstools/app/decision_analyzer/pages/11_Single_Decision.py
@@ -5,7 +5,7 @@ from itertools import groupby
 import polars as pl
 import streamlit as st
 import streamlit.components.v1 as components
-from da_streamlit_utils import (
+from pdstools.app.decision_analyzer.da_streamlit_utils import (
     ensure_data,
     stage_level_selector,
 )

--- a/python/pdstools/app/decision_analyzer/pages/2_Overview.py
+++ b/python/pdstools/app/decision_analyzer/pages/2_Overview.py
@@ -1,6 +1,10 @@
 import polars as pl
 import streamlit as st
-from da_streamlit_utils import collect_page_filters, ensure_data, polars_lazyframe_hashing
+from pdstools.app.decision_analyzer.da_streamlit_utils import (
+    collect_page_filters,
+    ensure_data,
+    polars_lazyframe_hashing,
+)
 
 from pdstools.decision_analyzer.plots import offer_quality_single_pie
 from pdstools.utils.streamlit_utils import standard_page_config

--- a/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
@@ -1,7 +1,7 @@
 import polars as pl
 import streamlit as st
 
-from da_streamlit_utils import (
+from pdstools.app.decision_analyzer.da_streamlit_utils import (
     collect_page_filters,
     contextual_filters,
     ensure_data,

--- a/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
+++ b/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
@@ -1,7 +1,7 @@
 # python/pdstools/app/decision_analyzer/pages/5_Action_Funnel.py
 import polars as pl
 import streamlit as st
-from da_streamlit_utils import (
+from pdstools.app.decision_analyzer.da_streamlit_utils import (
     collect_page_filters,
     contextual_filters,
     ensure_data,

--- a/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
+++ b/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
@@ -1,6 +1,6 @@
 import polars as pl
 import streamlit as st
-from da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data
+from pdstools.app.decision_analyzer.da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data
 from pdstools.utils.streamlit_utils import get_current_index
 
 from pdstools.decision_analyzer.utils import apply_filter

--- a/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
@@ -1,6 +1,6 @@
 import polars as pl
 import streamlit as st
-from da_streamlit_utils import (
+from pdstools.app.decision_analyzer.da_streamlit_utils import (
     collect_page_filters,
     contextual_filters,
     ensure_data,

--- a/python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
@@ -1,7 +1,7 @@
 # python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
 import polars as pl
 import streamlit as st
-from da_streamlit_utils import (
+from pdstools.app.decision_analyzer.da_streamlit_utils import (
     collect_page_filters,
     contextual_filters,
     ensure_data,

--- a/python/pdstools/app/decision_analyzer/pages/8_Offer_Quality_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/8_Offer_Quality_Analysis.py
@@ -3,7 +3,7 @@ import polars as pl
 import streamlit as st
 
 from pdstools.decision_analyzer.plots import getTrendChart, offer_quality_piecharts
-from da_streamlit_utils import (
+from pdstools.app.decision_analyzer.da_streamlit_utils import (
     collect_page_filters,
     contextual_filters,
     ensure_data,

--- a/python/pdstools/app/decision_analyzer/pages/9_Thresholding_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/9_Thresholding_Analysis.py
@@ -5,7 +5,7 @@ import plotly.express as px
 import polars as pl
 import streamlit as st
 
-from da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data
+from pdstools.app.decision_analyzer.da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data
 from pdstools.decision_analyzer.utils import apply_filter
 from pdstools.utils.streamlit_utils import standard_page_config
 


### PR DESCRIPTION
The 10 DA Streamlit pages used bare `from da_streamlit_utils import ...` imports that only resolved because `streamlit run Home.py` mutates `sys.path` at startup. Health Check and Impact Analyzer already use full-package imports — DA was inconsistent.

Converted all pages to
`from pdstools.app.decision_analyzer.da_streamlit_utils import ...`. This removes the `sys.path` dependency and unblocks testing DA pages with `streamlit.testing.v1.AppTest`, which does not replicate the `sys.path` mutation.