### PR TITLE
explanations: add Schema.py and validate raw parquet inputs up front

### DIFF
--- a/python/pdstools/explanations/Preprocess.py
+++ b/python/pdstools/explanations/Preprocess.py
@@ -14,6 +14,7 @@ import polars as pl
 from ..utils.namespaces import LazyNamespace
 from .ExplanationsUtils import _COL, _PREDICTOR_TYPE, _TABLE_NAME
 from .resources import queries as queries_data
+from .Schema import REQUIRED_RAW_COLUMNS, RawExplanationData
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +107,12 @@ class Preprocess(LazyNamespace):
             logger.error("Failed to populate selected files: %s", e)
             raise
 
+        try:
+            self._validate_raw_data(self.selected_files)
+        except ValueError as e:
+            logger.error("Raw explanation parquet failed schema validation: %s", e)
+            raise
+
         self._conn = duckdb.connect(database=":memory:")
 
         try:
@@ -145,6 +152,56 @@ class Preprocess(LazyNamespace):
             if any(self.explanations_folder.iterdir()):
                 return True
         return False
+
+    @staticmethod
+    def _validate_raw_data(file_paths: list[str]) -> None:
+        """Validate that raw explanation parquet files have the expected schema.
+
+        Reads only the parquet metadata (no row scan) for each file and checks
+        that every required column is present. Also verifies that at least one
+        of ``symbolic_value`` / ``numeric_value`` is present, since the SQL
+        aggregations need at least one of them to bin against.
+
+        Raises
+        ------
+        ValueError
+            If any required column is missing, or neither ``symbolic_value``
+            nor ``numeric_value`` is present, with a message naming the
+            offending file and missing columns.
+
+        """
+        for path in file_paths:
+            try:
+                schema = pl.scan_parquet(path).collect_schema()
+            except Exception as e:
+                raise ValueError(
+                    f"Failed to read parquet schema for {path}: {e}",
+                ) from e
+
+            present = set(schema.names())
+            missing = [c for c in REQUIRED_RAW_COLUMNS if c not in present]
+            if missing:
+                raise ValueError(
+                    f"Raw explanation parquet {path} is missing required "
+                    f"columns: {missing}. Expected schema includes "
+                    f"{list(REQUIRED_RAW_COLUMNS)}.",
+                )
+
+            if "symbolic_value" not in present and "numeric_value" not in present:
+                raise ValueError(
+                    f"Raw explanation parquet {path} must contain at least one of 'symbolic_value' or 'numeric_value'.",
+                )
+
+            for col, expected_dtype in (
+                ("shap_coeff", RawExplanationData.shap_coeff),
+                ("numeric_value", RawExplanationData.numeric_value),
+            ):
+                if col in present and not schema[col].is_numeric():
+                    raise ValueError(
+                        f"Raw explanation parquet {path} column '{col}' has "
+                        f"dtype {schema[col]}; expected numeric "
+                        f"(e.g. {expected_dtype}).",
+                    )
 
     def _run_agg(self, predictor_type: _PREDICTOR_TYPE):
         try:

--- a/python/pdstools/explanations/Schema.py
+++ b/python/pdstools/explanations/Schema.py
@@ -1,0 +1,92 @@
+"""Polars schemas for explanations input parquet files and aggregate outputs.
+
+Mirrors the pattern used by ``pdstools.adm.Schema``: each class is a
+collection of class-level attributes naming the expected columns and
+their polars dtypes. Apply with ``cdh_utils._apply_schema_types``.
+
+The raw explanation parquet schema is the public contract between Pega
+and the Explanations module. Validating against it up front (in
+``Preprocess.generate``) turns malformed inputs into a clear
+``ValueError`` instead of a cryptic DuckDB error mid-processing.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+class RawExplanationData:
+    """Schema for a single explanation parquet file produced by Pega.
+
+    Each row is one (sample, predictor) shap-coefficient observation.
+    Context columns (``pyChannel``, ``pyDirection``, ``pyIssue``,
+    ``pyGroup``, ``pyName``, ``pyTreatment``) are user-configurable and
+    not all of them are required to be present, so they are not part of
+    the strict required-columns check. The ``partition`` column
+    (JSON-encoded context dict) is required because every downstream
+    SQL aggregation groups by it.
+    """
+
+    pySubjectID = pl.Utf8
+    pyInteractionID = pl.Utf8
+    predictor_name = pl.Utf8
+    predictor_type = pl.Utf8
+    symbolic_value = pl.Utf8
+    numeric_value = pl.Float64
+    shap_coeff = pl.Float64
+    score = pl.Float64
+    partition = pl.Utf8
+
+
+REQUIRED_RAW_COLUMNS: tuple[str, ...] = (
+    "pyInteractionID",
+    "predictor_name",
+    "predictor_type",
+    "shap_coeff",
+    "partition",
+)
+"""Columns that must be present in every raw explanation parquet file.
+
+``symbolic_value`` and ``numeric_value`` are technically optional per
+row (one is null depending on ``predictor_type``), but at least one
+must exist as a column or the SQL queries fail. We check this
+separately in ``_validate_raw_data``.
+"""
+
+
+class ContextualAggregate:
+    """Schema for the per-context aggregate parquet (``*_BATCH_*.parquet``).
+
+    Produced by ``Preprocess._parquet_in_batches`` from
+    ``resources/queries/numeric.sql`` or ``symbolic.sql``.
+    """
+
+    partition = pl.Utf8
+    predictor_name = pl.Utf8
+    predictor_type = pl.Utf8
+    bin_contents = pl.Utf8
+    bin_order = pl.Int64
+    contribution_abs = pl.Float64
+    contribution = pl.Float64
+    contribution_min = pl.Float64
+    contribution_max = pl.Float64
+    frequency = pl.Int64
+
+
+class OverallAggregate:
+    """Schema for the per-model aggregate parquet (``*_OVERALL.parquet``).
+
+    Same shape as ``ContextualAggregate`` but ``partition`` is always the
+    literal string ``'whole_model'``.
+    """
+
+    partition = pl.Utf8
+    predictor_name = pl.Utf8
+    predictor_type = pl.Utf8
+    bin_contents = pl.Utf8
+    bin_order = pl.Int64
+    contribution_abs = pl.Float64
+    contribution = pl.Float64
+    contribution_min = pl.Float64
+    contribution_max = pl.Float64
+    frequency = pl.Int64

--- a/python/tests/explanations/test_ExplanationsPreprocess.py
+++ b/python/tests/explanations/test_ExplanationsPreprocess.py
@@ -247,3 +247,102 @@ class TestDataFileSupport:
                 preprocess._populate_selected_files_from_url(
                     "https://example.com/file.parquet",
                 )
+
+
+class TestValidateRawData:
+    """Exact-value tests for the raw-parquet schema validator."""
+
+    @staticmethod
+    def _write_parquet(path, schema_overrides=None, drop_cols=()):
+        import polars as pl
+
+        cols = {
+            "pySubjectID": ["S1"],
+            "pyInteractionID": ["I1"],
+            "predictor_name": ["pyAge"],
+            "predictor_type": ["NUMERIC"],
+            "symbolic_value": [None],
+            "numeric_value": [42.0],
+            "shap_coeff": [0.123],
+            "score": [0.5],
+            "partition": ['{"partition":{"pyChannel":"Web"}}'],
+        }
+        for col in drop_cols:
+            cols.pop(col, None)
+        df = pl.DataFrame(cols, schema_overrides=schema_overrides or {})
+        df.write_parquet(path)
+
+    def test_valid_file_passes(self, tmp_path):
+        path = tmp_path / "ok.parquet"
+        self._write_parquet(path)
+        # Must not raise.
+        Preprocess._validate_raw_data([str(path)])
+
+    def test_missing_required_column_raises(self, tmp_path):
+        path = tmp_path / "missing.parquet"
+        self._write_parquet(path, drop_cols=("shap_coeff",))
+        with pytest.raises(ValueError, match=r"missing required columns: \['shap_coeff'\]"):
+            Preprocess._validate_raw_data([str(path)])
+
+    def test_missing_partition_raises(self, tmp_path):
+        path = tmp_path / "no_partition.parquet"
+        self._write_parquet(path, drop_cols=("partition",))
+        with pytest.raises(ValueError, match=r"missing required columns: \['partition'\]"):
+            Preprocess._validate_raw_data([str(path)])
+
+    def test_missing_both_value_columns_raises(self, tmp_path):
+        path = tmp_path / "no_values.parquet"
+        self._write_parquet(path, drop_cols=("symbolic_value", "numeric_value"))
+        with pytest.raises(
+            ValueError,
+            match=r"must contain at least one of 'symbolic_value' or 'numeric_value'",
+        ):
+            Preprocess._validate_raw_data([str(path)])
+
+    def test_only_symbolic_value_passes(self, tmp_path):
+        path = tmp_path / "sym_only.parquet"
+        self._write_parquet(path, drop_cols=("numeric_value",))
+        Preprocess._validate_raw_data([str(path)])
+
+    def test_only_numeric_value_passes(self, tmp_path):
+        path = tmp_path / "num_only.parquet"
+        self._write_parquet(path, drop_cols=("symbolic_value",))
+        Preprocess._validate_raw_data([str(path)])
+
+    def test_non_numeric_shap_raises(self, tmp_path):
+        import polars as pl
+
+        path = tmp_path / "bad_shap.parquet"
+        df = pl.DataFrame(
+            {
+                "pyInteractionID": ["I1"],
+                "predictor_name": ["pyAge"],
+                "predictor_type": ["NUMERIC"],
+                "symbolic_value": [None],
+                "numeric_value": [42.0],
+                "shap_coeff": ["not-a-number"],
+                "partition": ['{"p":1}'],
+            },
+        )
+        df.write_parquet(path)
+        with pytest.raises(ValueError, match=r"column 'shap_coeff' has dtype .*expected numeric"):
+            Preprocess._validate_raw_data([str(path)])
+
+    def test_unreadable_file_raises(self, tmp_path):
+        path = tmp_path / "broken.parquet"
+        path.write_text("not a parquet file")
+        with pytest.raises(ValueError, match="Failed to read parquet schema"):
+            Preprocess._validate_raw_data([str(path)])
+
+    def test_validates_each_file_in_list(self, tmp_path):
+        good = tmp_path / "good.parquet"
+        bad = tmp_path / "bad.parquet"
+        self._write_parquet(good)
+        self._write_parquet(bad, drop_cols=("partition",))
+        with pytest.raises(ValueError, match=r"missing required columns: \['partition'\]"):
+            Preprocess._validate_raw_data([str(good), str(bad)])
+
+    def test_real_sample_parquet_passes(self):
+        """The shipped sample parquet must satisfy the schema validator."""
+        sample = basePath / "data" / "explanations" / "AdaptiveBoostCT_20250328064604.parquet"
+        Preprocess._validate_raw_data([str(sample)])


### PR DESCRIPTION
Adds an explanations-specific schema module mirroring pdstools.adm.Schema, and wires a fail-fast validator into Preprocess.generate so that malformed or partially-written explanation parquet files raise a descriptive ValueError before any DuckDB work begins, instead of surfacing as a cryptic SQL error mid-aggregation.

Schema.py declares three logical tables:
  - RawExplanationData   - input parquet from Pega
  - ContextualAggregate  - per-context aggregate output
  - OverallAggregate     - whole-model aggregate output

Preprocess._validate_raw_data(file_paths) checks each input parquet's schema (via pl.scan_parquet().collect_schema(), no row scan):
  - all REQUIRED_RAW_COLUMNS present
  - at least one of symbolic_value / numeric_value present
  - shap_coeff and numeric_value have numeric dtypes when present

Tests cover all branches with exact-value assertions, plus a smoke test against the shipped sample parquet.

Resolves the 'schema-and-validate' item from the v5 peer-audit plan (checklist items 3 and 4 in AGENTS.md).