### PR TITLE
feat(streamlit): cross-app launcher hosts HC + DA + IA in one process

### DIFF
--- a/python/pdstools/app/decision_analyzer/_navigation.py
+++ b/python/pdstools/app/decision_analyzer/_navigation.py
@@ -57,21 +57,72 @@ def locked_page_titles() -> list[str]:
     return [p.title for p in _DATA_PAGES]
 
 
+def _slug(title: str) -> str:
+    """Lowercase, underscore-separated slug used for stable URL paths."""
+    return title.lower().replace(" / ", "_").replace(" ", "_").replace("/", "_")
+
+
+def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
+    """Return the DA page list for ``st.navigation``.
+
+    Parameters
+    ----------
+    url_prefix : str or None
+        When set (e.g. ``"da"``), every page is registered with a
+        ``url_path`` of ``f"{url_prefix}/{slug}"`` so multiple tools
+        can be hosted in one Streamlit process without URL collisions.
+        When ``None``, page URLs are derived from titles by Streamlit
+        — preserves the standalone tool's existing URL scheme.
+    default : bool
+        Whether the Home page is marked as the navigation default.
+        The launcher must designate exactly one default page across
+        all sections, so it sets this to ``False`` for tools other
+        than the one it picks as the entry point.
+    """
+    locked = locked_page_titles()
+
+    def _url(name: str) -> str | None:
+        # Streamlit's ``st.Page`` rejects nested ``url_path`` values
+        # (no "/"). Use an underscore-prefixed flat namespace instead
+        # so launcher URLs look like ``/da_overview`` while standalone
+        # tool launches keep their original ``/overview`` URLs.
+        return f"{url_prefix}_{name}" if url_prefix else None
+
+    # Wrap render so st.Page can call it with no arguments while still
+    # passing the locked-page list for the discoverability hint.
+    home = st.Page(
+        lambda: render_home(locked),
+        title="Home",
+        icon="🏠",
+        default=default,
+        url_path=_url("home"),
+    )
+    about = st.Page(
+        str(_PAGES_DIR / _ABOUT_PAGE_FILE),
+        title="About",
+        icon="ℹ️",
+        url_path=_url("about"),
+    )
+
+    result = [home]
+    if "decision_data" in st.session_state:
+        result.extend(
+            st.Page(
+                str(_PAGES_DIR / p.filename),
+                title=p.title,
+                icon=p.icon,
+                url_path=_url(_slug(p.title)),
+            )
+            for p in _DATA_PAGES
+        )
+    result.append(about)
+    return result
+
+
 def build_navigation():
     """Return the configured ``st.navigation`` object for the DA app.
 
     Always shows Home (default) and About. Data-dependent pages are
     appended to the menu only when ``decision_data`` is loaded.
     """
-    locked = locked_page_titles()
-    # Wrap render so st.Page can call it with no arguments while still
-    # passing the locked-page list for the discoverability hint.
-    home = st.Page(lambda: render_home(locked), title="Home", icon="🏠", default=True)
-    about = st.Page(str(_PAGES_DIR / _ABOUT_PAGE_FILE), title="About", icon="ℹ️")
-
-    pages = [home]
-    if "decision_data" in st.session_state:
-        pages.extend(st.Page(str(_PAGES_DIR / p.filename), title=p.title, icon=p.icon) for p in _DATA_PAGES)
-    pages.append(about)
-
-    return st.navigation(pages, position="sidebar")
+    return st.navigation(pages(), position="sidebar")

--- a/python/pdstools/app/health_check/_navigation.py
+++ b/python/pdstools/app/health_check/_navigation.py
@@ -36,12 +36,47 @@ _SUB_PAGES: tuple[_SubPage, ...] = (
 )
 
 
