### PR TITLE
chore(impact-analyzer): consumer-friendly pre-load language + consist…

### DIFF
--- a/python/pdstools/app/impact_analyzer/_home_page.py
+++ b/python/pdstools/app/impact_analyzer/_home_page.py
@@ -141,13 +141,13 @@ def home_page() -> None:
         """
 # Impact Analyzer
 
-Analyze A/B test experiments from PDC exports or VBD Scenario Planner Actuals.
-Two data formats are supported — format is auto-detected on upload:
+Analyze A/B test experiments from your decisioning monitoring exports or
+scenario-planner data. Multiple input formats are supported — the format
+is auto-detected on upload:
 
-| | **PDC Export** | **PDC Excel Export** | **VBD Scenario Planner** | **Interaction History** |
+| | **Monitoring Export (JSON)** | **Monitoring Export (Excel)** | **Scenario Planner Export** | **Interaction History** |
 |---|---|---|---|---|
 | Format | JSON/NDJSON | XLSX | ZIP archive | TBD - future |
-| Source | Pega Diagnostic Cloud | Pega Diagnostic Cloud | Pega Infinity | Pega Infinity |
 
 All charts are interactive ([Plotly](https://plotly.com/graphing-libraries/)) — pan,
 zoom, and hover for details.
@@ -184,7 +184,8 @@ zoom, and hover for details.
 
         if not filtered_files:
             st.error(
-                "No valid data files found. Upload JSON/NDJSON (PDC), XLSX (PDC Excel), or ZIP (VBD) files. "
+                "No valid data files found. Upload JSON/NDJSON (monitoring export), "
+                "XLSX (Excel monitoring export), or ZIP (scenario-planner export) files. "
                 "If you dragged a folder, try uploading just the `data.json` file instead."
             )
         else:
@@ -201,13 +202,13 @@ zoom, and hover for details.
                     )
             # Multiple JSON files: treat as PDC
             elif suffixes.issubset({".json", ".ndjson"}):
-                with st.spinner("Loading PDC data"):
+                with st.spinner("Loading data…"):
                     impact_analyzer = _load_with_warning(
                         lambda: load_pdc_from_uploads(filtered_files),
-                        "PDC",
+                        "uploaded",
                     )
             else:
-                st.error("Upload a single file (JSON/NDJSON/ZIP) or multiple JSON/NDJSON files (PDC).")
+                st.error("Upload a single file (JSON/NDJSON/ZIP) or multiple JSON/NDJSON files.")
 
     # 2. Handle --data-path CLI flag
     has_existing_data = "impact_analyzer" in st.session_state
@@ -225,7 +226,7 @@ zoom, and hover for details.
 
     # 3. Fall back to sample data
     if impact_analyzer is None and not has_existing_data and not uploaded_files:
-        with st.spinner("Loading sample PDC data"):
+        with st.spinner("Loading sample data"):
             impact_analyzer = _load_with_warning(load_sample_pdc, "Sample")
         if impact_analyzer is not None:
             # Match the Decision Analyzer / Health Check first-run UX:

--- a/python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
+++ b/python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
@@ -473,7 +473,10 @@ def handle_data_path_ia() -> ImpactAnalyzer | None:
             st.session_state["ia_outcome_aliases_loaded_from"] = str(loaded_from) if loaded_from else str(p)
         return load_vbd_from_path(str(p), outcome_labels_json=outcome_labels_json)
     else:
-        st.error(f"Unsupported file type: {suffix}. Use JSON/NDJSON (PDC), XLSX (PDC Excel), or ZIP (VBD).")
+        st.error(
+            f"Unsupported file type: {suffix}. Use JSON/NDJSON (monitoring export), "
+            "XLSX (Excel monitoring export), or ZIP (scenario-planner export)."
+        )
         return None
 
 

--- a/python/pdstools/app/impact_analyzer/pages/1_Overall_Summary.py
+++ b/python/pdstools/app/impact_analyzer/pages/1_Overall_Summary.py
@@ -4,7 +4,7 @@ import streamlit as st
 from pdstools.app.impact_analyzer.ia_streamlit_utils import ensure_impact_analyzer
 from pdstools.utils.streamlit_utils import standard_page_config
 
-standard_page_config(page_title="Impact Analyzer · Overall Summary")
+standard_page_config(page_title="Overall Summary · Impact Analyzer")
 
 ia = ensure_impact_analyzer()
 

--- a/python/pdstools/app/impact_analyzer/pages/2_Trend.py
+++ b/python/pdstools/app/impact_analyzer/pages/2_Trend.py
@@ -5,7 +5,7 @@ from pdstools.app.impact_analyzer.ia_streamlit_utils import ensure_impact_analyz
 from pdstools.utils.cdh_utils import is_valid_polars_duration
 from pdstools.utils.streamlit_utils import standard_page_config
 
-standard_page_config(page_title="Impact Analyzer · Trend")
+standard_page_config(page_title="Trend · Impact Analyzer")
 
 ia = ensure_impact_analyzer()
 
@@ -17,7 +17,19 @@ seasonal patterns, and the stability of your experiment results.
 """
 
 
