### PR TITLE
test(streamlit): add AppTest smoke coverage for all three apps (#724)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,13 @@ guide.
 - `pdstools.valuefinder.__init__` now re-exports `ValueFinder` (was empty).
 - `CHANGELOG.md` (this file).
 - `docs/migration-v4-to-v5.md`.
+- AppTest-based smoke tests for all three Streamlit apps under
+  `python/tests/streamlit_apps/` — covers Decision Analyzer (Home + 10
+  sub-pages), Health Check (Home + 3 sub-pages) and Impact Analyzer
+  (Home + 3 sub-pages). Uses seeded fixtures so pages render the
+  populated branch, not the upload-prompt branch.
+- Unit tests for `cdh_utils.get_latest_pdstools_version` covering
+  happy path, network failure and malformed-response paths.
 
 ---
 

--- a/python/tests/streamlit_apps/conftest.py
+++ b/python/tests/streamlit_apps/conftest.py
@@ -1,0 +1,127 @@
+"""Shared fixtures for Streamlit AppTest-based page tests.
+
+These tests exercise the Streamlit layer in-process via
+``streamlit.testing.v1.AppTest`` — no browser, no server. They cover
+the glue that unit tests can't: session_state wiring, widget
+persistence, ``ensure_data()`` guards, filter namespacing, and the
+assumptions made by ``standard_page_config`` / ``show_sidebar_branding``.
+
+Library-level logic (plots, aggregates, compute) is covered by the
+main test suite; these tests intentionally stay thin at the page
+level — assert the page renders without exception and the expected
+widgets / session_state are present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pdstools.adm.ADMDatamart import ADMDatamart
+from pdstools.decision_analyzer.DecisionAnalyzer import DecisionAnalyzer
+from pdstools.impactanalyzer.ImpactAnalyzer import ImpactAnalyzer
+
+
+@pytest.fixture(autouse=True)
+def _stub_pypi_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent AppTest pages from calling PyPI for the latest-version check.
+
+    ``show_about_page()`` (and the sidebar branding helper) call
+    ``cdh_utils.get_latest_pdstools_version()`` which hits PyPI with a
+    5 s timeout. Under AppTest the call slows tests down and adds
+    network flake — the version-check helper has its own dedicated
+    unit test, so mocking it here is the right boundary.
+    """
+    monkeypatch.setattr(
+        "pdstools.utils.cdh_utils._io.get_latest_pdstools_version",
+        lambda: None,
+    )
+    # Streamlit's ``@st.cache_data`` persists across AppTest script
+    # runs in the same process — clear it so the patched function is
+    # actually called instead of a stale cached return value.
+    import streamlit as st
+
+    st.cache_data.clear()
+    st.cache_resource.clear()
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DATA_DIR = REPO_ROOT / "data"
+
+DA_APP_DIR = REPO_ROOT / "python" / "pdstools" / "app" / "decision_analyzer"
+HC_APP_DIR = REPO_ROOT / "python" / "pdstools" / "app" / "health_check"
+IA_APP_DIR = REPO_ROOT / "python" / "pdstools" / "app" / "impact_analyzer"
+
+DA_SAMPLE_CSV = DATA_DIR / "da" / "sample_eev2_minimal.csv"
+ADM_MODEL_FILE = "Data-Decision-ADM-ModelSnapshot_pyModelSnapshots_20210526T131808_GMT.zip"
+ADM_PREDICTOR_FILE = "Data-Decision-ADM-PredictorBinningSnapshot_pyADMPredictorSnapshots_20210526T133622_GMT.zip"
+
+
+@pytest.fixture(scope="session")
+def da_app_dir() -> Path:
+    """Absolute path to the DA Streamlit app directory."""
+    return DA_APP_DIR
+
+
+@pytest.fixture(scope="session")
+def hc_app_dir() -> Path:
+    """Absolute path to the Health Check Streamlit app directory."""
+    return HC_APP_DIR
+
+
+@pytest.fixture(scope="session")
+def ia_app_dir() -> Path:
+    """Absolute path to the Impact Analyzer Streamlit app directory."""
+    return IA_APP_DIR
+
+
+@pytest.fixture(scope="session")
+def da_sample_path() -> Path:
+    """Path to the minimal EEV2 sample used for DA smoke tests.
+
+    Using the minimal CSV (not the full parquet) keeps test runtime
+    down — every value in it is traceable back to the fixture, which
+    also helps when we promote smoke tests to exact-value tests.
+    """
+    if not DA_SAMPLE_CSV.exists():
+        pytest.skip(f"DA sample data missing: {DA_SAMPLE_CSV}")
+    return DA_SAMPLE_CSV
+
+
+@pytest.fixture
+def seeded_decision_analyzer(da_sample_path: Path) -> DecisionAnalyzer:
+    """A DecisionAnalyzer pre-loaded with the minimal EEV2 fixture.
+
+    Tests inject this into ``session_state["decision_data"]`` before
+    running the page so ``ensure_data()`` guards pass.
+    """
+    return DecisionAnalyzer.from_decision_analyzer(da_sample_path)
+
+
+@pytest.fixture
+def seeded_admdatamart() -> ADMDatamart:
+    """An ADMDatamart loaded from the canonical CDH sample.
+
+    Health Check pages read this from ``st.session_state["dm"]``. We
+    re-use the same fixture data as ``test_ADMDatamart.py`` so any
+    schema drift surfaces in both layers.
+    """
+    if not (DATA_DIR / ADM_MODEL_FILE).exists():
+        pytest.skip(f"ADM sample data missing: {DATA_DIR / ADM_MODEL_FILE}")
+    return ADMDatamart.from_ds_export(
+        base_path=str(DATA_DIR),
+        model_filename=ADM_MODEL_FILE,
+        predictor_filename=ADM_PREDICTOR_FILE,
+    )
+
+
+IA_SAMPLE_JSON = DATA_DIR / "ia" / "CDH_Metrics_ImpactAnalyzer.json"
+
+
+@pytest.fixture
+def seeded_impact_analyzer() -> ImpactAnalyzer:
+    """An ImpactAnalyzer loaded from the bundled PDC sample."""
+    if not IA_SAMPLE_JSON.exists():
+        pytest.skip(f"IA sample data missing: {IA_SAMPLE_JSON}")
+    return ImpactAnalyzer.from_pdc(str(IA_SAMPLE_JSON))

--- a/python/tests/streamlit_apps/decision_analyzer/test_da_home.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_da_home.py
@@ -1,0 +1,32 @@
+"""AppTest smoke tests for the Decision Analysis Home page.
+
+Home is the data-entry point — it doesn't depend on prior
+``session_state``, so these tests exercise the "no data loaded yet"
+rendering path. Pages 2+ are tested with ``session_state.decision_data``
+seeded via the ``seeded_decision_analyzer`` fixture.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from streamlit.testing.v1 import AppTest
+
+
+def test_home_renders_without_data(da_app_dir: Path):
+    """Home page renders cleanly before any data is uploaded.
+
+    This is the first thing a user sees — if it raises we have a
+    boot-time regression. Checks:
+    - No exception bubbles out of the script.
+    - The page title appears (proves ``standard_page_config`` ran).
+    - At least one input widget rendered (the sample-size spinner).
+    """
+    at = AppTest.from_file(str(da_app_dir / "Home.py"), default_timeout=30)
+    at.run()
+
+    assert not at.exception, f"Home raised: {at.exception}"
+    headings = [str(h.value) for h in at.title] + [str(h.value) for h in at.header]
+    headings += [str(m.value) for m in at.markdown]
+    assert any("Decision Analysis" in s for s in headings), "Expected 'Decision Analysis' header/title not found"
+    assert list(at.number_input), "Expected at least one number_input (sample size)"

--- a/python/tests/streamlit_apps/decision_analyzer/test_da_pages.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_da_pages.py
@@ -1,0 +1,56 @@
+"""AppTest smoke tests for Decision Analyzer sub-pages.
+
+Each page is exercised once with a seeded ``DecisionAnalyzer`` in
+``session_state["decision_data"]`` — mirroring how a real user
+arrives at the page after loading data on Home. We assert only that
+the page renders without exception; library-layer behaviour is
+covered by ``test_DecisionAnalyzer.py`` and friends.
+
+Adding a new page test
+----------------------
+Append the page filename to ``DA_PAGES`` below. No other change
+needed — the parametrize id keeps reports readable.
+
+Phase 2 (filter persistence, ensure_data guards, #649-style
+regression locks) will get its own test files; this file stays
+narrowly scoped to "boots without crashing".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from pdstools.decision_analyzer.DecisionAnalyzer import DecisionAnalyzer
+
+# Page 12 (About) is intentionally excluded — it uses the shared
+# `show_about_page()` helper, which is exercised by the HC/IA About
+# tests and doesn't depend on `decision_data`.
+DA_PAGES = [
+    "2_Overview.py",
+    "3_Action_Distribution.py",
+    "4_Action_Funnel.py",
+    "5_Global_Sensitivity.py",
+    "6_Win_Loss_Analysis.py",
+    "7_Optionality_Analysis.py",
+    "8_Offer_Quality_Analysis.py",
+    "9_Thresholding_Analysis.py",
+    "10_Arbitration_Distribution.py",
+    "11_Single_Decision.py",
+]
+
+
+@pytest.mark.parametrize("page", DA_PAGES, ids=lambda p: p.removesuffix(".py"))
+def test_da_page_renders(
+    page: str,
+    seeded_decision_analyzer: DecisionAnalyzer,
+    da_app_dir: Path,
+):
+    """Page renders with seeded ``decision_data`` and no exception."""
+    at = AppTest.from_file(str(da_app_dir / "pages" / page), default_timeout=30)
+    at.session_state["decision_data"] = seeded_decision_analyzer
+    at.run()
+
+    assert not at.exception, f"{page} raised: {at.exception}"

--- a/python/tests/streamlit_apps/health_check/test_hc_pages.py
+++ b/python/tests/streamlit_apps/health_check/test_hc_pages.py
@@ -1,0 +1,39 @@
+"""AppTest smoke tests for the Health Check Streamlit app."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from pdstools.adm.ADMDatamart import ADMDatamart
+
+
+def test_home_renders_without_data(hc_app_dir: Path):
+    """Home renders cleanly before any data is uploaded."""
+    at = AppTest.from_file(str(hc_app_dir / "Home.py"), default_timeout=30)
+    at.run()
+    assert not at.exception, f"HC Home raised: {at.exception}"
+
+
+# Page 3 (About) renders the shared about page with no session_state
+# requirement, so it's covered by the no-data path.
+HC_PAGES = ["1_Data_Filters.py", "2_Reports.py", "3_About.py"]
+
+
+@pytest.mark.parametrize("page", HC_PAGES, ids=lambda p: p.removesuffix(".py"))
+def test_hc_page_renders(
+    page: str,
+    seeded_admdatamart: ADMDatamart,
+    hc_app_dir: Path,
+):
+    """Each sub-page renders with a seeded ADMDatamart and no exception.
+
+    HC pages guard with ``if "dm" in st.session_state`` rather than a
+    helper, so seeding the key reaches the populated branch.
+    """
+    at = AppTest.from_file(str(hc_app_dir / "pages" / page), default_timeout=30)
+    at.session_state["dm"] = seeded_admdatamart
+    at.run()
+    assert not at.exception, f"{page} raised: {at.exception}"

--- a/python/tests/streamlit_apps/impact_analyzer/test_ia_pages.py
+++ b/python/tests/streamlit_apps/impact_analyzer/test_ia_pages.py
@@ -1,0 +1,37 @@
+"""AppTest smoke tests for the Impact Analyzer Streamlit app."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from pdstools.impactanalyzer.ImpactAnalyzer import ImpactAnalyzer
+
+
+def test_home_renders_without_data(ia_app_dir: Path):
+    """Home renders cleanly before any data is uploaded."""
+    at = AppTest.from_file(str(ia_app_dir / "Home.py"), default_timeout=30)
+    at.run()
+    assert not at.exception, f"IA Home raised: {at.exception}"
+
+
+# Page 3 (About) renders the shared about page and is covered by the
+# no-data path; sub-pages 1 and 2 require ``impact_analyzer`` in
+# session_state via ``ensure_impact_analyzer()``.
+IA_PAGES = ["1_Overall_Summary.py", "2_Trend.py", "3_About.py"]
+
+
+@pytest.mark.parametrize("page", IA_PAGES, ids=lambda p: p.removesuffix(".py"))
+def test_ia_page_renders(
+    page: str,
+    seeded_impact_analyzer: ImpactAnalyzer,
+    ia_app_dir: Path,
+):
+    """Each sub-page renders with a seeded ImpactAnalyzer and no exception."""
+    at = AppTest.from_file(str(ia_app_dir / "pages" / page), default_timeout=30)
+    at.session_state["impact_analyzer"] = seeded_impact_analyzer
+    at.session_state["ia_is_sample_data"] = True
+    at.run()
+    assert not at.exception, f"{page} raised: {at.exception}"

--- a/python/tests/test_cdh_utils.py
+++ b/python/tests/test_cdh_utils.py
@@ -1370,3 +1370,34 @@ def test_is_valid_polars_duration_custom_max_length():
 
     # Should reject with smaller limit
     assert not cdh_utils.is_valid_polars_duration("1d", max_length=1)
+
+
+class TestGetLatestPdstoolsVersion:
+    """Targeted tests for the PyPI version-check helper.
+
+    The helper is mocked out at the AppTest layer (see
+    ``python/tests/streamlit_apps/conftest.py``) so it doesn't slow
+    those tests down — these unit tests exercise the actual call
+    behaviour instead.
+    """
+
+    def test_happy_path(self, mocker):
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {"info": {"version": "9.9.9"}}
+        mocker.patch("requests.get", return_value=mock_response)
+        assert cdh_utils.get_latest_pdstools_version() == "9.9.9"
+
+    def test_returns_none_on_request_failure(self, mocker):
+        import requests
+
+        mocker.patch(
+            "requests.get",
+            side_effect=requests.RequestException("network down"),
+        )
+        assert cdh_utils.get_latest_pdstools_version() is None
+
+    def test_returns_none_on_malformed_response(self, mocker):
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {"unexpected": "shape"}
+        mocker.patch("requests.get", return_value=mock_response)
+        assert cdh_utils.get_latest_pdstools_version() is None


### PR DESCRIPTION
Adds in-process Streamlit page tests using
``streamlit.testing.v1.AppTest`` — no browser, no server. Covers:

- Decision Analyzer: Home + 10 sub-pages (parametrized).
- Health Check: Home (no-data path) + 3 sub-pages with seeded ``ADMDatamart`` injected as ``session_state["dm"]``.
- Impact Analyzer: Home (no-data path) + 3 sub-pages with seeded ``ImpactAnalyzer`` injected as ``session_state["impact_analyzer"]``.

Each test asserts only that the page renders without exception; library-layer behaviour stays in the existing pytest suite.

Conftest mocks ``cdh_utils.get_latest_pdstools_version`` so the About / sidebar branding helpers don't hit PyPI under test, and clears ``st.cache_data`` / ``st.cache_resource`` between runs so state from a prior page doesn't leak. The version-check helper gets its own dedicated unit tests (happy / network-failure / malformed-response) added to ``test_cdh_utils.py``.

Tests live under ``python/tests/streamlit_apps/`` (not ``streamlit/`` — that name shadows the real package and breaks collection). Test filenames are unique across subfolders so pytest's rootdir-based collection doesn't trip on import-mismatch.

Closes the AppTest skeleton tracked in
``docs/plans/testing/streamlit-apptest-coverage.md``, and closes #723 