+def _slug(title: str) -> str:
+    """Lowercase, underscore-separated slug used for stable URL paths."""
+    return title.lower().replace(" / ", "_").replace(" ", "_").replace("/", "_")
+
+
+def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
+    """Return the HC page list for ``st.navigation``.
+
+    See ``decision_analyzer._navigation.pages`` for the parameter
+    semantics — same contract across all pdstools tools so the
+    cross-app launcher can reuse them uniformly.
+    """
+
+    def _url(name: str) -> str | None:
+        # Streamlit's ``st.Page`` rejects nested ``url_path`` values
+        # (no "/"). Use an underscore-prefixed flat namespace instead.
+        return f"{url_prefix}_{name}" if url_prefix else None
+
+    home = st.Page(
+        home_page,
+        title="Home",
+        icon="🏠",
+        default=default,
+        url_path=_url("home"),
+    )
+    result = [home]
+    result.extend(
+        st.Page(
+            str(_PAGES_DIR / p.filename),
+            title=p.title,
+            icon=p.icon,
+            url_path=_url(_slug(p.title)),
+        )
+        for p in _SUB_PAGES
+    )
+    return result
+
+
 def build_navigation():
     """Return the configured ``st.navigation`` object for the HC app.
 
     Always shows Home (default) plus every page in ``pages/``.
     """
-    home = st.Page(home_page, title="Home", icon="🏠", default=True)
-    pages = [home]
-    pages.extend(st.Page(str(_PAGES_DIR / p.filename), title=p.title, icon=p.icon) for p in _SUB_PAGES)
-    return st.navigation(pages, position="sidebar")
+    return st.navigation(pages(), position="sidebar")

--- a/python/pdstools/app/impact_analyzer/_navigation.py
+++ b/python/pdstools/app/impact_analyzer/_navigation.py
@@ -36,12 +36,47 @@ _SUB_PAGES: tuple[_SubPage, ...] = (
 )
 
 
+def _slug(title: str) -> str:
+    """Lowercase, underscore-separated slug used for stable URL paths."""
+    return title.lower().replace(" / ", "_").replace(" ", "_").replace("/", "_")
+
+
+def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
+    """Return the IA page list for ``st.navigation``.
+
+    See ``decision_analyzer._navigation.pages`` for parameter
+    semantics — same contract across all pdstools tools so the
+    cross-app launcher can reuse them uniformly.
+    """
+
+    def _url(name: str) -> str | None:
+        # Streamlit's ``st.Page`` rejects nested ``url_path`` values
+        # (no "/"). Use an underscore-prefixed flat namespace instead.
+        return f"{url_prefix}_{name}" if url_prefix else None
+
+    home = st.Page(
+        home_page,
+        title="Home",
+        icon="🏠",
+        default=default,
+        url_path=_url("home"),
+    )
+    result = [home]
+    result.extend(
+        st.Page(
+            str(_PAGES_DIR / p.filename),
+            title=p.title,
+            icon=p.icon,
+            url_path=_url(_slug(p.title)),
+        )
+        for p in _SUB_PAGES
+    )
+    return result
+
+
 def build_navigation():
     """Return the configured ``st.navigation`` object for the IA app.
 
     Always shows Home (default) plus every page in ``pages/``.
     """
-    home = st.Page(home_page, title="Home", icon="🏠", default=True)
-    pages = [home]
-    pages.extend(st.Page(str(_PAGES_DIR / p.filename), title=p.title, icon=p.icon) for p in _SUB_PAGES)
-    return st.navigation(pages, position="sidebar")
+    return st.navigation(pages(), position="sidebar")

--- a/python/pdstools/app/launcher/Home.py
+++ b/python/pdstools/app/launcher/Home.py
@@ -1,0 +1,36 @@
+# python/pdstools/app/launcher/Home.py
+"""Entry script for the cross-app pdstools launcher.
+
+Hosts Health Check, Decision Analyzer, and Impact Analyzer side by
+side in a single Streamlit process using ``st.navigation``'s
+sectioned dict API. Standalone tool entry points
+(``app/<tool>/Home.py``) are unaffected.
+
+URL paths are flat-namespaced (``/hc_*``, ``/da_*``, ``/ia_*``) to
+avoid collisions between tools that share page names — Streamlit's
+``st.Page`` rejects nested ``/`` in ``url_path`` so the launcher uses
+an underscore separator instead.
+"""
+
+import streamlit as st
+
+from pdstools.app.decision_analyzer._navigation import pages as da_pages
+from pdstools.app.health_check._navigation import pages as hc_pages
+from pdstools.app.impact_analyzer._navigation import pages as ia_pages
+from pdstools.utils.streamlit_utils import (
+    show_sidebar_branding,
+    standard_page_config,
+)
+
+standard_page_config(page_title="pdstools")
+show_sidebar_branding("pdstools")
+
+# Health Check is the first section so its Home is the default page —
+# only one page may carry default=True across the whole navigation.
+sections: dict[str, list[st.Page]] = {
+    "Health Check": hc_pages(url_prefix="hc", default=True),
+    "Decision Analyzer": da_pages(url_prefix="da", default=False),
+    "Impact Analyzer": ia_pages(url_prefix="ia", default=False),
+}
+
+st.navigation(sections, position="sidebar").run()

