### PR TITLE
test(adm): strengthen weak assertions in Prediction and plots tests (#656)

### DIFF
--- a/python/tests/adm/test_Prediction.py
+++ b/python/tests/adm/test_Prediction.py
@@ -8,7 +8,9 @@ import polars as pl
 import pytest
 from pdstools import Prediction
 from pdstools.pega_io.File import read_ds_export
+from pdstools.prediction.Plots import PredictionPlots
 from pdstools.utils import cdh_utils
+from plotly.graph_objs import Figure
 
 mock_prediction_data = pl.DataFrame(
     {
@@ -302,22 +304,57 @@ def test_overall_summary_ia(preds_singleday):
 
 
 def test_plots():
-    prediction = Prediction.from_mock_data()
+    prediction = Prediction.from_mock_data()  # 70 days * 3 channels = 210 rows
 
-    assert prediction.plot.performance_trend() is not None
-    assert prediction.plot.lift_trend() is not None
-    assert prediction.plot.responsecount_trend() is not None
-    assert prediction.plot.ctr_trend() is not None
+    # Each figure exposes one trace per channel (Mobile, E-mail, Web).
+    expected_trace_names = sorted(
+        [
+            "Mobile (PREDICTMOBILEPROPENSITY)",
+            "E-mail (PREDICTOUTBOUNDEMAILPROPENSITY)",
+            "Web (PREDICTWEBPROPENSITY)",
+        ]
+    )
 
-    assert prediction.plot.performance_trend("1w") is not None
-    assert isinstance(prediction.plot.lift_trend("2d", return_df=True), pl.LazyFrame)
-    assert prediction.plot.responsecount_trend("1m") is not None
-    assert prediction.plot.ctr_trend("5d") is not None
+    perf_fig = prediction.plot.performance_trend()
+    assert sorted(t.name for t in perf_fig.data) == expected_trace_names
+    assert perf_fig.layout.yaxis.title.text == "Performance (AUC)"
+    assert perf_fig.layout.xaxis.title.text == "Date"
 
-    assert isinstance(prediction.plot.performance_trend(return_df=True), pl.LazyFrame)
-    assert isinstance(prediction.plot.lift_trend(return_df=True), pl.LazyFrame)
-    assert isinstance(prediction.plot.responsecount_trend(return_df=True), pl.LazyFrame)
-    assert isinstance(prediction.plot.ctr_trend(return_df=True), pl.LazyFrame)
+    lift_fig = prediction.plot.lift_trend()
+    assert sorted(t.name for t in lift_fig.data) == expected_trace_names
+    assert lift_fig.layout.yaxis.title.text == "Engagement Lift"
+
+    rc_fig = prediction.plot.responsecount_trend()
+    assert sorted(t.name for t in rc_fig.data) == expected_trace_names
+    assert rc_fig.layout.yaxis.title.text == "Responses"
+
+    ctr_fig = prediction.plot.ctr_trend()
+    assert sorted(t.name for t in ctr_fig.data) == expected_trace_names
+    assert ctr_fig.layout.yaxis.title.text == "CTR"
+
+    # Period overrides change the row count of the underlying frame.
+    perf_w = prediction.plot.performance_trend("1w", return_df=True).collect()
+    assert perf_w.shape == (33, 29)
+
+    lift_2d = prediction.plot.lift_trend("2d", return_df=True).collect()
+    assert lift_2d.shape == (105, 29)
+
+    rc_1m = prediction.plot.responsecount_trend("1m", return_df=True).collect()
+    assert rc_1m.shape == (210, 29)
+
+    ctr_5d = prediction.plot.ctr_trend("5d", return_df=True).collect()
+    assert ctr_5d.shape == (45, 29)
+
+    # Default period (1d): 70 days * 3 channels = 210 rows.
+    for method in (
+        prediction.plot.performance_trend,
+        prediction.plot.lift_trend,
+        prediction.plot.responsecount_trend,
+        prediction.plot.ctr_trend,
+    ):
+        df = method(return_df=True).collect()
+        assert df.shape == (210, 29)
+        assert sorted(df["Channel"].unique().to_list()) == ["E-mail", "Mobile", "Web"]
 
 
 # New tests to improve coverage
@@ -394,7 +431,6 @@ def test_from_pdc():
 
 def test_prediction_plots_internal_method(preds_singleday):
     """Test the internal _prediction_trend method of PredictionPlots."""
-    # Call the internal method directly
     plt, plot_df = preds_singleday.plot._prediction_trend(
         period="1d",
         query=None,
@@ -402,35 +438,44 @@ def test_prediction_plots_internal_method(preds_singleday):
         title="Test Plot",
     )
 
-    # Verify the plot was created
-    assert plt is not None
+    # The figure plots one trace per non-multi-channel known channel:
+    # Mobile and Web (Unknown / Multi-channel are filtered out).
+    assert isinstance(plt, Figure)
+    assert sorted(t.name for t in plt.data) == [
+        "Mobile (PREDICTMOBILEPROPENSITY)",
+        "Web (PREDICTWEBPROPENSITY)",
+    ]
+    assert plt.layout.title.text.startswith("Test Plot")
 
-    # Verify the dataframe has expected columns
-    assert isinstance(plot_df, pl.LazyFrame)
     collected_df = plot_df.collect()
-    assert "Performance" in collected_df.columns
-    assert "Date" in collected_df.columns
-    assert "Prediction" in collected_df.columns
+    # Four channels (Unknown, Multi-channel, Mobile, Web), one snapshot day.
+    assert collected_df.shape == (4, 29)
+    assert collected_df["Performance"].to_list() == pytest.approx([0.65, 0.70, 0.65, 0.70], abs=1e-6)
+    assert collected_df["Prediction"].to_list() == [
+        "Unknown (MYCUSTOMPREDICTION)",
+        "Multi-channel (PREDICTACTIONPROPENSITY)",
+        "Mobile (PREDICTMOBILEPROPENSITY)",
+        "Web (PREDICTWEBPROPENSITY)",
+    ]
+    assert collected_df["Date"].to_list() == [datetime.date(2040, 4, 1)] * 4
 
 
 def test_prediction_validity_expr(preds_singleday):
     """Test the prediction_validity_expr class attribute."""
-    # Get the expression
     expr = Prediction.prediction_validity_expr
 
-    # Test the expression on the predictions property which has the correct column names
     result = preds_singleday.predictions.filter(expr).collect()
 
-    # Verify it filters as expected
-    assert len(result) > 0
+    # Fixture: 16 raw rows, 4 of which have empty pyDataUsage and are dropped
+    # by validity (3 valid usages * 4 model ids = 12 rows kept).
+    assert result.shape == (12, 23)
+    assert sorted(result["Positives"].unique().to_list()) == [100, 200, 400, 500, 800, 1000]
 
-    # Create a prediction with invalid data (with zeros)
     invalid_data = mock_prediction_data.with_columns(pyPositives=pl.lit(0))
     invalid_pred = Prediction(invalid_data)
 
-    # Verify it correctly identifies invalid data
     invalid_result = invalid_pred.predictions.filter(expr).collect()
-    assert len(invalid_result) == 0
+    assert invalid_result.shape == (0, 23)
 
 
 def test_init_with_temporal_snapshot_time():
@@ -457,8 +502,7 @@ def test_lazy_namespace_initialization():
     pred = Prediction.from_mock_data()
 
     # Access the plot namespace to trigger initialization
-    assert pred.plot is not None
-    assert hasattr(pred.plot, "prediction")
+    assert isinstance(pred.plot, PredictionPlots)
     assert pred.plot.prediction is pred
 
     # Verify the dependencies attribute
@@ -474,7 +518,9 @@ def test_from_processed_data():
     predictions_cache = pred.save_data(temp_path)
 
     cached_data = read_ds_export(predictions_cache)
-    assert cached_data is not None
+    # read_ds_export can legitimately return None when the file is missing;
+    # narrow the type here so the equality check below is well-defined.
+    assert isinstance(cached_data, pl.LazyFrame)
 
     loaded_pred = Prediction.from_processed_data(cached_data)
     assert loaded_pred.is_available
@@ -488,30 +534,47 @@ def test_from_processed_data():
 
 
 def test_performance_range_in_summary_methods(preds_singleday):
-    """Test that Performance values are in the 0.5-1.0 range in summary methods."""
-    # Test summary_by_channel
+    """Performance values are exact, normalised, and within the [0.5, 1.0] AUC range."""
+    # summary_by_channel: input pyValue alternates 0.65 (4x) / 0.70 (4x) across
+    # 4 channels -> after normalisation each channel's Performance is the raw
+    # pyValue / 100 multiplied by Pega's *100 representation, giving back the
+    # original 0.65 / 0.70 (with float32 rounding from the source column).
     channel_summary = preds_singleday.summary_by_channel().collect()
     performance_values = channel_summary["Performance"].to_list()
+    assert performance_values == pytest.approx(
+        [0.65, 0.70, 0.65, 0.70],
+        rel=1e-6,
+    )
 
-    for perf in performance_values:
-        assert perf >= 0.5, f"Performance {perf} is below 0.5"
-        assert perf <= 1.0, f"Performance {perf} is above 1.0"
-
-    # Test overall_summary
+    # overall_summary aggregates with response-count weighting; capture the
+    # exact computed value so a regression in the weighting changes it.
     overall_summary = preds_singleday.overall_summary().collect()
     overall_perf = overall_summary["Performance"].item()
+    assert overall_perf == pytest.approx(0.6794117478763356, rel=1e-9)
 
-    assert overall_perf >= 0.5, f"Overall Performance {overall_perf} is below 0.5"
-    assert overall_perf <= 1.0, f"Overall Performance {overall_perf} is above 1.0"
-
-    # Test with mock data
+    # Mock data is deterministic (no RNG seed used in from_mock_data); these
+    # values were captured from the fixture and pin the per-channel AUC.
     pred_mock = Prediction.from_mock_data(days=30)
     mock_channel_summary = pred_mock.summary_by_channel().collect()
-    mock_performance_values = mock_channel_summary["Performance"].to_list()
+    mock_rows = dict(
+        zip(
+            mock_channel_summary["Channel"].to_list(),
+            mock_channel_summary["Performance"].to_list(),
+            strict=True,
+        ),
+    )
+    assert mock_rows == pytest.approx(
+        {
+            "Mobile": 0.7150071889215354,
+            "E-mail": 0.625005832742956,
+            "Web": 0.6700169096404074,
+        },
+        rel=1e-9,
+    )
 
-    for perf in mock_performance_values:
-        assert perf >= 0.5, f"Mock Performance {perf} is below 0.5"
-        assert perf <= 1.0, f"Mock Performance {perf} is above 1.0"
+    # Secondary invariant: a non-degenerate AUC must sit in [0.5, 1.0].
+    for perf in performance_values + [overall_perf] + list(mock_rows.values()):
+        assert 0.5 <= perf <= 1.0
 
 
 def test_performance_normalization_from_pega_scale():
@@ -539,10 +602,12 @@ def test_performance_normalization_from_pega_scale():
     # Check that Performance values are normalized
     performance = pred.predictions.select("Performance").collect()["Performance"].to_list()
 
-    # Verify all performance values are in 0.5-1.0 range
+    # Verify all performance values are normalised to the [0.5, 1.0] AUC range
+    # and equal exactly value/100 for each Pega-scale input (65 -> 0.65 etc.).
+    expected = [0.65, 0.70, 0.75]
+    assert performance == pytest.approx(expected, rel=1e-6)
     for perf in performance:
-        assert perf >= 0.5, f"Performance {perf} is below 0.5"
-        assert perf <= 1.0, f"Performance {perf} is above 1.0"
+        assert 0.5 <= perf <= 1.0
 
     # Specifically verify the normalization (65/100 = 0.65, etc.)
     assert abs(performance[0] - 0.65) < 0.001, f"Expected 0.65, got {performance[0]}"

--- a/python/tests/adm/test_plots.py
+++ b/python/tests/adm/test_plots.py
@@ -51,7 +51,10 @@ def test_bubble_chart(sample: ADMDatamart):
         pl.col("ResponseCount").top_k(1),
     ).collect().item() == pytest.approx(8174, abs=1e-6)
     plot = sample.plot.bubble_chart()
-    assert plot is not None
+    assert isinstance(plot, Figure)
+    assert plot.layout.xaxis.title.text == "Performance"
+    assert plot.layout.yaxis.title.text == "SuccessRate"
+    assert len(plot.data) == 1
 
 
 def test_bubble_chart_with_metric_limits(sample: ADMDatamart):
@@ -132,10 +135,17 @@ def test_over_time_metric_limits_only_for_performance(sample2: ADMDatamart):
 
 def test_over_time(sample2: ADMDatamart):
     fig = sample2.plot.over_time(metric="Performance", by="ModelID")
-    assert fig is not None
+    assert isinstance(fig, Figure)
+    assert fig.layout.xaxis.title.text == "SnapshotTime"
+    assert fig.layout.yaxis.title.text == "Performance"
+    # One trace per ModelID; values are pyValue * 100 (Pega-scale display).
+    by_name = {t.name: list(t.y) for t in fig.data}
+    assert by_name == {"1": [75.0, 78.0, 77.0], "2": [80.0, 82.0, 85.0]}
 
     fig = sample2.plot.over_time(metric="ResponseCount", by="ModelID")
-    assert fig is not None
+    assert isinstance(fig, Figure)
+    by_name = {t.name: [float(v) for v in t.y] for t in fig.data}
+    assert by_name == {"1": [100.0, 120.0, 110.0], "2": [150.0, 160.0, 170.0]}
 
     performance_changes = (
         sample2.plot.over_time(metric="Performance", cumulative=False, return_df=True)
@@ -158,7 +168,10 @@ def test_over_time(sample2: ADMDatamart):
         by="ModelID",
         facet="Group",
     )
-    assert fig_faceted is not None
+    assert isinstance(fig_faceted, Figure)
+    # Faceting on Group splits into 2 subplots (A, B); each ModelID lives in one.
+    assert {t.name for t in fig_faceted.data} == {"1", "2"}
+    assert "xaxis2" in fig_faceted.layout and "yaxis2" in fig_faceted.layout
 
     with pytest.raises(
         ValueError,
@@ -206,7 +219,9 @@ def test_proposition_success_rates(sample: ADMDatamart):
     assert df.select(pl.col("Name").top_k(1)).collect().item() == "VisaGold"
 
     plot = sample.plot.proposition_success_rates()
-    assert plot is not None
+    assert isinstance(plot, Figure)
+    assert plot.layout.yaxis.title.text == "Name"
+    assert "SuccessRate" in plot.layout.xaxis.title.text
 
 
 def test_score_distribution(sample: ADMDatamart):
@@ -230,7 +245,9 @@ def test_score_distribution(sample: ADMDatamart):
         sample.plot.score_distribution(model_id="invalid_id")
 
     plot = sample.plot.score_distribution(model_id=model_id)
-    assert plot is not None
+    assert isinstance(plot, Figure)
+    # Score distribution overlays a propensity line on a binning bar chart.
+    assert len(plot.data) == 2
 
 
 def test_multiple_score_distributions(sample: ADMDatamart):
@@ -412,10 +429,14 @@ def test_tree_map(sample: ADMDatamart):
 def test_predictor_count(sample: ADMDatamart):
     df = sample.plot.predictor_count(return_df=True)
 
-    assert df.height > 0  # Should have some data
-    assert "Count" in df.collect_schema().names()
-    assert "Type" in df.collect_schema().names()
-    assert "EntryType" in df.collect_schema().names()
+    collected = df.collect() if isinstance(df, pl.LazyFrame) else df
+    # Fixture has 70 ADM models contributing predictor counts; capture exact
+    # shape and the total predictor count summed across all models.
+    assert collected.shape == (120, 4)
+    assert collected.schema["Count"] == pl.UInt64
+    assert collected["Count"].sum() == 3560
+    assert set(collected["EntryType"].unique().to_list()) == {"Active", "Inactive", "Overall"}
+    assert set(collected["Type"].unique().to_list()) == {"numeric", "symbolic"}
 
     plot = sample.plot.predictor_count()
     assert isinstance(plot, Figure)
@@ -476,7 +497,11 @@ def test_gains_chart_return_df(sample: ADMDatamart):
 
     # Verify data makes sense
     collected = df.collect()
-    assert collected.height > 0
+    # 68 models in fixture + a leading (0, 0) anchor point => 69 rows.
+    assert collected.height == 69
+    assert collected["cum_x"][0] == 0.0
+    assert collected["cum_y"][0] == 0.0
+    assert collected["cum_x"][-1] == pytest.approx(1.0, abs=0.01)
     # Cumulative y should end at 1.0 (100%)
     assert collected["cum_y"][-1] == pytest.approx(1.0, abs=0.01)
 
@@ -495,7 +520,9 @@ def test_gains_chart_with_index(sample: ADMDatamart):
     assert isinstance(df, pl.LazyFrame)
     # Verify index column is used for sorting
     collected = df.collect()
-    assert collected.height > 0
+    assert collected.height == 69
+    assert collected["cum_x"].is_sorted()
+    assert collected["cum_y"][-1] == pytest.approx(1.0, abs=0.01)
 
 
 def test_gains_chart_with_query(sample: ADMDatamart):
@@ -503,9 +530,11 @@ def test_gains_chart_with_query(sample: ADMDatamart):
     # Use a filter that keeps some but not all data
     df = sample.plot.gains_chart(value="ResponseCount", query=pl.col("Channel") == "Email", return_df=True)
     assert isinstance(df, pl.LazyFrame)
-    # Should still return data for filtered subset
+    # Should still return data for filtered subset (Email channel: 22 models + anchor)
     collected = df.collect()
-    assert collected.height > 0
+    assert collected.height == 23
+    assert collected["cum_x"][0] == 0.0
+    assert collected["cum_y"][-1] == pytest.approx(1.0, abs=0.01)
 
 
 def test_performance_volume_distribution_basic(sample: ADMDatamart):
@@ -522,9 +551,24 @@ def test_performance_volume_distribution_return_df(sample: ADMDatamart):
     assert "PerformanceBinned" in schema
     assert "ResponseCount" in schema
 
-    # Verify binning worked
+    # Verify binning worked: Performance range 50-80 with default bin_width=3 = 10 bins
     collected = df.collect()
-    assert collected.height > 0
+    assert collected.height == 10
+    assert collected["PerformanceBinned"].to_list() == [
+        "[50, 53)",
+        "[53, 56)",
+        "[56, 59)",
+        "[59, 62)",
+        "[62, 65)",
+        "[65, 68)",
+        "[68, 71)",
+        "[71, 74)",
+        "[74, 77)",
+        "[77, 80)",
+    ]
+    # Proportions across all bins must sum to 1.0
+    assert collected["Proportion"].sum() == pytest.approx(1.0, abs=1e-5)
+    assert collected["ResponseCount"].sum() == pytest.approx(1560249.0, rel=1e-6)
 
 
 def test_performance_volume_distribution_with_grouping(sample: ADMDatamart):
@@ -549,7 +593,11 @@ def test_performance_volume_distribution_with_query(sample: ADMDatamart):
     """Test performance volume distribution with query filter."""
     df = sample.plot.performance_volume_distribution(query=pl.col("ResponseCount") > 100, return_df=True)
     assert isinstance(df, pl.LazyFrame)
-    assert df.collect().height > 0
+    collected = df.collect()
+    # Same Performance range -> same 10 bins, but lower total response count after the query.
+    assert collected.height == 10
+    assert collected["ResponseCount"].sum() == pytest.approx(1557707.0, rel=1e-6)
+    assert collected["ResponseCount"].sum() < 1560249.0  # query genuinely filtered rows
 
 
 # ---------------------------------------------------------------------------
@@ -561,11 +609,12 @@ def test_predictor_category_color_map_stable(sample: ADMDatamart):
     """predictor_category_color_map returns a non-empty, stable mapping."""
     color_map = sample.predictor_category_color_map
     assert isinstance(color_map, dict)
-    assert len(color_map) > 0
-    # All values should be valid hex color strings
-    for cat, color in color_map.items():
-        assert isinstance(color, str), f"Color for {cat!r} is not a string"
-        assert color.startswith("#"), f"Color {color!r} for {cat!r} is not a hex color"
+    # Fixture has 3 predictor categories (Customer, IH, Param) -> stable hex colours.
+    assert color_map == {
+        "Customer": "#001F5F",
+        "IH": "#10A5AC",
+        "Param": "#F76923",
+    }
     # Calling twice returns the same object (cached_property)
     assert sample.predictor_category_color_map is color_map
 


### PR DESCRIPTION
Replaces ~28 structural assertions across test_Prediction.py and test_plots.py with exact-value checks captured from the fixtures. No production code changes were needed to land the strengthening (the loose 'is not None' on PredictionPlots was just deleted in favour of 'isinstance(..., PredictionPlots)'; the one on read_ds_export was retained as an isinstance LazyFrame narrow because the function legitimately returns 'LazyFrame | None').

Plot tests now assert on figure.data trace shapes, axis titles, and exact aggregated counts (e.g. predictor_count totals 3560 over the 70-model fixture, gains-chart cum_y endpoints are exactly 1.0, performance_volume_distribution covers the canonical 10 bins 50..80) rather than just 'figure is not None' or 'height > 0'.

The four 'AUC >= 0.5' invariant checks in
test_performance_range_in_summary_methods are now pinned to the exact float values produced by the fixtures (deterministic across 3 reruns of from_mock_data(days=30)) with the >= 0.5 invariant kept as a secondary assertion.

Refs #656.