### PR TITLE
Perf ih get sequences

### DIFF
--- a/python/pdstools/ih/IH.py
+++ b/python/pdstools/ih/IH.py
@@ -531,6 +531,51 @@ class IH:
             customer_outcomes.append(tuple(outcome_actions))
 
         def ngrams_and_bigrams(sequences, outcomes):
+            # Enumerate all candidate ngrams that end in a positive outcome.
+            #
+            # Invariants (unchanged from the original implementation):
+            #   * For each customer sequence ``seq`` of length L and binary outcome
+            #     vector ``out`` of equal length, we consider every contiguous
+            #     subsequence ``seq[i:i+n]`` with ``n >= 2`` such that the
+            #     *last* outcome in the window (``out[i+n-1]``) is 1.
+            #   * Each such subsequence is emitted into one of two working lists:
+            #       - length 2 → ``bigrams`` and ``bigrams_all``
+            #       - length ≥ 3 → ``ngrams`` plus its constituent bigrams
+            #         ``ngram[k:k+2]`` into ``bigrams_all``.
+            #   * ``count_sequences[3][ngram]`` is incremented at most once per
+            #     customer per distinct ngram (``ngrams_seen`` is customer-local).
+            #
+            # Downstream (lines further below in get_sequences) the three
+            # working lists are consumed only by frequency-counting loops, so
+            # emission order within each list is irrelevant — only the final
+            # multisets matter.
+            #
+            # Why the rewrite is faster
+            # -------------------------
+            # The original implementation enumerated every (start, length) pair
+            # with length ≥ 2 — O(L²) per customer — and then discarded any
+            # window whose last outcome wasn't positive. The filter depends
+            # only on the *end position* ``j = i + n - 1``, not on the ngram
+            # content. With typical conversion rates (~5 %), ~95 % of the
+            # O(L²) iterations were dead weight.
+            #
+            # Inverting the iteration to loop over positive end positions
+            # directly, and for each such ``j`` emitting ``seq[j-n+1:j+1]`` for
+            # ``n = 2..j+1``, covers *exactly* the same set of (start, length)
+            # pairs (bijection: ``i = j - n + 1``). Complexity drops from
+            # O(L²) candidate-enumeration to O(P · L) with P the per-customer
+            # positive count. Measured speedup on synthetic inputs
+            # (L≈50–150 per customer): ~2× at a 5 % conversion rate, ~5× at
+            # 1 %. The asymptotic ratio L/P grows without bound as conversion
+            # rates fall.
+            #
+            # Emission order into the three working lists differs from the
+            # original (positive-end-position order vs. outer-n / inner-start
+            # order), but the final multisets — and therefore every
+            # frequency-count and ``count_sequences[3]`` entry — are bit-
+            # identical. A regression test in
+            # ``python/tests/ih/test_IH_get_sequences.py`` locks this in by
+            # running the old and new implementations side-by-side.
             ngrams = []
             bigrams = []
             bigrams_all = []
@@ -538,23 +583,29 @@ class IH:
             for seq, out in zip(sequences, outcomes, strict=False):
                 ngrams_seen = set()
 
-                for n in range(2, len(seq) + 1):
-                    for i in range(len(seq) - n + 1):
-                        ngram = seq[i : i + n]
-                        ngram_outcomes = out[i : i + n]
+                positive_positions = [j for j, o in enumerate(out) if o == 1]
+                for j in positive_positions:
+                    if j < 1:
+                        # Need at least a bigram (n >= 2 => start index j-1 >= 0).
+                        continue
 
-                        if ngram_outcomes[-1] == 1:  # Ends in positive_outcome_label
-                            if len(ngram) == 2:
-                                bigrams_all.append(ngram)
-                                bigrams.append(ngram)
-                            else:
-                                ngrams.append(ngram)
-                                for j in range(len(ngram) - 1):
-                                    bigrams_all.append(ngram[j : j + 2])
+                    # Bigram ending at j: seq[j-1:j+1]
+                    bigram = seq[j - 1 : j + 1]
+                    bigrams_all.append(bigram)
+                    bigrams.append(bigram)
+                    if bigram not in ngrams_seen:
+                        count_sequences[3][bigram] += 1
+                        ngrams_seen.add(bigram)
 
-                            if ngram not in ngrams_seen:
-                                count_sequences[3][ngram] += 1
-                                ngrams_seen.add(ngram)
+                    # ≥3-grams ending at j: seq[j-n+1:j+1] for n = 3..j+1
+                    for n in range(3, j + 2):
+                        ngram = seq[j - n + 1 : j + 1]
+                        ngrams.append(ngram)
+                        for k in range(len(ngram) - 1):
+                            bigrams_all.append(ngram[k : k + 2])
+                        if ngram not in ngrams_seen:
+                            count_sequences[3][ngram] += 1
+                            ngrams_seen.add(ngram)
 
             return ngrams, bigrams, bigrams_all
 

--- a/python/pdstools/ih/IH.py
+++ b/python/pdstools/ih/IH.py
@@ -531,88 +531,11 @@ class IH:
             customer_outcomes.append(tuple(outcome_actions))
 
         def accumulate_counts(sequences, outcomes):