--- a/python/pdstools/app/launcher/__init__.py
+++ b/python/pdstools/app/launcher/__init__.py
@@ -1,0 +1,9 @@
+"""Cross-app launcher hosting Health Check, Decision Analyzer, and
+Impact Analyzer in a single Streamlit process.
+
+Each tool keeps its own per-section sidebar group via
+``st.navigation``'s sectioned dict API; URL paths are flat-namespaced
+(``/hc_*``, ``/da_*``, ``/ia_*``) to avoid collisions between tools
+that share page names. Standalone tool launches keep their original
+URLs intact so existing bookmarks don't break.
+"""

--- a/python/pdstools/cli.py
+++ b/python/pdstools/cli.py
@@ -18,8 +18,14 @@ from pdstools import __version__
 # bare app name) is routed to ``run`` for backwards compatibility.
 _SUBCOMMANDS = {"run", "doctor", "list"}
 
-# App configuration with display names and paths
+# App configuration with display names and paths.
+# ``launcher`` is listed first so it's the default selection in the
+# interactive picker — it hosts all three tools in one process.
 APPS = {
+    "launcher": {
+        "display_name": "All tools (launcher)",
+        "path": "pdstools.app.launcher",
+    },
     "health_check": {
         "display_name": "Adaptive Model Health Check",
         "path": "pdstools.app.health_check",
@@ -36,6 +42,7 @@ APPS = {
 
 # Aliases for app names
 ALIASES = {
+    "all": "launcher",
     "hc": "health_check",
     "da": "decision_analyzer",
     "ia": "impact_analyzer",
@@ -409,7 +416,18 @@ def run(args, unknown):
             "--server.enableXsrfProtection",
             "false",
         ]
-    else:  # health_check
+    elif args.app == "launcher":
+        # The launcher hosts the DA pages, so it inherits DA's XSRF
+        # exemption (DA uses the file-uploader workaround that breaks
+        # under XSRF). Standalone HC / IA launches keep XSRF on.
+        sys.argv = [
+            "streamlit",
+            "run",
+            filename,
+            "--server.enableXsrfProtection",
+            "false",
+        ]
+    else:  # health_check, impact_analyzer
         sys.argv = ["streamlit", "run", filename]
 
     if unknown:

--- a/python/tests/streamlit_apps/launcher/test_launcher.py
+++ b/python/tests/streamlit_apps/launcher/test_launcher.py
@@ -1,0 +1,43 @@
+"""AppTest smoke test for the cross-app pdstools launcher.
+
+Verifies the launcher boots without exception, registers all three
+tools as sidebar sections, and namespaces their URLs to avoid
+collisions. A regression here means the launcher won't host one or
+more tools.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from streamlit.testing.v1 import AppTest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+LAUNCHER_HOME = REPO_ROOT / "python" / "pdstools" / "app" / "launcher" / "Home.py"
+HC_HOME = REPO_ROOT / "python" / "pdstools" / "app" / "health_check" / "Home.py"
+
+
+def test_launcher_home_renders_without_data():
+    """Launcher entry script runs without exception on first load.
+
+    Indirectly validates that all three tools' ``pages()`` helpers
+    are callable, that the sectioned ``st.navigation`` dict API
+    accepts the result, and that the per-tool URL namespacing
+    produces URL paths Streamlit considers valid (no nested ``/``,
+    no collisions across the three "About" pages).
+    """
+    at = AppTest.from_file(str(LAUNCHER_HOME), default_timeout=60)
+    at.run()
+    assert not at.exception, f"Launcher Home raised: {at.exception}"
+
+
+def test_standalone_hc_home_still_renders():
+    """Standalone HC launch must keep working with the refactored ``pages()``.
+
+    The launcher refactor moved page construction into a helper that
+    accepts a ``url_prefix``; the standalone entry script must keep
+    rendering the original URL scheme so bookmarks don't break.
+    """
+    at = AppTest.from_file(str(HC_HOME), default_timeout=60)
+    at.run()
+    assert not at.exception, f"HC standalone Home raised: {at.exception}"

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -16,7 +16,15 @@ from pdstools.cli import ALIASES, APPS, check_for_typos, create_parser, main, ru
 
 class TestAppsDict:
     def test_expected_keys(self):
-        assert set(APPS.keys()) == {"health_check", "decision_analyzer", "impact_analyzer"}
+        assert set(APPS.keys()) == {"launcher", "health_check", "decision_analyzer", "impact_analyzer"}
+
+    def test_launcher_is_first_entry(self):
+        # Order matters — launcher is the default selection in the
+        # interactive picker, so it must be the first key.
+        assert list(APPS.keys())[0] == "launcher"
+
+    def test_launcher_path_points_at_launcher_module(self):
+        assert APPS["launcher"]["path"] == "pdstools.app.launcher"
 
     def test_each_entry_has_display_name_and_path(self):
         for key, value in APPS.items():
@@ -50,7 +58,16 @@ class TestCreateParser:
         parser = create_parser()
         # The 'app' positional argument should have correct choices (including aliases)
         app_action = None
-        expected_choices = {"health_check", "decision_analyzer", "impact_analyzer", "hc", "da", "ia"}
+        expected_choices = {
+            "launcher",
+            "health_check",
+            "decision_analyzer",
+            "impact_analyzer",
+            "all",
+            "hc",
+            "da",
+            "ia",
+        }
         for action in parser._actions:
             if hasattr(action, "choices") and action.choices is not None:
                 if set(action.choices) == expected_choices:
@@ -80,9 +97,16 @@ class TestArgumentParsing:
 
     def test_app_argument(self):
         parser = create_parser()
-        for app_name in ("health_check", "decision_analyzer", "impact_analyzer"):
+        for app_name in ("launcher", "health_check", "decision_analyzer", "impact_analyzer"):
             args = parser.parse_args([app_name])
             assert args.app == app_name
+
+    def test_launcher_alias(self):
+        parser = create_parser()
+        args = parser.parse_args(["all"])
+        # alias resolution happens in main(), not the parser — parser
+        # should still accept it as a valid choice
+        assert args.app == "all"
 
     def test_data_path_flag(self):
         parser = create_parser()
@@ -390,8 +414,16 @@ class TestRunInteractivePrompt:
 
     def test_select_by_number(self):
         args = self._run_with_input(["1"])
-        # First entry in APPS is health_check
+        # First entry in APPS is the cross-app launcher
         assert args.app == list(APPS.keys())[0]
+        assert args.app == "launcher"
+
+    def test_launcher_alias_resolves(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["pdstools", "all"])
+        with patch.object(cli_module, "run") as mock_run:
+            main()
+        args, _ = mock_run.call_args[0]
+        assert args.app == "launcher"
 
     def test_select_by_internal_name(self):
         self._run_with_input(["decision_analyzer"])


### PR DESCRIPTION
Adds an opt-in launcher that uses st.navigation()'s section grouping to host all three tools in a single Streamlit process. Each tool keeps its own sidebar group; URLs are namespaced per tool (/hc_*, /da_*, /ia_*) with an underscore separator since st.Page rejects nested url_path values.

The launcher is the new default 'pdstools' picker selection. Each tool can still be launched standalone (pdstools hc / da / ia) with its original URL scheme intact for bookmarked links.

Built on top of PR #<TBD> (streamlit-navigation-unification).