### PR TITLE
chore(v5): bump version to 5.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -609,6 +609,33 @@ in `ADMDatamart` at load time" by the third comment. Acting on the
 title alone would have produced a correct-looking but wrongly-placed
 fix that another reviewer would have to redo.
 
+### Verify "removed / renamed / dropped" claims against current source
+
+When writing changelog entries, migration guides, deprecation notes, or
+any prose that describes an API change as having happened, **grep
+master for the symbol first**. PR titles and commit messages routinely
+overstate the change ("drop the `**kwargs` catch-all" can mean
+"replace bare `**kwargs` with `**options: Unpack[ReportOptions]`",
+which keeps the splat working and merely types it). A migration guide
+that tells users to rewrite call sites that don't actually need
+rewriting is worse than no entry at all — it forces a noisy review
+cycle and erodes trust in the rest of the document.
+
+Workflow:
+1. Identify the symbol/parameter the PR claims to change.
+2. `grep` for it in `python/pdstools/` on current `master`.
+3. If it still exists, read how it's used now and write the entry to
+   match reality (or omit the entry entirely if the change is
+   transparent to callers).
+4. Only describe something as "removed" / "renamed" if step 2 confirms
+   the old name is gone.
+
+This applies double when the AGENTS.md design rules contain an
+**explicit exception** for the pattern in question (e.g. "shared
+option sets across 2+ public entry points → use `Unpack[TypedDict]`").
+A grep-then-write check would have caught the bogus
+"`ReportOptions` removed" migration entry that prompted this rule.
+
 ### Don't land a "plan-files-only" PR
 
 Plan files (`docs/plans/<feature>/<slug>.md`) are designed to be

--- a/python/pdstools/__init__.py
+++ b/python/pdstools/__init__.py
@@ -1,6 +1,6 @@
 """Pega Data Scientist Tools Python library"""
 
-__version__ = "4.7.1"
+__version__ = "5.0.0"
 
 from pathlib import Path
 


### PR DESCRIPTION
Bumps __version__ from 4.7.1 to 5.0.0. Smoke-tested with:

  uv run python -m build --sdist --wheel --outdir dist/ .
  → pdstools-5.0.0-py3-none-any.whl built cleanly
  uv run python -c 'import pdstools; print(pdstools.__version__)'
  → 5.0.0

CHANGELOG.md still has '## [5.0.0] — TBD' — set the date in a follow-up commit on the day of release.

Tag + PyPI publish are NOT part of this PR; they are manual steps done after merge.

Also adds a new AGENTS.md section ('Verify removed / renamed / dropped claims against current source') capturing the lesson from the migration-audit ReportOptions false-positive.