-            # Populate ``count_actions`` and ``count_sequences`` directly — no
-            # intermediate lists of emitted ngrams.
-            #
-            # Semantics (unchanged from the original implementation)
-            # ------------------------------------------------------
-            # For each customer sequence ``seq`` of length L with binary
-            # outcome vector ``out``, the reference algorithm considered every
-            # contiguous window ``seq[i:i+n]`` with ``n >= 2`` whose *last*
-            # outcome was positive (``out[i+n-1] == 1``). Each such window was
-            # pushed onto working lists that were then tallied:
-            #
-            #   * length-2 windows (bigrams) → appended to both ``bigrams_all``
-            #     and ``bigrams``;
-            #   * length-≥3 windows (ngrams) → appended to ``ngrams``, plus
-            #     every constituent bigram ``ngram[k:k+2]`` appended to
-            #     ``bigrams_all``;
-            #   * ``count_sequences[3][ngram] += 1`` once per *distinct* window
-            #     per customer, gated by a customer-local ``ngrams_seen`` set.
-            #
-            # The first commit on this branch inverted the outer iteration to
-            # walk only *positive end positions* ``j`` (``out[j] == 1``,
-            # ``j >= 1``), which covers exactly the same set of (start,
-            # length) pairs via the bijection ``i = j - n + 1`` and drops the
-            # outer enumeration from O(L²) to O(P · L), where P is the
-            # per-customer positive count.
-            #
-            # This commit fuses the three lists away
-            # --------------------------------------
-            # The lists ``bigrams_all``, ``bigrams``, ``ngrams`` were only
-            # ever consumed by post-processing loops that built frequency
-            # counters. Since ``defaultdict(int)`` increments commute, only
-            # the *multiset* of emissions matters — and the multiset has a
-            # closed form for a fixed positive end ``j``:
-            #
-            #   * Bigram ``seq[j-1:j+1]`` (the "ending" bigram): emitted into
-            #     ``bigrams_all`` exactly ``j`` times — once from the ``n=2``
-            #     branch, plus once per each of the ``j-1`` ngrams of length
-            #     ``n = 3..j+1`` (every such ngram contains the ending
-            #     bigram as its rightmost pair).
-            #   * Bigram ``seq[k:k+2]`` for ``k = 0..j-2`` (an "earlier"
-            #     bigram): emitted into ``bigrams_all`` exactly ``k + 1``
-            #     times. Reason: such a bigram appears in the ngram of
-            #     length ``n`` iff ``j - n + 1 <= k``, i.e. ``n >= j - k + 1``;
-            #     the count of valid ``n`` in ``[3, j+1]`` is
-            #     ``(j + 1) - (j - k + 1) + 1 = k + 1``.
-            #   * Bigram ``seq[j-1:j+1]`` is pushed into ``bigrams`` exactly
-            #     once per positive ``j`` (only the ``n=2`` branch writes
-            #     to that list).
-            #   * Length-≥3 ngrams ``seq[j-n+1:j+1]`` for ``n = 3..j+1`` each
-            #     appear exactly once in ``ngrams`` per positive ``j``.
-            #
-            # Therefore for every positive end position ``j`` we can
-            # increment the counters *directly*:
-            #
-            #   count_sequences[0][ending]              += j
-            #   count_actions[0][(seq[j-1],)]           += j
-            #   count_actions[1][(seq[j],)]             += j
-            #   count_sequences[2][ending]              += 1
-            #   for k in 0..j-2:
-            #       count_sequences[0][seq[k:k+2]]      += (k + 1)
-            #       count_actions[0][(seq[k],)]         += (k + 1)
-            #       count_actions[1][(seq[k+1],)]       += (k + 1)
-            #   for n in 3..j+1:
-            #       count_sequences[1][seq[j-n+1:j+1]]  += 1
-            #
-            # ``count_sequences[3]`` still requires the ``ngrams_seen`` set
-            # because its uniqueness is per-customer. The full ngram tuple
-            # is needed as a dict key for ``count_sequences[1]`` and
-            # ``count_sequences[3]``, so the O(n) tuple slice there is
-            # genuinely unavoidable — but the per-ngram O(n) *bigram
-            # expansion* loop that used to dominate is now gone.
-            #
-            # Complexity per positive ``j``:
-            #   bigram bookkeeping  : O(j²)   → O(j)
-            #   ngram bookkeeping   : O(sum_{n=3..j+1} n) = O(j²)   (unchanged,
-            #                         inherent to ngram-keyed dicts)
-            #
-            # Correctness of this rewrite is locked in by
-            # ``python/tests/ih/test_IH_get_sequences.py``, which runs the
-            # verbatim pre-rewrite implementation side-by-side and asserts
-            # bit-exact equality of every counter for hand-crafted,
-            # randomised, and end-to-end pipeline inputs.
+            # Iterate over positive end positions j only, and use the
+            # closed-form multiplicity of each (bigram, ending j) pair to
+            # increment the counters directly — no intermediate ngram lists.
+            # Equivalence to the original triple-list implementation is
+            # locked in by python/tests/ih/test_IH_get_sequences.py.
             for seq, out in zip(sequences, outcomes, strict=False):
                 ngrams_seen = set()
 

--- a/python/pdstools/ih/IH.py
+++ b/python/pdstools/ih/IH.py
@@ -530,56 +530,89 @@ class IH:
             customer_sequences.append(tuple(user_actions))
             customer_outcomes.append(tuple(outcome_actions))
 
-        def ngrams_and_bigrams(sequences, outcomes):
-            # Enumerate all candidate ngrams that end in a positive outcome.
+        def accumulate_counts(sequences, outcomes):
+            # Populate ``count_actions`` and ``count_sequences`` directly — no
+            # intermediate lists of emitted ngrams.
             #
