### PR TITLE
docs(changelog): backfill missing v5.0.0 entries from merged PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ guide.
 
 ### Added
 
+- Python 3.14 support (#416). CI now runs against 3.10–3.14.
+- `ADMDatamart.from_s3` is now implemented (was a no-op stub). Downloads
+  model + predictor data from S3 to a temporary directory and delegates
+  to `from_ds_export`. `boto3` is gated via `MissingDependenciesException`
+  and lives in the existing `pega_io` extras group (#702).
+- `ADMDatamart.plot.over_time` (and aggregates equivalent) now accepts a
+  list of column names for `by`, in addition to the existing single-string
+  form — enables grouping by Channel × Direction etc. in Health Check /
+  Model Reports (#700).
+- `ImpactAnalyzer.from_excel` classmethod reads PDC Excel exports
+  (`.xlsx`) using polars' built-in calamine engine (no extra deps). The
+  Streamlit app and `--data-path` CLI flag accept `.xlsx` uploads with
+  auto-detection (#685).
+- `pega_io.read_data` now recognises `.xlsx` / `.xls` and owns the
+  `fastexcel` optional-dependency shim. `ImpactAnalyzer.from_excel`
+  delegates the file load to `read_data` (#694).
+- Decision Analyzer auto-detects mandatory actions (priority ≥ 5M) when
+  no `mandatory_expr` is passed, and flags them visually in the global
+  win/loss distribution pie and on the Global Sensitivity page (#698).
+- Health Check `--full-embed` / `--no-full-embed` CLI flag, propagated to
+  the Streamlit Reports page as a new "Embed JS/CSS for offline viewing"
+  toggle in the Advanced expander. Defaults preserve the previous
+  behaviour (#688).
 - `pdstools.valuefinder.__init__` now re-exports `ValueFinder` (was empty).
 - `CHANGELOG.md` (this file).
 - `docs/migration-v4-to-v5.md`.
@@ -115,7 +138,58 @@ guide.
   (shadowed the builtin).
 - Internal split of
   `pdstools.infinity.resources.prediction_studio.v24_2.prediction` and
-  `prediction_studio` into multi-module packages. Public imports unchanged.
+  `prediction_studio` into multi-module packages. Public imports unchanged
+  (#732, #735 also splits `champion_challenger`).
+- `Infinity(...)` / `AsyncInfinity(...)` now require keyword-only
+  `base_url` and `auth` (plus optional `application_name`, `verify`,
+  `pega_version`, `timeout`). The catch-all `*args, **kwargs` signature
+  is gone; unknown kwargs are rejected. Direct `Infinity()` with no args
+  now raises `TypeError` instead of `RuntimeError`. The
+  `from_basic_auth` / `from_client_credentials` /
+  `from_client_id_and_secret` classmethods are unchanged (#714).
+- Explanations: `sort_by`, `display_by`, `descending`, `missing`,
+  `remaining`, `include_numeric_single_bin` are now explicit keyword-only
+  parameters with literal defaults across `Plots.contributions`,
+  `Plots.plot_contributions_for_overall`,
+  `Plots.plot_contributions_by_context`,
+  `Aggregate.get_predictor_contributions`,
+  `Aggregate.get_predictor_value_contributions`, and `Reports.generate`.
+  New `SortBy` / `DisplayBy` `Literal` type aliases (#714).
+- Explanations now validates raw input parquet schemas up front in
+  `Preprocess.generate` and raises a descriptive `ValueError` for
+  malformed / partially-written files instead of surfacing as a cryptic
+  DuckDB SQL error mid-aggregation. New `pdstools.explanations.Schema`
+  module (#741).
+- `pdstools.adm.Reports` shared options (`title`, `subtitle`,
+  `disclaimer`, `output_dir`, `output_type`, `qmd_file`, `full_embed`,
+  `keep_temp_files`) are now passed via `**options: Unpack[ReportOptions]`
+  (PEP 692 `TypedDict`). Existing keyword call sites
+  (`dm.generate.health_check(title=..., output_type='pdf')`) continue to
+  work unchanged and now get IDE autocomplete + static type checking.
+  Unknown option keys raise `TypeError` (#653).
+- `verbose=` parameters that only gated internal noise (subprocess
+  output, schema warnings, decoded values, raw `os.listdir`) have been
+  dropped on `cdh_utils._apply_schema_types`,
+  `report_utils.{get_quarto_with_version, get_pandoc_with_version, run_quarto}`,
+  `Reports.{model_reports, health_check}`,
+  `pega_io.File.{read_ds_export, read_zipped_file, get_latest_file}`,
+  `ADMTrees.{get_agb_models, __new__, get_multi_trees}` and the inner
+  `_decode_trees` helpers. Such output now goes through
+  `logger.debug` / `logger.info`. The `verbose=` parameter is preserved
+  on call sites that drive genuine user-facing progress (S3,
+  `read_multi_zip`, `Anonymization`). `Reports.health_check` no longer
+  couples `verbose` to cache / error-reporting paths (#647).
+- `BinAggregator` constructor parameter renamed `dm=` → `datamart=`,
+  matching every other sub-namespace on `ADMDatamart`. No deprecated
+  alias — the class is always constructed via
+  `ADMDatamart.bin_aggregator` (#675).
+- `pdstools.infinity.internal._base_client._infer_version` now logs
+  warnings via the module logger (with `exc_info`) instead of `print()`
+  (#736).
+- Optional-dependency handling tightened: `MissingDependenciesException`
+  is now raised consistently across pdstools instead of bare
+  `ImportError`s, and the Quarto `standalone` flag is now wired through
+  to report generation (#639, closes #436).
 - Reorganised `python/tests/` into per-module subfolders mirroring
   `python/pdstools/` (`adm/`, `decision_analyzer/`, `impact_analyzer/`,
   `infinity/`, `pega_io/`, `ih/`, `valuefinder/`, `healthcheck/`,
@@ -143,6 +217,56 @@ guide.
   documented entry point.
 - `pdstools.pega_io.File.import_file` (public helper). It was always
   internal to `read_ds_export`; use `read_ds_export` instead.
+
+### Fixed
+
+- Better diagnostic information when Health Check report generation
+  hits a `PermissionDenied` from Quarto on Windows; Infinity API
+  client now supports Pega `'25.1`; Decision Analyzer no longer
+  crashes with `ColumnNotFoundError: "Stage Group"` when the dataset
+  only contains `Stage` — `__init__` now validates `level` against
+  `available_levels` and falls back when needed (#642, closes #439,
+  #409, #599).
+- `pega_io.File.find_latest_files` no longer raises a silent
+  `re.PatternError` on every call (`\d.{0,15}*GMT` had a stray
+  repeat). Surfaced while narrowing `except Exception:` blocks across
+  the codebase to specific exception types, which also restores
+  meaningful error reporting for previously-swallowed bugs (#650).
+- Health Check `report_utils` now inlines CSS in CDN-mode HTML output,
+  fixing reports that rendered unstyled when opened without network
+  access (#679).
+- Health Check hides trend plots when only one snapshot is present
+  (instead of rendering a misleading single-point line) (#682).
+- Decision Analyzer `get_thresholding_data` now works with
+  `num_samples > 1` (was incorrectly locked to a single sample) (#683).
+- Decision Analyzer Streamlit app: more robust file uploads — META-INF
+  entries from zipped exports are filtered out, partial state is
+  cleared on upload errors, and error messages are clearer (#687).
+- ADM `plot.over_time` and other category-coloured charts now use a
+  global category → colour map so legends stay consistent across
+  plots within a single report (#689).
+- `ADMTreesModel` decoder dispatch converted from chained `try/except`
+  to explicit `if/elif`, and its "warn once" path is now thread-safe
+  (#690).
+- Decision Analyzer `prio_factor_boxplots` no longer mutates
+  `self.sample_size` as a side effect of plotting (#691).
+- Decision Analyzer column schema now distinguishes Model Propensity
+  vs Final Propensity display names so plots that reference one don't
+  silently pick up the other (#699).
+
+### Performance
+
+- Lazy-import `plotly` across `adm`, `explanations`, `valuefinder`,
+  `ih`, `impactanalyzer` and the Decision Analyzer Overview page so
+  importing pdstools (or rendering a cold page) no longer pays the
+  plotly import cost up front (#676, #686, #692).
+- `BinAggregator.accumulate_num_binnings` is now batched, removing a
+  per-binning Python-loop hot spot (#747).
+- `IH.get_sequences` rewritten for fewer scans / collects (#745).
+- `utils.overlap_matrix` and `overlap_lists_polars` vectorised over
+  polars expressions, replacing per-row Python work (#746).
+- Per-row `map_elements` lookups across the codebase replaced with
+  `pl.Expr.replace_strict` (#652).
 
 ---
 


### PR DESCRIPTION
Add Added/Changed/Fixed/Performance entries for ~30 PRs merged since v4.7.1 that were not yet captured in the v5.0.0 section: Python 3.14 support, ImpactAnalyzer/pega_io Excel input, ADMDatamart.from_s3, over_time multi-by, healthcheck full_embed flag, mandatory action detection, Infinity/Explanations explicit kwargs, Reports TypedDict options, verbose-param cleanup, BinAggregator rename, explanations Schema validation, all 10 user-visible bug fixes (#642, #650, #679, #682, #683, #687, #689, #690, #691, #699), and the perf bundle (#652, #676, #686, #692, #745, #746, #747).