### PR TITLE
refactor(typing): final sweep of # type: ignore comments

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -1092,7 +1092,7 @@ class ADMDatamart:
         # time is null, due to import/export woes. This is problematic
         # for model data but here we just test for it and assume one snapshot.
         most_recent_binning_data = cdh_utils._apply_query(
-            self.predictor_data.filter(  # type: ignore[union-attr]
+            self._require_predictor_data().filter(
                 (
                     # TODO consider using the "last" function of the aggregates
                     # last("predictor_data") instead of this, but that currently

--- a/python/pdstools/adm/BinAggregator.py
+++ b/python/pdstools/adm/BinAggregator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 __all__ = ["BinAggregator"]
 import logging
 from functools import cached_property
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 import polars as pl
 
@@ -184,10 +184,11 @@ class BinAggregator(LazyNamespace):
                     )
 
                 if is_numeric:
+                    assert empty_numeric_binning is not None  # set above when is_numeric
                     cum_binning = self.accumulate_num_binnings(
                         predictor,
                         ids,
-                        empty_numeric_binning.clone(),  # type: ignore[union-attr]
+                        empty_numeric_binning.clone(),
                     )
                 else:
                     cum_binning = self.accumulate_sym_binnings(
@@ -558,19 +559,19 @@ class BinAggregator(LazyNamespace):
         if len(boundaries) == 1:
             boundaries = boundaries * 2
 
-        boundaries = np.array(boundaries, dtype=np.float64)  # type: ignore[assignment]
+        boundaries_arr = np.array(boundaries, dtype=np.float64)
 
         target_binning = pl.DataFrame(
             {
                 "PredictorName": predictor,
-                "BinIndex": list(range(1, len(boundaries))),
-                "BinLowerBound": boundaries[:-1],
-                "BinUpperBound": boundaries[1:],
+                "BinIndex": list(range(1, len(boundaries_arr))),
+                "BinLowerBound": boundaries_arr[:-1],
+                "BinUpperBound": boundaries_arr[1:],
             },
         ).with_columns(
             # Creating a simple representation of the intervals
             # TODO: the round(2) should be generalized
-            pl.when(pl.col("BinIndex") < len(boundaries))
+            pl.when(pl.col("BinIndex") < len(boundaries_arr))
             .then(pl.format("<{}", pl.col("BinUpperBound").round(2)))
             .otherwise(pl.format("<={}", pl.col("BinUpperBound").round(2)))
             .alias("BinSymbol"),
@@ -901,20 +902,23 @@ class BinAggregator(LazyNamespace):
 
         n_channels = self.all_predictorbinning.select(["Channel", "Direction"]).unique().collect().shape[0]
 
-        fig = self.plot_binning_lift(
-            binning.with_columns(
-                (pl.col("BinCoverage") / pl.col("Models")).alias("RelativeBinCoverage"),
+        fig = cast(
+            "Figure",
+            self.plot_binning_lift(
+                binning.with_columns(
+                    (pl.col("BinCoverage") / pl.col("Models")).alias("RelativeBinCoverage"),
+                ),
+                col_facet=model_facet,
+                row_facet=predictor_facet,
+                custom_data=[
+                    "PredictorName",
+                    "BinSymbol",
+                    "RelativeBinCoverage",
+                    "BinResponses",
+                ],
             ),
-            col_facet=model_facet,
-            row_facet=predictor_facet,
-            custom_data=[
-                "PredictorName",
-                "BinSymbol",
-                "RelativeBinCoverage",
-                "BinResponses",
-            ],
         )
-        fig.update_traces(  # type: ignore[union-attr]
+        fig.update_traces(
             hovertemplate="<br>".join(
                 [
                     "<b>%{customdata[0]}</b>",
@@ -937,7 +941,7 @@ class BinAggregator(LazyNamespace):
         else:
             title = f"Propensity lift in {n_models} models across {n_channels} channels"
 
-        fig.update_layout(  # type: ignore[union-attr]
+        fig.update_layout(
             title=title,
         )
 

--- a/python/pdstools/app/decision_analyzer/Home.py
+++ b/python/pdstools/app/decision_analyzer/Home.py
@@ -1,6 +1,7 @@
 # python/pdstools/app/decision_analyzer/Home.py
 import polars as pl
 import streamlit as st
+from typing import cast
 
 from pdstools.app.decision_analyzer.da_streamlit_utils import (
     handle_data_path,
@@ -193,8 +194,8 @@ if raw_data is not None:
             with st.spinner(sampling_msg):
                 raw_data, sample_path = prepare_and_save(
                     raw_data,
-                    n=sample_kwargs.get("n"),  # type: ignore[arg-type]
-                    fraction=sample_kwargs.get("fraction"),  # type: ignore[arg-type]
+                    n=cast("int | None", sample_kwargs.get("n")),
+                    fraction=cast("float | None", sample_kwargs.get("fraction")),
                     output_dir=get_temp_dir(),
                     source_path=data_source_path,
                 )

--- a/python/pdstools/app/health_check/pages/2_Reports.py
+++ b/python/pdstools/app/health_check/pages/2_Reports.py
@@ -33,9 +33,8 @@ with health_check:
     st.title("Generate Health Check")
     """To begin monitoring your models, you can create a Health Check document that provides a summary of all models and predictors."""
     with st.expander("Health Check options"):
-        name = st.text_input("Customer name")
-        if name == "":
-            name = None  # type: ignore[assignment]
+        name_input = st.text_input("Customer name")
+        name: str | None = name_input if name_input != "" else None
         output_type = st.selectbox("Select output type", ["html"], index=0)
         working_dir = Path(st.text_input("Change working directory", "healthCheckDir"))
         keep_temp_files = st.checkbox("Keep temporary files", False)
@@ -118,10 +117,11 @@ with health_check:
                     predictor_binning=include_binning,
                 )
                 st.session_state["run"][st.session_state["runID"]]["tables"] = tablename
-                st.session_state["run"][st.session_state["runID"]]["tablefile"] = open(
-                    tables,  # type: ignore[arg-type]
-                    "rb",
-                )
+                if tables is not None:
+                    st.session_state["run"][st.session_state["runID"]]["tablefile"] = open(
+                        tables,
+                        "rb",
+                    )
                 for message in warning_messages:
                     st.warning(message)
 
@@ -156,7 +156,7 @@ if st.session_state["dm"].predictor_data is not None:
     with model_report:
         try:
             if "working_dir" not in locals():
-                working_dir = "healthCheckDir"  # type: ignore[assignment]
+                working_dir = Path("healthCheckDir")
             if "model_selection_df" not in st.session_state:
                 st.session_state["model_selection_df"] = model_selection_df(
                     df=_apply_query(

--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -762,9 +762,10 @@ def get_latest_file(
 
     def parse_timestamp(filepath: str) -> datetime:
         try:
-            return from_prpc_date_time(
-                re.search(r"\d.{0,15}GMT", filepath)[0].replace("_", " "),  # type: ignore[index]
-            )
+            match = re.search(r"\d.{0,15}GMT", filepath)
+            if match is None:
+                raise ValueError(f"No GMT timestamp pattern found in {filepath}")
+            return from_prpc_date_time(match[0].replace("_", " "))
         except (AttributeError, TypeError, ValueError) as exc:
             logger.debug("Falling back to ctime for %s: %s", filepath, exc)
             return datetime.fromtimestamp(os.path.getctime(filepath), tz=timezone.utc)

--- a/python/pdstools/utils/report_utils/_quarto.py
+++ b/python/pdstools/utils/report_utils/_quarto.py
@@ -42,7 +42,7 @@ def _write_params_files(
     None
 
     """
-    import yaml  # type: ignore[import-untyped]
+    import yaml  # type: ignore[import-untyped]  # types-PyYAML not in project deps
 
     params = params or {}
     analysis = analysis or {}

--- a/python/pdstools/utils/streamlit_utils.py
+++ b/python/pdstools/utils/streamlit_utils.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Literal
 
 from packaging.version import Version, InvalidVersion
 import plotly.express as px
@@ -62,7 +63,7 @@ def _apply_sidebar_logo():
     )
 
 
-def standard_page_config(page_title: str, layout: str = "wide", **kwargs):
+def standard_page_config(page_title: str, layout: Literal["centered", "wide"] = "wide", **kwargs):
     """Apply a consistent ``st.set_page_config`` across all pdstools apps.
 
     Parameters
@@ -79,7 +80,7 @@ def standard_page_config(page_title: str, layout: str = "wide", **kwargs):
     logo_path = _ASSETS_DIR / "pega-logo.svg"
     if logo_path.exists():
         kwargs.setdefault("page_icon", str(logo_path))
-    st.set_page_config(layout=layout, page_title=page_title, **kwargs)  # type: ignore[arg-type]
+    st.set_page_config(layout=layout, page_title=page_title, **kwargs)
     _apply_sidebar_logo()
 
 
@@ -501,15 +502,13 @@ def from_file_path(extract_pyname_keys, codespaces, infer_schema_length=10000):
 
 
 def model_selection_df(df: pl.LazyFrame, context_keys: list):
-    df = (
+    return (
         df.select(["ModelID", "Configuration"] + context_keys)
         .unique()
         .sort("Name")
         .select(pl.lit(False).alias("Generate Report"), pl.all())
-        .collect()  # type: ignore[assignment]
+        .collect()
     )
-
-    return df
 
 
 def filter_dataframe(
@@ -589,7 +588,7 @@ def filter_dataframe(
                     max_value=_max,
                     value=_max,
                 )
-                user_num_input = [user_min, user_max]  # type: ignore[assignment]
+                user_num_input = (user_min, user_max)
             if user_num_input[0] != _min or user_num_input[1] != _max:
                 queries.append(pl.col(column).is_between(*user_num_input))
         elif df.select(cs.temporal()).collect_schema().get(column) is not None:

--- a/python/tests/test_active_ranges.py
+++ b/python/tests/test_active_ranges.py
@@ -99,7 +99,7 @@ def test_active_ranges_edge_cases():
     """Test active_ranges with edge cases."""
     # Test with empty data
     dm_empty = ADMDatamart(model_df=None, predictor_df=None)
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError, match="requires predictor data"):
         dm_empty.active_ranges().collect()
 
     # Test with model data but no predictor data
@@ -108,7 +108,7 @@ def test_active_ranges_edge_cases():
         model_df=pl.scan_csv(test_data_mdls),
         predictor_df=None,
     )
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError, match="requires predictor data"):
         dm_no_predictors.active_ranges().collect()
 
 


### PR DESCRIPTION
Reduce `# type: ignore` comments from 38 to 24 across python/pdstools/. All remaining are justified (third-party stubs, vendor v24_2 client code, pydantic kwargs, mypy ParamSpec limitation, intentional overrides, cooperative MRO).

Counts before / after by area:
  adm:           9 -> 4   (Plots/_helpers.py mypy ParamSpec — keep)
  app:           5 -> 0
  explanations:  1 -> 1   (yaml import-untyped)
  infinity:     14 -> 12  (no removable; v24_2 vendor + cooperative MRO)
  pega_io:       3 -> 2   (requests import-untyped)
  utils:         6 -> 3   (great_tables / yaml / requests imports)

Categories of fixes applied:
- Use existing `_require_predictor_data()` helper (ADMDatamart)
- Replace union-attr ignores with assert / cast (BinAggregator)
- Rename reassigned variables to avoid type-narrowing conflicts (BinAggregator boundaries -> boundaries_arr; 2_Reports.py name -> name_input + name: str | None; 2_Reports.py working_dir wrapped in Path)
- Convert arg-type ignores to typing.cast (decision_analyzer/Home.py)
- Tighten Literal type annotation (streamlit_utils.standard_page_config)
- Replace user_num_input list/tuple mismatch with consistent tuple
- Replace re.search()[0] index-on-Optional with explicit None check (pega_io/File.py)
- Add explanatory comment to lone undocumented yaml import-untyped

Tightly-coupled bug fixes (1):
- python/pdstools/adm/ADMDatamart.py:1095 — `active_ranges()` previously raised `AttributeError` on `None.filter()` when constructed without predictor_data. Now correctly raises `ValueError` with a clear "requires predictor data" message via the existing `_require_predictor_data()` helper. Test in python/tests/test_active_ranges.py::test_active_ranges_edge_cases was relying on the implicit AttributeError; updated to expect the intentional ValueError.