-facet = "Channel" if "Channel" in ia.ia_data.collect_schema().names() else None
+schema_names = ia.ia_data.collect_schema().names()
+facet = "Channel" if "Channel" in schema_names else None
+
+if "SnapshotTime" in schema_names:
+    import polars as pl
+
+    n_timestamps = ia.ia_data.select(pl.col("SnapshotTime").n_unique()).collect().item()
+    if n_timestamps is not None and n_timestamps < 2:
+        st.info(
+            "Trend analysis requires snapshots from multiple time periods. "
+            "The currently loaded data only spans a single point in time."
+        )
+        st.stop()
 
 with st.container(border=True):
     "## Time Series View"

--- a/python/tests/streamlit_apps/impact_analyzer/test_ia_pages.py
+++ b/python/tests/streamlit_apps/impact_analyzer/test_ia_pages.py
@@ -8,12 +8,29 @@ instead of passing silently.
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 
+import polars as pl
 import pytest
 from streamlit.testing.v1 import AppTest
 
 from pdstools.impactanalyzer.ImpactAnalyzer import ImpactAnalyzer
+
+
+def test_home_pre_load_text_is_product_neutral(ia_app_dir: Path):
+    """Pre-load home text must not mention internal product names.
+
+    Before the user uploads data, the UI describes Impact Analyzer
+    generically. Once data is loaded and a format is detected, the
+    detected-format label (``**PDC Export**``) is allowed.
+    """
+    at = AppTest.from_file(str(ia_app_dir / "Home.py"), default_timeout=30)
+    at.run()
+    assert not at.exception, f"IA Home raised: {at.exception}"
+    pre_load_text = "\n".join(m.value for m in at.markdown)
+    for forbidden in ("PDC", "Pega Diagnostic Cloud"):
+        assert forbidden not in pre_load_text, f"Pre-load IA Home text leaks {forbidden!r}: {pre_load_text!r}"
 
 
 def test_home_renders_without_data(ia_app_dir: Path):
@@ -46,6 +63,62 @@ IA_PAGES: list[tuple[str, str, dict[str, int]]] = [
 ]
 
 
