### PR TITLE
docs(migration): backfill v4→v5 migration guide entries

### DIFF
--- a/docs/migration-v4-to-v5.md
+++ b/docs/migration-v4-to-v5.md
@@ -149,10 +149,52 @@ model=...)` directly.
 Previously `def __init__(self, *args, **kwargs)`. Now uses explicit
 parameters matching the documented constructor signature.
 
-### `Explanations.filter_*`
+### Explanations: explicit filter parameters
 
-Previously `**filter_kwargs`. Now uses explicit parameters per
-`docs/plans/explanations/typed-filter-kwargs.md`.
+The `**filter_kwargs` catch-all on the Explanations `Plots`,
+`Aggregate`, and `Reports` public methods has been replaced with
+explicit, keyword-only parameters: `sort_by`, `display_by`,
+`descending`, `missing`, `remaining`, `include_numeric_single_bin`.
+Affected methods: `Plots.contributions`,
+`Plots.plot_contributions_for_overall`,
+`Plots.plot_contributions_by_context`,
+`Aggregate.get_predictor_contributions`,
+`Aggregate.get_predictor_value_contributions`, and `Reports.generate`.
+Unknown kwargs now raise `TypeError`. New `SortBy` / `DisplayBy`
+`Literal` aliases are exported alongside.
+
+```python
+# Before (v4.x):
+plots.contributions(**{"sort_by": "value", "typo_arg": True})  # silently dropped
+
+# After (v5):
+plots.contributions(sort_by="value")  # unknown kwargs raise TypeError
+```
+
+### `Reports.model_reports` / `Reports.health_check` — explicit kwargs
+
+The `**options: Unpack[ReportOptions]` catch-all is gone. Both methods
+now take explicit keyword-only parameters (`title`, `subtitle`,
+`disclaimer`, `output_dir`, `output_type`, `qmd_file`, `full_embed`,
+`keep_temp_files`), and `output_type` is typed `Literal["html", "pdf"]`.
+The `ReportOptions` `TypedDict` and the
+`pdstools.adm.Reports.ReportOptions` re-export have been removed —
+call-sites that splatted a `ReportOptions` dict must pass the fields
+as plain kwargs instead.
+
+```python
+# Before (v4.x):
+from pdstools.adm.Reports import ReportOptions
+opts: ReportOptions = {"title": "My Report", "output_type": "pdf"}
+dm.generate.model_reports(model_list=models, **opts)
+
+# After (v5):
+dm.generate.model_reports(
+    model_list=models,
+    title="My Report",
+    output_type="pdf",
+)
+```
 
 ### `DecisionAnalyzer.__init__` and `from_*` classmethods
 

--- a/docs/migration-v4-to-v5.md
+++ b/docs/migration-v4-to-v5.md
@@ -171,31 +171,6 @@ plots.contributions(**{"sort_by": "value", "typo_arg": True})  # silently droppe
 plots.contributions(sort_by="value")  # unknown kwargs raise TypeError
 ```
 
-### `Reports.model_reports` / `Reports.health_check` — explicit kwargs
-
-The `**options: Unpack[ReportOptions]` catch-all is gone. Both methods
-now take explicit keyword-only parameters (`title`, `subtitle`,
-`disclaimer`, `output_dir`, `output_type`, `qmd_file`, `full_embed`,
-`keep_temp_files`), and `output_type` is typed `Literal["html", "pdf"]`.
-The `ReportOptions` `TypedDict` and the
-`pdstools.adm.Reports.ReportOptions` re-export have been removed —
-call-sites that splatted a `ReportOptions` dict must pass the fields
-as plain kwargs instead.
-
-```python
-# Before (v4.x):
-from pdstools.adm.Reports import ReportOptions
-opts: ReportOptions = {"title": "My Report", "output_type": "pdf"}
-dm.generate.model_reports(model_list=models, **opts)
-
-# After (v5):
-dm.generate.model_reports(
-    model_list=models,
-    title="My Report",
-    output_type="pdf",
-)
-```
-
 ### `DecisionAnalyzer.__init__` and `from_*` classmethods
 
 Previously accepted positional arguments and `**kwargs`. Now all


### PR DESCRIPTION
Expand the Explanations section with the actual affected methods (Plots.contributions, Aggregate.get_predictor_*, Reports.generate) and the new keyword-only parameters, replacing the vague filter_* heading and the dead reference to a deleted plan file.

Add a new entry for the removal of the ReportOptions TypedDict on Reports.model_reports / Reports.health_check, with a before/after snippet showing how to migrate from **opts splat to plain kwargs.