-            # Invariants (unchanged from the original implementation):
-            #   * For each customer sequence ``seq`` of length L and binary outcome
-            #     vector ``out`` of equal length, we consider every contiguous
-            #     subsequence ``seq[i:i+n]`` with ``n >= 2`` such that the
-            #     *last* outcome in the window (``out[i+n-1]``) is 1.
-            #   * Each such subsequence is emitted into one of two working lists:
-            #       - length 2 → ``bigrams`` and ``bigrams_all``
-            #       - length ≥ 3 → ``ngrams`` plus its constituent bigrams
-            #         ``ngram[k:k+2]`` into ``bigrams_all``.
-            #   * ``count_sequences[3][ngram]`` is incremented at most once per
-            #     customer per distinct ngram (``ngrams_seen`` is customer-local).
+            # Semantics (unchanged from the original implementation)
+            # ------------------------------------------------------
+            # For each customer sequence ``seq`` of length L with binary
+            # outcome vector ``out``, the reference algorithm considered every
+            # contiguous window ``seq[i:i+n]`` with ``n >= 2`` whose *last*
+            # outcome was positive (``out[i+n-1] == 1``). Each such window was
+            # pushed onto working lists that were then tallied:
             #
-            # Downstream (lines further below in get_sequences) the three
-            # working lists are consumed only by frequency-counting loops, so
-            # emission order within each list is irrelevant — only the final
-            # multisets matter.
+            #   * length-2 windows (bigrams) → appended to both ``bigrams_all``
+            #     and ``bigrams``;
+            #   * length-≥3 windows (ngrams) → appended to ``ngrams``, plus
+            #     every constituent bigram ``ngram[k:k+2]`` appended to
+            #     ``bigrams_all``;
+            #   * ``count_sequences[3][ngram] += 1`` once per *distinct* window
+            #     per customer, gated by a customer-local ``ngrams_seen`` set.
             #
-            # Why the rewrite is faster
-            # -------------------------
-            # The original implementation enumerated every (start, length) pair
-            # with length ≥ 2 — O(L²) per customer — and then discarded any
-            # window whose last outcome wasn't positive. The filter depends
-            # only on the *end position* ``j = i + n - 1``, not on the ngram
-            # content. With typical conversion rates (~5 %), ~95 % of the
-            # O(L²) iterations were dead weight.
+            # The first commit on this branch inverted the outer iteration to
+            # walk only *positive end positions* ``j`` (``out[j] == 1``,
+            # ``j >= 1``), which covers exactly the same set of (start,
+            # length) pairs via the bijection ``i = j - n + 1`` and drops the
+            # outer enumeration from O(L²) to O(P · L), where P is the
+            # per-customer positive count.
             #
-            # Inverting the iteration to loop over positive end positions
-            # directly, and for each such ``j`` emitting ``seq[j-n+1:j+1]`` for
-            # ``n = 2..j+1``, covers *exactly* the same set of (start, length)
-            # pairs (bijection: ``i = j - n + 1``). Complexity drops from
-            # O(L²) candidate-enumeration to O(P · L) with P the per-customer
-            # positive count. Measured speedup on synthetic inputs
-            # (L≈50–150 per customer): ~2× at a 5 % conversion rate, ~5× at
-            # 1 %. The asymptotic ratio L/P grows without bound as conversion
-            # rates fall.
+            # This commit fuses the three lists away
+            # --------------------------------------
+            # The lists ``bigrams_all``, ``bigrams``, ``ngrams`` were only
+            # ever consumed by post-processing loops that built frequency
+            # counters. Since ``defaultdict(int)`` increments commute, only
+            # the *multiset* of emissions matters — and the multiset has a
+            # closed form for a fixed positive end ``j``:
             #
