### PR TITLE
refactor(infinity): swap print() for logger.warning in _infer_version

### DIFF
--- a/python/pdstools/infinity/internal/_base_client.py
+++ b/python/pdstools/infinity/internal/_base_client.py
@@ -220,8 +220,9 @@ class SyncAPIClient(BaseClient[httpx.Client]):
             response = self.get("/prweb/api/PredictionStudio/v3/predictions/repository")
         except Exception as e:
             if on_error == "warn":
-                print(
+                logger.warning(
                     "Could not validate connection to the Infinity system. Please check if the system is up.",
+                    exc_info=e,
                 )
                 return None
             if on_error == "error":
@@ -465,8 +466,9 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient]):  # pragma: no cover
                 raise repo
         except Exception as e:
             if on_error == "warn":
-                print(
+                logger.warning(
                     "Could not validate connection to the Infinity system. Please check if the system is up.",
+                    exc_info=e,
                 )
                 return None
             if on_error == "error":

--- a/python/tests/infinity/test_base_client.py
+++ b/python/tests/infinity/test_base_client.py
@@ -274,12 +274,15 @@ class TestSyncInferVersion:
         with pytest.raises(Exception, match="network down"):
             client._infer_version(on_error="error")
 
-    def test_infer_version_warn_mode_prints(self, mocker, capsys):
+    def test_infer_version_warn_mode_logs(self, mocker, caplog):
         client = self._make_client()
         mocker.patch.object(client, "get", side_effect=Exception("network down"))
-        client._infer_version(on_error="warn")
-        captured = capsys.readouterr()
-        assert "Could not validate connection" in captured.out
+        with caplog.at_level("WARNING", logger="pdstools.infinity.internal._base_client"):
+            client._infer_version(on_error="warn")
+        assert any(
+            "Could not validate connection" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
 
     def test_infer_version_ignore_mode_returns_none(self, mocker):
         client = self._make_client()


### PR DESCRIPTION
Two print() calls in `_base_client._infer_version` (sync + async) violated AGENTS.md → "no print() in library code". Module logger is already declared at line 25; one-line swap, message preserved, now includes exc_info for debug-log users.

Closes plan: docs/plans/infinity/replace-print-with-logger.md (peer audit, unmerged) — also remove the plan file in this PR since the work is done.