### PR TITLE
refactor(streamlit): single shared About in the launcher

### DIFF
--- a/python/pdstools/app/decision_analyzer/_navigation.py
+++ b/python/pdstools/app/decision_analyzer/_navigation.py
@@ -62,7 +62,11 @@ def _slug(title: str) -> str:
     return title.lower().replace(" / ", "_").replace(" ", "_").replace("/", "_")
 
 
-def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
+def pages(
+    url_prefix: str | None = None,
+    default: bool = True,
+    include_about: bool = True,
+) -> list[st.Page]:
     """Return the DA page list for ``st.navigation``.
 
     Parameters
@@ -78,6 +82,11 @@ def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
         The launcher must designate exactly one default page across
         all sections, so it sets this to ``False`` for tools other
         than the one it picks as the entry point.
+    include_about : bool
+        Whether to append the per-tool About page. Standalone tool
+        launches keep it (``True``); the cross-app launcher passes
+        ``False`` so all three tools share a single top-level About
+        entry instead of crowding the sidebar with three.
     """
     locked = locked_page_titles()
 
@@ -115,7 +124,8 @@ def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
             )
             for p in _DATA_PAGES
         )
-    result.append(about)
+    if include_about:
+        result.append(about)
     return result
 
 

--- a/python/pdstools/app/health_check/_navigation.py
+++ b/python/pdstools/app/health_check/_navigation.py
@@ -32,8 +32,9 @@ class _SubPage:
 _SUB_PAGES: tuple[_SubPage, ...] = (
     _SubPage("1_Data_Filters.py", "Data Filters", "🔍"),
     _SubPage("2_Reports.py", "Reports", "📊"),
-    _SubPage("3_About.py", "About", "ℹ️"),
 )
+
+_ABOUT_PAGE = _SubPage("3_About.py", "About", "ℹ️")
 
 
 def _slug(title: str) -> str:
@@ -41,7 +42,11 @@ def _slug(title: str) -> str:
     return title.lower().replace(" / ", "_").replace(" ", "_").replace("/", "_")
 
 
-def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
+def pages(
+    url_prefix: str | None = None,
+    default: bool = True,
+    include_about: bool = True,
+) -> list[st.Page]:
     """Return the HC page list for ``st.navigation``.
 
     See ``decision_analyzer._navigation.pages`` for the parameter
@@ -71,6 +76,15 @@ def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
         )
         for p in _SUB_PAGES
     )
+    if include_about:
+        result.append(
+            st.Page(
+                str(_PAGES_DIR / _ABOUT_PAGE.filename),
+                title=_ABOUT_PAGE.title,
+                icon=_ABOUT_PAGE.icon,
+                url_path=_url(_slug(_ABOUT_PAGE.title)),
+            )
+        )
     return result
 
 

--- a/python/pdstools/app/impact_analyzer/_navigation.py
+++ b/python/pdstools/app/impact_analyzer/_navigation.py
@@ -32,8 +32,9 @@ class _SubPage:
 _SUB_PAGES: tuple[_SubPage, ...] = (
     _SubPage("1_Overall_Summary.py", "Overall Summary", "📈"),
     _SubPage("2_Trend.py", "Trend", "📉"),
-    _SubPage("3_About.py", "About", "ℹ️"),
 )
+
+_ABOUT_PAGE = _SubPage("3_About.py", "About", "ℹ️")
 
 
 def _slug(title: str) -> str:
@@ -41,7 +42,11 @@ def _slug(title: str) -> str:
     return title.lower().replace(" / ", "_").replace(" ", "_").replace("/", "_")
 
 
-def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
+def pages(
+    url_prefix: str | None = None,
+    default: bool = True,
+    include_about: bool = True,
+) -> list[st.Page]:
     """Return the IA page list for ``st.navigation``.
 
     See ``decision_analyzer._navigation.pages`` for parameter
@@ -71,6 +76,15 @@ def pages(url_prefix: str | None = None, default: bool = True) -> list[st.Page]:
         )
         for p in _SUB_PAGES
     )
+    if include_about:
+        result.append(
+            st.Page(
+                str(_PAGES_DIR / _ABOUT_PAGE.filename),
+                title=_ABOUT_PAGE.title,
+                icon=_ABOUT_PAGE.icon,
+                url_path=_url(_slug(_ABOUT_PAGE.title)),
+            )
+        )
     return result
 
 

--- a/python/pdstools/app/launcher/Home.py
+++ b/python/pdstools/app/launcher/Home.py
@@ -12,12 +12,16 @@ avoid collisions between tools that share page names — Streamlit's
 an underscore separator instead.
 """
 
+from pathlib import Path
+
 import streamlit as st
 
 from pdstools.utils.streamlit_utils import (
     show_sidebar_branding,
     standard_page_config,
 )
+
+_ABOUT_SCRIPT = Path(__file__).parent / "_about.py"
 
 
 # Each tool's _navigation module is imported on first call only — the
@@ -26,22 +30,25 @@ from pdstools.utils.streamlit_utils import (
 # rerun even when the user only ever clicks into one tool. After the
 # first call sys.modules caches the module so subsequent reruns are
 # free.
+#
+# include_about=False on every tool: the launcher exposes one shared
+# top-level About entry instead of three near-identical per-tool ones.
 def _hc_section() -> list[st.Page]:
     from pdstools.app.health_check._navigation import pages
 
-    return pages(url_prefix="hc", default=True)
+    return pages(url_prefix="hc", default=True, include_about=False)
 
 
 def _da_section() -> list[st.Page]:
     from pdstools.app.decision_analyzer._navigation import pages
 
-    return pages(url_prefix="da", default=False)
+    return pages(url_prefix="da", default=False, include_about=False)
 
 
 def _ia_section() -> list[st.Page]:
     from pdstools.app.impact_analyzer._navigation import pages
 
-    return pages(url_prefix="ia", default=False)
+    return pages(url_prefix="ia", default=False, include_about=False)
 
 
 standard_page_config(page_title="pdstools")
@@ -49,10 +56,20 @@ show_sidebar_branding("pdstools")
 
 # Health Check is the first section so its Home is the default page —
 # only one page may carry default=True across the whole navigation.
+# The shared About page lives in its own section so it reads as a
+# top-level entry, not buried under any one tool.
 sections: dict[str, list[st.Page]] = {
     "Health Check": _hc_section(),
     "Decision Analyzer": _da_section(),
     "Impact Analyzer": _ia_section(),
+    "pdstools": [
+        st.Page(
+            str(_ABOUT_SCRIPT),
+            title="About",
+            icon="ℹ️",
+            url_path="about",
+        ),
+    ],
 }
 
 st.navigation(sections, position="sidebar").run()

--- a/python/pdstools/app/launcher/_about.py
+++ b/python/pdstools/app/launcher/_about.py
@@ -1,0 +1,14 @@
+# python/pdstools/app/launcher/_about.py
+"""Shared About page for the cross-app pdstools launcher.
+
+Single top-level About entry — replaces the three near-identical
+per-tool About entries that would otherwise crowd the launcher
+sidebar (one per tool section). Standalone tool launches keep
+their own About page via ``pages(include_about=True)``.
+"""
+
+from pdstools.utils.streamlit_utils import show_about_page, standard_page_config
+
+standard_page_config(page_title="About · pdstools")
+
+show_about_page()


### PR DESCRIPTION
Each tool's pages() helper now accepts include_about (default True to preserve standalone UX). The launcher passes include_about=False for every tool section and registers one top-level About page — instead of three near-identical About entries cluttering the launcher sidebar.