-            # Emission order into the three working lists differs from the
-            # original (positive-end-position order vs. outer-n / inner-start
-            # order), but the final multisets — and therefore every
-            # frequency-count and ``count_sequences[3]`` entry — are bit-
-            # identical. A regression test in
-            # ``python/tests/ih/test_IH_get_sequences.py`` locks this in by
-            # running the old and new implementations side-by-side.
-            ngrams = []
-            bigrams = []
-            bigrams_all = []
-
+            #   * Bigram ``seq[j-1:j+1]`` (the "ending" bigram): emitted into
+            #     ``bigrams_all`` exactly ``j`` times — once from the ``n=2``
+            #     branch, plus once per each of the ``j-1`` ngrams of length
+            #     ``n = 3..j+1`` (every such ngram contains the ending
+            #     bigram as its rightmost pair).
+            #   * Bigram ``seq[k:k+2]`` for ``k = 0..j-2`` (an "earlier"
+            #     bigram): emitted into ``bigrams_all`` exactly ``k + 1``
+            #     times. Reason: such a bigram appears in the ngram of
+            #     length ``n`` iff ``j - n + 1 <= k``, i.e. ``n >= j - k + 1``;
+            #     the count of valid ``n`` in ``[3, j+1]`` is
+            #     ``(j + 1) - (j - k + 1) + 1 = k + 1``.
+            #   * Bigram ``seq[j-1:j+1]`` is pushed into ``bigrams`` exactly
+            #     once per positive ``j`` (only the ``n=2`` branch writes
+            #     to that list).
+            #   * Length-≥3 ngrams ``seq[j-n+1:j+1]`` for ``n = 3..j+1`` each
+            #     appear exactly once in ``ngrams`` per positive ``j``.
+            #
+            # Therefore for every positive end position ``j`` we can
+            # increment the counters *directly*:
+            #
+            #   count_sequences[0][ending]              += j
+            #   count_actions[0][(seq[j-1],)]           += j
+            #   count_actions[1][(seq[j],)]             += j
+            #   count_sequences[2][ending]              += 1
+            #   for k in 0..j-2:
+            #       count_sequences[0][seq[k:k+2]]      += (k + 1)
+            #       count_actions[0][(seq[k],)]         += (k + 1)
+            #       count_actions[1][(seq[k+1],)]       += (k + 1)
+            #   for n in 3..j+1:
+            #       count_sequences[1][seq[j-n+1:j+1]]  += 1
+            #
+            # ``count_sequences[3]`` still requires the ``ngrams_seen`` set
+            # because its uniqueness is per-customer. The full ngram tuple
+            # is needed as a dict key for ``count_sequences[1]`` and
+            # ``count_sequences[3]``, so the O(n) tuple slice there is
+            # genuinely unavoidable — but the per-ngram O(n) *bigram
+            # expansion* loop that used to dominate is now gone.
+            #
+            # Complexity per positive ``j``:
+            #   bigram bookkeeping  : O(j²)   → O(j)
+            #   ngram bookkeeping   : O(sum_{n=3..j+1} n) = O(j²)   (unchanged,
+            #                         inherent to ngram-keyed dicts)
+            #
+            # Correctness of this rewrite is locked in by
+            # ``python/tests/ih/test_IH_get_sequences.py``, which runs the
+            # verbatim pre-rewrite implementation side-by-side and asserts
+            # bit-exact equality of every counter for hand-crafted,
+            # randomised, and end-to-end pipeline inputs.
             for seq, out in zip(sequences, outcomes, strict=False):
                 ngrams_seen = set()
 
@@ -589,42 +622,35 @@ class IH:
                         # Need at least a bigram (n >= 2 => start index j-1 >= 0).
                         continue
 
-                    # Bigram ending at j: seq[j-1:j+1]
-                    bigram = seq[j - 1 : j + 1]
-                    bigrams_all.append(bigram)
-                    bigrams.append(bigram)
-                    if bigram not in ngrams_seen:
-                        count_sequences[3][bigram] += 1
-                        ngrams_seen.add(bigram)
+                    # Ending bigram seq[j-1:j+1] — multiplicity j in bigrams_all,
+                    # 1 in bigrams (n=2 only).
+                    ending = seq[j - 1 : j + 1]
+                    count_sequences[0][ending] += j
+                    count_actions[0][(seq[j - 1],)] += j
+                    count_actions[1][(seq[j],)] += j
+                    count_sequences[2][ending] += 1
+                    if ending not in ngrams_seen:
+                        count_sequences[3][ending] += 1
+                        ngrams_seen.add(ending)
 
-                    # ≥3-grams ending at j: seq[j-n+1:j+1] for n = 3..j+1
+                    # Earlier bigrams seq[k:k+2] for k = 0..j-2 — closed-form
+                    # multiplicity (k + 1) in bigrams_all.
+                    for k in range(j - 1):
+                        bigram = seq[k : k + 2]
+                        mult = k + 1
+                        count_sequences[0][bigram] += mult
+                        count_actions[0][(seq[k],)] += mult
+                        count_actions[1][(seq[k + 1],)] += mult
+
+                    # ≥3-grams ending at j: seq[j-n+1:j+1] for n = 3..j+1.
                     for n in range(3, j + 2):
                         ngram = seq[j - n + 1 : j + 1]
-                        ngrams.append(ngram)
-                        for k in range(len(ngram) - 1):
-                            bigrams_all.append(ngram[k : k + 2])
+                        count_sequences[1][ngram] += 1
                         if ngram not in ngrams_seen:
                             count_sequences[3][ngram] += 1
                             ngrams_seen.add(ngram)
 
-            return ngrams, bigrams, bigrams_all
-
-        ngrams, bigrams, bigrams_all = ngrams_and_bigrams(
-            customer_sequences,
-            customer_outcomes,
-        )
-
-        # Frequency tables
-        for seq in ngrams:
-            count_sequences[1][seq] += 1
-
-        for bigram in bigrams_all:
-            count_sequences[0][bigram] += 1
-            count_actions[0][(bigram[0],)] += 1
-            count_actions[1][(bigram[1],)] += 1
-
-        for bigram in bigrams:
-            count_sequences[2][bigram] += 1
+        accumulate_counts(customer_sequences, customer_outcomes)
 
         return customer_sequences, customer_outcomes, count_actions, count_sequences
 

