### PR TITLE
chore: drop redundant '# pragma: no cover' on TYPE_CHECKING blocks

### DIFF
--- a/python/pdstools/adm/Aggregates.py
+++ b/python/pdstools/adm/Aggregates.py
@@ -15,7 +15,7 @@ from ..utils.metric_limits import (
 )
 from ..utils.types import QUERY
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .ADMDatamart import ADMDatamart
 
 logger = logging.getLogger(__name__)

--- a/python/pdstools/adm/BinAggregator.py
+++ b/python/pdstools/adm/BinAggregator.py
@@ -16,7 +16,7 @@ from ..utils.plot_utils import (
     simplify_facet_titles,
 )
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .ADMDatamart import ADMDatamart
 
 logger = logging.getLogger(__name__)

--- a/python/pdstools/adm/Plots/__init__.py
+++ b/python/pdstools/adm/Plots/__init__.py
@@ -43,7 +43,7 @@ from ._performance import _PerformancePlotsMixin
 from ._predictors import _PredictorPlotsMixin
 from ._score import _ScorePlotsMixin
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ..ADMDatamart import ADMDatamart
 
 __all__ = [

--- a/python/pdstools/adm/Plots/_base.py
+++ b/python/pdstools/adm/Plots/_base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ..ADMDatamart import ADMDatamart
 
 

--- a/python/pdstools/adm/Plots/_helpers.py
+++ b/python/pdstools/adm/Plots/_helpers.py
@@ -24,7 +24,7 @@ from typing_extensions import ParamSpec
 from ...utils.metric_limits import MetricLimits
 from ...utils.plot_utils import Figure
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ._base import _PlotsBase
 
 logger = logging.getLogger(__name__)

--- a/python/pdstools/adm/trees/_agb.py
+++ b/python/pdstools/adm/trees/_agb.py
@@ -15,7 +15,7 @@ from ...utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ..ADMDatamart import ADMDatamart
     from ._multi import MultiTrees
 

--- a/python/pdstools/adm/trees/_model.py
+++ b/python/pdstools/adm/trees/_model.py
@@ -30,7 +30,7 @@ from ._nodes import (
     parse_split,
 )
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     import pydot
 
 # Pinned to the original module path so existing log filters and the

--- a/python/pdstools/decision_analyzer/_aggregates.py
+++ b/python/pdstools/decision_analyzer/_aggregates.py
@@ -16,7 +16,7 @@ import polars as pl
 
 from .utils import apply_filter, gini_coefficient
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .DecisionAnalyzer import DecisionAnalyzer
 
 

--- a/python/pdstools/decision_analyzer/_scoring.py
+++ b/python/pdstools/decision_analyzer/_scoring.py
@@ -16,7 +16,7 @@ import polars.selectors as cs
 
 from .utils import apply_filter
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .DecisionAnalyzer import DecisionAnalyzer
 
 

--- a/python/pdstools/explanations/Plots.py
+++ b/python/pdstools/explanations/Plots.py
@@ -19,7 +19,7 @@ from .ExplanationsUtils import (
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     import plotly.graph_objects as go
 
     from .Explanations import Explanations

--- a/python/pdstools/ih/Plots.py
+++ b/python/pdstools/ih/Plots.py
@@ -15,7 +15,7 @@ from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .IH import IH as IH_Class
 
 

--- a/python/pdstools/impactanalyzer/Plots.py
+++ b/python/pdstools/impactanalyzer/Plots.py
@@ -14,7 +14,7 @@ from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .ImpactAnalyzer import ImpactAnalyzer as ImpactAnalyzer_Class
 
 

--- a/python/pdstools/infinity/client.py
+++ b/python/pdstools/infinity/client.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from ..utils.namespaces import MissingDependenciesException
 from .internal._base_client import AsyncAPIClient, SyncAPIClient
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     import httpx
 
     from .internal._auth import PegaOAuth

--- a/python/pdstools/infinity/internal/_base_client.py
+++ b/python/pdstools/infinity/internal/_base_client.py
@@ -392,7 +392,7 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):  # pragma: no cover
         super().__init__(**kwargs)
 
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     DefaultAsyncHttpxClient = httpx.AsyncClient
     """An alias to `httpx.AsyncClient` that provides the same defaults that this SDK
     uses internally.

--- a/python/pdstools/prediction/Plots.py
+++ b/python/pdstools/prediction/Plots.py
@@ -9,7 +9,7 @@ from ..utils import cdh_utils
 from ..utils.namespaces import LazyNamespace
 from ..utils.types import QUERY
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from plotly.graph_objects import Figure
 
     from .Prediction import Prediction

--- a/python/pdstools/utils/plot_utils.py
+++ b/python/pdstools/utils/plot_utils.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 
 import polars as pl
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from plotly.graph_objs import Figure as _Figure
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # Modules use this in annotations (and as a runtime alias) so they can be
 # imported without plotly being installed. At runtime it resolves to ``Any``
 # so importers don't need plotly; type checkers see the real ``Figure``.
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     Figure: TypeAlias = "_Figure"
 else:
     Figure = Any

--- a/python/pdstools/valuefinder/Aggregates.py
+++ b/python/pdstools/valuefinder/Aggregates.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .ValueFinder import ValueFinder
 
 

--- a/python/pdstools/valuefinder/Plots.py
+++ b/python/pdstools/valuefinder/Plots.py
@@ -20,7 +20,7 @@ from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .ValueFinder import ValueFinder
 
 COLORSCALE_TYPES = list[tuple[float, str]] | list[str]


### PR DESCRIPTION
The project's coverage config (python/tests/.coveragerc) already lists 'if TYPE_CHECKING:' under [report] exclude_also, so the per-line '# pragma: no cover' annotations on those guards are noise.

Per AGENTS.md, '# pragma: no cover' should be reserved for code that genuinely can't be exercised. TYPE_CHECKING blocks are a global, config-level exclusion — they don't need the per-line marker.

Verified: full pytest suite still passes; mypy reports no new unused-ignore warnings (warn_unused_ignores=true is enabled).