+# Each entry: (filename, expected page_title). Mirrors the
+# ``"<Page> · <App>"`` convention used by HC and DA so the browser tab
+# reads the page name first.
+IA_PAGE_TITLES: list[tuple[str, str]] = [
+    ("1_Overall_Summary.py", "Overall Summary · Impact Analyzer"),
+    ("2_Trend.py", "Trend · Impact Analyzer"),
+    ("3_About.py", "About · Impact Analyzer"),
+]
+
+
+@pytest.mark.parametrize(
+    ("page", "expected_title"),
+    IA_PAGE_TITLES,
+    ids=[p[0].removesuffix(".py") for p in IA_PAGE_TITLES],
+)
+def test_ia_page_title_order(
+    page: str,
+    expected_title: str,
+    ia_app_dir: Path,
+):
+    """Browser-tab title is ``"<Page> · Impact Analyzer"``.
+
+    AppTest doesn't expose ``st.set_page_config(page_title=...)`` as a
+    queryable attribute, so assert against the source to guarantee the
+    convention is followed.
+    """
+    source = (ia_app_dir / "pages" / page).read_text()
+    assert f'page_title="{expected_title}"' in source, f"{page} expected page_title={expected_title!r} in source"
+
+
+def test_trend_guards_single_timestamp_data(
+    seeded_impact_analyzer: ImpactAnalyzer,
+    ia_app_dir: Path,
+):
+    """Trend page shows an info message and stops when data spans a
+    single point in time, instead of rendering a degenerate axis with
+    microsecond ticks."""
+    ia = copy.copy(seeded_impact_analyzer)
+    df = ia.ia_data.collect()
+    fixed = df.with_columns(pl.col("SnapshotTime").min().alias("SnapshotTime"))
+    ia.ia_data = fixed.lazy()
+
+    at = AppTest.from_file(str(ia_app_dir / "pages" / "2_Trend.py"), default_timeout=30)
+    at.session_state["impact_analyzer"] = ia
+    at.session_state["ia_is_sample_data"] = True
+    at.run()
+    assert not at.exception, f"2_Trend.py raised: {at.exception}"
+
+    info_messages = [i.value for i in at.info]
+    assert any("single point in time" in msg for msg in info_messages), (
+        f"Expected single-timestamp guard message; got info={info_messages!r}"
+    )
+    # Chart must not render when the page has stopped early.
+    assert not at.get("plotly_chart"), "Trend chart rendered despite single-timestamp guard"
+
+
 @pytest.mark.parametrize(
     ("page", "heading", "widget_checks"),
     IA_PAGES,
@@ -60,8 +133,18 @@ def test_ia_page_renders(
 ):
     """Each sub-page renders with a seeded ImpactAnalyzer and produces
     its expected heading + widget surface."""
+    ia = seeded_impact_analyzer
+    if page == "2_Trend.py":
+        # The bundled IA sample only has one SnapshotTime, which would
+        # trigger the single-timestamp guard. Expand it to two so the
+        # Trend page renders its chart + table for the smoke check.
+        ia = copy.copy(ia)
+        df = ia.ia_data.collect()
+        df2 = df.with_columns((pl.col("SnapshotTime") + pl.duration(days=1)).alias("SnapshotTime"))
+        ia.ia_data = pl.concat([df, df2]).lazy()
+
     at = AppTest.from_file(str(ia_app_dir / "pages" / page), default_timeout=30)
-    at.session_state["impact_analyzer"] = seeded_impact_analyzer
+    at.session_state["impact_analyzer"] = ia
     at.session_state["ia_is_sample_data"] = True
     at.run()
     assert not at.exception, f"{page} raised: {at.exception}"


### PR DESCRIPTION
…ent page titles + Trend guard

- Replace internal product references (PDC, Pega Diagnostic Cloud) in pre-load Home UI with generic, user-facing labels ("monitoring export", "scenario-planner export"). The detected-format label shown after a successful load is unchanged.
- Reorder sub-page browser-tab titles to "<Page> · Impact Analyzer" to mirror the HC/DA convention (already used by the IA About page).
- Guard the Trend page against single-timestamp data: show an info message and stop instead of rendering a degenerate axis with microsecond ticks (reproduces with the bundled CDH sample).
- Tests: assert pre-load Home text is product-neutral, page titles follow the convention, and the Trend guard fires on single-timestamp data without rendering a chart.