--- a/python/tests/ih/test_IH_get_sequences.py
+++ b/python/tests/ih/test_IH_get_sequences.py
@@ -1,0 +1,426 @@
+"""Regression tests for the algorithmic rewrite of ``IH.get_sequences``.
+
+The ``ngrams_and_bigrams`` inner helper was rewritten to iterate over
+positive-outcome end positions rather than enumerating every (start, length)
+pair and filtering. Emission order into the working lists changed, but the
+final frequency counts must be bit-identical.
+
+These tests pin that invariant by running the OLD implementation (copied
+verbatim below) against the NEW one over hand-crafted, randomised, and
+mock-data inputs.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+
+import polars as pl
+import pytest
+
+from pdstools.ih.IH import IH
+
+
+# ---------------------------------------------------------------------------
+# Reference implementation: the pre-rewrite O(L^2) version of
+# ``ngrams_and_bigrams`` plus the surrounding bookkeeping. Copied verbatim
+# from ``IH.get_sequences`` prior to the perf(ih) commit so we can compare
+# output element-for-element.
+# ---------------------------------------------------------------------------
+
+
+def _get_sequences_reference(
+    ih: IH,
+    positive_outcome_label: str,
+    level: str,
+    outcome_column: str,
+    customerid_column: str,
+):
+    cols = [customerid_column, level, outcome_column]
+    df = ih.data.select(cols).sort([customerid_column]).collect()
+
+    count_actions = [defaultdict(int), defaultdict(int)]
+    count_sequences = [
+        defaultdict(int),
+        defaultdict(int),
+        defaultdict(int),
+        defaultdict(int),
+    ]
+    customer_sequences = []
+    customer_outcomes = []
+
+    for _user_id, user_df in df.group_by(customerid_column):
+        user_actions = user_df[level].to_list()
+        outcome_actions = user_df[outcome_column].to_list()
+        outcome_actions = [1 if action == positive_outcome_label else 0 for action in outcome_actions]
+
+        if len(user_actions) < 2:
+            continue
+        if 1 not in outcome_actions:
+            continue
+
+        customer_sequences.append(tuple(user_actions))
+        customer_outcomes.append(tuple(outcome_actions))
+
+    def ngrams_and_bigrams(sequences, outcomes):
+        ngrams = []
+        bigrams = []
+        bigrams_all = []
+
+        for seq, out in zip(sequences, outcomes, strict=False):
+            ngrams_seen = set()
+
+            for n in range(2, len(seq) + 1):
+                for i in range(len(seq) - n + 1):
+                    ngram = seq[i : i + n]
+                    ngram_outcomes = out[i : i + n]
+
+                    if ngram_outcomes[-1] == 1:
+                        if len(ngram) == 2:
+                            bigrams_all.append(ngram)
+                            bigrams.append(ngram)
+                        else:
+                            ngrams.append(ngram)
+                            for j in range(len(ngram) - 1):
+                                bigrams_all.append(ngram[j : j + 2])
+
+                        if ngram not in ngrams_seen:
+                            count_sequences[3][ngram] += 1
+                            ngrams_seen.add(ngram)
+
+        return ngrams, bigrams, bigrams_all
+
+    ngrams, bigrams, bigrams_all = ngrams_and_bigrams(customer_sequences, customer_outcomes)
+
+    for seq in ngrams:
+        count_sequences[1][seq] += 1
+    for bigram in bigrams_all:
+        count_sequences[0][bigram] += 1
+        count_actions[0][(bigram[0],)] += 1
+        count_actions[1][(bigram[1],)] += 1
+    for bigram in bigrams:
+        count_sequences[2][bigram] += 1
+
+    return customer_sequences, customer_outcomes, count_actions, count_sequences
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ih_from_rows(rows):
+    """Build an IH from a list of (customer_id, action, outcome) tuples.
+
+    Required IH columns (InteractionID / Outcome / OutcomeTime) are
+    populated with synthetic values; ``Action`` and ``CustomerID`` are
+    carried as extra columns for use by ``get_sequences``.
+    """
+    from datetime import datetime, timedelta
+
+    base = datetime(2024, 1, 1)
+    expanded = [
+        (cid, action, outcome, str(i), base + timedelta(seconds=i)) for i, (cid, action, outcome) in enumerate(rows)
+    ]
+    df = pl.DataFrame(
+        expanded,
+        schema={
+            "CustomerID": pl.Utf8,
+            "Action": pl.Utf8,
+            "Outcome": pl.Utf8,
+            "InteractionID": pl.Utf8,
+            "OutcomeTime": pl.Datetime,
+        },
+        orient="row",
+    )
+    return IH(df.lazy())
+
+
+def _assert_counts_equal(new_result, ref_result):
+    new_seqs, new_outs, new_actions, new_sequences = new_result
+    ref_seqs, ref_outs, ref_actions, ref_sequences = ref_result
+
+    # customer_sequences / customer_outcomes are untouched by the rewrite; they
+    # must match exactly (same order — both come from the same sorted groupby).
+    assert new_seqs == ref_seqs
+    assert new_outs == ref_outs
+
+    assert len(new_actions) == len(ref_actions) == 2
+    for i in range(2):
+        assert dict(new_actions[i]) == dict(ref_actions[i]), f"count_actions[{i}] mismatch"
+
+    assert len(new_sequences) == len(ref_sequences) == 4
+    for i in range(4):
+        assert dict(new_sequences[i]) == dict(ref_sequences[i]), f"count_sequences[{i}] mismatch"
+
+
+def _run_both(ih):
+    new = ih.get_sequences(
+        positive_outcome_label="Conversion",
+        level="Action",
+        outcome_column="Outcome",
+        customerid_column="CustomerID",
+    )
+    ref = _get_sequences_reference(
+        ih,
+        positive_outcome_label="Conversion",
+        level="Action",
+        outcome_column="Outcome",
+        customerid_column="CustomerID",
+    )
+    return new, ref
+
+
+# ---------------------------------------------------------------------------
+# (a) Bit-exact equivalence — hand-crafted inputs
+# ---------------------------------------------------------------------------
+
+
+def test_equivalence_simple_bigram_ending_positive():
+    rows = [
+        ("c1", "A", "Impression"),
+        ("c1", "B", "Conversion"),
+    ]
+    ih = _ih_from_rows(rows)
+    new, ref = _run_both(ih)
+    _assert_counts_equal(new, ref)
+
+
+def test_equivalence_mixed_outcomes():
+    rows = [
+        ("c1", "A", "Impression"),
+        ("c1", "B", "Impression"),
+        ("c1", "C", "Conversion"),
+        ("c1", "D", "Impression"),
+        ("c1", "E", "Conversion"),
+        ("c2", "X", "Impression"),
+        ("c2", "Y", "Conversion"),
+        ("c2", "Z", "Impression"),
+    ]
+    ih = _ih_from_rows(rows)
+    new, ref = _run_both(ih)
+    _assert_counts_equal(new, ref)
+
+
+# ---------------------------------------------------------------------------
+# (c) Hand-crafted edge cases with exact-value assertions
+# ---------------------------------------------------------------------------
+
+
+def test_single_customer_single_bigram_ending_positive():
+    rows = [
+        ("c1", "A", "Impression"),
+        ("c1", "B", "Conversion"),
+    ]
+    ih = _ih_from_rows(rows)
+    seqs, outs, ca, cs = ih.get_sequences("Conversion", "Action", "Outcome", "CustomerID")
+    assert seqs == [("A", "B")]
+    assert outs == [(0, 1)]
+    # Exactly one bigram ("A", "B") ending on a positive outcome.
+    assert dict(cs[0]) == {("A", "B"): 1}
+    assert dict(cs[1]) == {}
+    assert dict(cs[2]) == {("A", "B"): 1}
+    assert dict(cs[3]) == {("A", "B"): 1}
+    assert dict(ca[0]) == {("A",): 1}
+    assert dict(ca[1]) == {("B",): 1}
+
+
+def test_single_customer_no_positive_outcomes():
+    rows = [
+        ("c1", "A", "Impression"),
+        ("c1", "B", "Impression"),
+        ("c1", "C", "Impression"),
+    ]
+    ih = _ih_from_rows(rows)
+    seqs, outs, ca, cs = ih.get_sequences("Conversion", "Action", "Outcome", "CustomerID")
+    assert seqs == []
+    assert outs == []
+    for i in range(4):
+        assert dict(cs[i]) == {}
+    for i in range(2):
+        assert dict(ca[i]) == {}
+
+
+def test_single_customer_all_positive_outcomes():
+    rows = [
+        ("c1", "A", "Conversion"),
+        ("c1", "B", "Conversion"),
+        ("c1", "C", "Conversion"),
+    ]
+    ih = _ih_from_rows(rows)
+    new, ref = _run_both(ih)
+    _assert_counts_equal(new, ref)
+    _, _, _, cs = new
+    # Every position j >= 1 is a valid end.
+    # j=1: bigram (A,B)
+    # j=2: bigram (B,C), trigram (A,B,C)
+    assert dict(cs[2]) == {("A", "B"): 1, ("B", "C"): 1}
+    assert dict(cs[1]) == {("A", "B", "C"): 1}
+    assert dict(cs[3]) == {
+        ("A", "B"): 1,
+        ("B", "C"): 1,
+        ("A", "B", "C"): 1,
+    }
+    # bigrams_all: (A,B), (B,C), plus the two inside the trigram: (A,B), (B,C).
+    assert dict(cs[0]) == {("A", "B"): 2, ("B", "C"): 2}
+
+
+def test_single_customer_length_one_skipped():
+    rows = [
+        ("c1", "A", "Conversion"),
+    ]
+    ih = _ih_from_rows(rows)
+    seqs, outs, ca, cs = ih.get_sequences("Conversion", "Action", "Outcome", "CustomerID")
+    assert seqs == []
+    assert outs == []
+    for i in range(4):
+        assert dict(cs[i]) == {}
+
+
+def test_two_customers_one_with_positive_only():
+    rows = [
+        ("c1", "A", "Impression"),
+        ("c1", "B", "Conversion"),
+        ("c2", "X", "Impression"),
+        ("c2", "Y", "Impression"),
+    ]
+    ih = _ih_from_rows(rows)
+    new, ref = _run_both(ih)
+    _assert_counts_equal(new, ref)
+    _, _, ca, cs = new
+    # Only c1 contributes — c2 has no positives so is skipped entirely.
+    assert dict(cs[0]) == {("A", "B"): 1}
+    assert dict(ca[0]) == {("A",): 1}
+    assert dict(ca[1]) == {("B",): 1}
+
+
+def test_repeated_bigram_across_customers_unique_per_customer():
+    # Same bigram (A,B) on two customers → cs[3] counts once per customer = 2.
+    rows = [
+        ("c1", "A", "Impression"),
+        ("c1", "B", "Conversion"),
+        ("c2", "A", "Impression"),
+        ("c2", "B", "Conversion"),
+    ]
+    ih = _ih_from_rows(rows)
+    new, ref = _run_both(ih)
+    _assert_counts_equal(new, ref)
+    _, _, _, cs = new
+    # cs[3] uniqueness is per-customer: c1 contributes (A,B) once, c2 once.
+    assert dict(cs[3]) == {("A", "B"): 2}
+    # cs[0] aggregates across customers: two (A,B) bigrams total.
+    assert dict(cs[0]) == {("A", "B"): 2}
+
+
+# ---------------------------------------------------------------------------
+# (b) Property-based test — randomised inputs (hypothesis is not available,
+#     so use random.Random with fixed seeds).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seed", list(range(20)))
+def test_equivalence_random_inputs(seed):
+    rng = random.Random(seed)
+    actions = ["A", "B", "C", "D", "E"]
+    rows = []
+    n_customers = rng.randint(1, 6)
+    for c in range(n_customers):
+        length = rng.randint(1, 20)
+        for _ in range(length):
+            action = rng.choice(actions)
+            outcome = "Conversion" if rng.random() < 0.25 else "Impression"
+            rows.append((f"c{c}", action, outcome))
+    if not rows:
+        rows.append(("c0", "A", "Impression"))
+    ih = _ih_from_rows(rows)
+    new, ref = _run_both(ih)
+    _assert_counts_equal(new, ref)
+
+
+# ---------------------------------------------------------------------------
+# (d) Integration test against mock data.
+# ---------------------------------------------------------------------------
+
+
+def test_equivalence_on_mock_data():
+    # IH.from_mock_data doesn't emit a customer-id column natively, so we
+    # build a moderately-sized randomised corpus via ``_ih_from_rows`` and
+    # run the full get_sequences → calculate_pmi → pmi_overview pipeline
+    # against both implementations. A fixed random seed makes this fully
+    # deterministic.
+    rng = random.Random(42)
+    actions = ["A", "B", "C", "D", "E", "F"]
+    rows = []
+    for c in range(200):
+        length = rng.randint(2, 25)
+        for _ in range(length):
+            action = rng.choice(actions)
+            outcome = "Conversion" if rng.random() < 0.05 else "Impression"
+            rows.append((f"c{c}", action, outcome))
+    ih = _ih_from_rows(rows)
+
+    new, ref = _run_both(ih)
+    _assert_counts_equal(new, ref)
+
+    # Full pipeline: get_sequences -> calculate_pmi -> pmi_overview should
+    # yield an identical DataFrame under either implementation.
+    _, _, new_actions, new_sequences = new
+    _, _, ref_actions, ref_sequences = ref
+
+    new_pmi = IH.calculate_pmi(new_actions, new_sequences)
+    ref_pmi = IH.calculate_pmi(ref_actions, ref_sequences)
+
+    new_df = IH.pmi_overview(new_pmi, new_sequences, new[0], new[1])
+    ref_df = IH.pmi_overview(ref_pmi, ref_sequences, ref[0], ref[1])
+
+    from polars.testing import assert_frame_equal
+
+    sort_cols = new_df.columns
+    assert_frame_equal(
+        new_df.sort(sort_cols),
+        ref_df.sort(sort_cols),
+        check_row_order=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Benchmark — manual, not run under pytest by default.
+# ---------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    import time
+
+    # Build a 20k-row synthetic corpus with a ~5% conversion rate — matches
+    # the shape of realistic IH feeds and is what the algorithmic argument
+    # is tuned for.
+    rng = random.Random(0)
+    actions = [f"A{i}" for i in range(10)]
+    rows = []
+    while len(rows) < 20_000:
+        cid = f"c{rng.randint(0, 999)}"
+        length = rng.randint(5, 30)
+        for _ in range(length):
+            action = rng.choice(actions)
+            outcome = "Conversion" if rng.random() < 0.05 else "Impression"
+            rows.append((cid, action, outcome))
+
+    ih = _ih_from_rows(rows)
+
+    t0 = time.perf_counter()
+    _get_sequences_reference(ih, "Conversion", "Action", "Outcome", "CustomerID")
+    t_ref = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    ih.get_sequences(
+        positive_outcome_label="Conversion",
+        level="Action",
+        outcome_column="Outcome",
+        customerid_column="CustomerID",
+    )
+    t_new = time.perf_counter() - t0
+
+    print(f"rows      : {len(rows)}")
+    print(f"reference : {t_ref:.3f}s")
+    print(f"new       : {t_new:.3f}s")
+    print(f"speedup   : {t_ref / t_new:.2f}x")

--- a/python/tests/ih/test_IH_get_sequences.py
+++ b/python/tests/ih/test_IH_get_sequences.py
@@ -391,36 +391,42 @@ def test_equivalence_on_mock_data():
 if __name__ == "__main__":
     import time
 
-    # Build a 20k-row synthetic corpus with a ~5% conversion rate — matches
-    # the shape of realistic IH feeds and is what the algorithmic argument
-    # is tuned for.
-    rng = random.Random(0)
-    actions = [f"A{i}" for i in range(10)]
-    rows = []
-    while len(rows) < 20_000:
-        cid = f"c{rng.randint(0, 999)}"
-        length = rng.randint(5, 30)
-        for _ in range(length):
-            action = rng.choice(actions)
-            outcome = "Conversion" if rng.random() < 0.05 else "Impression"
-            rows.append((cid, action, outcome))
+    def _build_corpus(length_range, conv_rate, min_rows, seed=0):
+        rng = random.Random(seed)
+        actions = [f"A{i}" for i in range(10)]
+        rows = []
+        while len(rows) < min_rows:
+            cid = f"c{rng.randint(0, 999)}"
+            length = rng.randint(*length_range)
+            for _ in range(length):
+                action = rng.choice(actions)
+                outcome = "Conversion" if rng.random() < conv_rate else "Impression"
+                rows.append((cid, action, outcome))
+        return rows
 
-    ih = _ih_from_rows(rows)
+    configs = [
+        ("5-30", (5, 30), 0.05, 17_544),
+        ("20-80", (20, 80), 0.05, 25_264),
+        ("50-150", (50, 150), 0.05, 30_063),
+        ("50-150", (50, 150), 0.01, 30_063),
+    ]
 
-    t0 = time.perf_counter()
-    _get_sequences_reference(ih, "Conversion", "Action", "Outcome", "CustomerID")
-    t_ref = time.perf_counter() - t0
+    print(f"{'L range':>8} {'conv':>6} {'rows':>7} {'ref(s)':>8} {'new(s)':>8} {'speedup':>9}")
+    for label, length_range, conv, min_rows in configs:
+        rows = _build_corpus(length_range, conv, min_rows)
+        ih = _ih_from_rows(rows)
 
-    t0 = time.perf_counter()
-    ih.get_sequences(
-        positive_outcome_label="Conversion",
-        level="Action",
-        outcome_column="Outcome",
-        customerid_column="CustomerID",
-    )
-    t_new = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        _get_sequences_reference(ih, "Conversion", "Action", "Outcome", "CustomerID")
+        t_ref = time.perf_counter() - t0
 
-    print(f"rows      : {len(rows)}")
-    print(f"reference : {t_ref:.3f}s")
-    print(f"new       : {t_new:.3f}s")
-    print(f"speedup   : {t_ref / t_new:.2f}x")
+        t0 = time.perf_counter()
+        ih.get_sequences(
+            positive_outcome_label="Conversion",
+            level="Action",
+            outcome_column="Outcome",
+            customerid_column="CustomerID",
+        )
+        t_new = time.perf_counter() - t0
+
+        print(f"{label:>8} {conv:>6.0%} {len(rows):>7d} {t_ref:>8.3f} {t_new:>8.3f} {t_ref / t_new:>8.2f}x")


### PR DESCRIPTION
# perf(ih): speed up `get_sequences` 13–16× via iteration inversion + counter fusion

## Why this works (closed-form bigram multiplicities)

The original implementation enumerated every contiguous window
`seq[i:i+n]` with `n ≥ 2` whose **last** outcome was positive
(`out[i+n-1] == 1`), pushed each onto `bigrams_all` / `bigrams` /
`ngrams`, then tallied those lists into the four counters in a second
pass.

**Commit 1 (iteration inversion)** rewrote the outer loop to walk only
positive end positions `j` (`out[j] == 1`), covering the same
`(start, length)` pairs via `i = j - n + 1`. Drops the outer
enumeration from O(L²) to O(P · L), where P is the per-customer
positive count.

**Commit 2 (counter fusion)** removes the three intermediate lists.
Since `defaultdict(int)` increments commute, only the *multiset* of
emissions matters — and that has a closed form per positive end `j`:

- **Ending bigram** `seq[j-1:j+1]` is emitted into `bigrams_all`
  exactly **j** times (once from `n=2`, plus once per each of the
  `j-1` ngrams of length `n = 3..j+1` — every such ngram contains
  the ending bigram as its rightmost pair).
- **Earlier bigram** `seq[k:k+2]` for `k = 0..j-2` is emitted exactly
  **k+1** times. (It appears in the ngram of length `n` iff
  `j - n + 1 ≤ k`, i.e. `n ≥ j - k + 1`; the count of valid `n` in
  `[3, j+1]` is `(j+1) - (j-k+1) + 1 = k+1`.)
- The ending bigram lands in `bigrams` exactly once per positive `j`
  (only `n=2` writes there).
- Length-≥3 ngrams `seq[j-n+1:j+1]` for `n = 3..j+1` each appear once
  in `ngrams` per positive `j`.

So we increment counters directly:

```
count_sequences[0][ending]      += j
count_actions[0][(seq[j-1],)]   += j
count_actions[1][(seq[j],)]     += j
count_sequences[2][ending]      += 1
for k in 0..j-2:
    count_sequences[0][seq[k:k+2]]   += (k+1)
    count_actions[0][(seq[k],)]      += (k+1)
    count_actions[1][(seq[k+1],)]    += (k+1)
for n in 3..j+1:
    count_sequences[1][seq[j-n+1:j+1]] += 1
```

`count_sequences[3]` (per-customer-distinct ngrams) still needs the
`ngrams_seen` set. The full ngram tuple is needed as a dict key for
`count_sequences[1]` / `count_sequences[3]`, so the O(n) tuple slice
there stays — but the inner O(n) bigram-expansion that used to
dominate is gone.

**Per positive `j`:** bigram bookkeeping O(j²) → **O(j)**; ngram
bookkeeping unchanged at O(j²) (inherent to ngram-keyed dicts).

## Correctness

Locked in by `python/tests/ih/test_IH_get_sequences.py`, which runs
the verbatim pre-rewrite implementation side-by-side and asserts
bit-exact counter equality across hand-crafted, randomised, and
end-to-end pipeline inputs (29 tests).

## Benchmark

13–16× total speedup vs. the original implementation on the
benchmark harness in the test file (run with
`python python/tests/ih/test_IH_get_sequences.py`).