### PR TITLE
feat(streamlit): auto-load sample on data-required sub-pages

### DIFF
--- a/python/pdstools/app/health_check/_home_page.py
+++ b/python/pdstools/app/health_check/_home_page.py
@@ -16,12 +16,10 @@ def home_page() -> None:
     """Render the ADM Health Check home page."""
     import shutil
 
-    from pdstools.app.health_check.hc_streamlit_utils import handle_data_path_hc
+    from pdstools.app.health_check.hc_streamlit_utils import ensure_dm_loaded
     from pdstools.utils import streamlit_utils
     from pdstools.utils.cdh_utils import setup_logger
     from pdstools.utils.streamlit_utils import (
-        cached_sample,
-        cached_sample_prediction,
         get_data_path,
         show_sidebar_branding,
         show_version_header,
@@ -63,31 +61,18 @@ interactive visuals and an Excel export for further exploration.
         )
 
     # Auto-load on first visit so the app is immediately usable —
-    # matches DA / IA first-run UX. Order:
-    #   1. Honour ``--data-path`` if set (HC-specific helper handles dir
-    #      or zip; returns None on miss/unsupported so we fall through).
-    #   2. Fall back to the bundled CDH sample.
-    # The toast reflects whichever path actually loaded so users know
-    # what they're looking at. ``st.rerun()`` rebuilds the script with
-    # ``dm`` set so downstream pages see populated session state in the
-    # same user action.
+    # matches DA / IA first-run UX. Delegates the priority chain
+    # (``--data-path`` → bundled sample) to the shared helper so
+    # data-required sub-pages can do the same on deep-link.
+    # ``st.rerun()`` rebuilds the script with ``dm`` set so the rest of
+    # the home page (data summary, etc.) renders in the same user action.
     if "dm" not in st.session_state:
         configured_path = get_data_path()
-        loaded_from_path = False
-        if configured_path:
-            with st.spinner(f"Loading data from `{configured_path}`…"):
-                dm = handle_data_path_hc()
-            if dm is not None:
-                loaded_from_path = True
+        if ensure_dm_loaded():
+            if configured_path and st.session_state.get("data_source") == "Direct file path":
                 st.toast(f"Loaded data from `{configured_path}`.", icon="📂")
-                st.rerun()
-
-        if not loaded_from_path:
-            with st.spinner("Loading sample data…"):
-                st.session_state["dm"] = cached_sample()
-                st.session_state["prediction"] = cached_sample_prediction()
-                st.session_state["data_source"] = "CDH Sample"
-            st.toast("Loaded sample data — upload your own to replace it.", icon="📊")
+            else:
+                st.toast("Loaded sample data — upload your own to replace it.", icon="📊")
             st.rerun()
 
     # --- Data Import (previously a separate page) ---

--- a/python/pdstools/app/health_check/hc_streamlit_utils.py
+++ b/python/pdstools/app/health_check/hc_streamlit_utils.py
@@ -17,12 +17,83 @@ import streamlit as st
 from pdstools import pega_io
 from pdstools.adm.ADMDatamart import ADMDatamart
 from pdstools.utils.streamlit_utils import (
+    _apply_sidebar_logo,
     cached_datamart,
     cached_prediction_table,
+    cached_sample,
+    cached_sample_prediction,
     get_data_path,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def ensure_dm_loaded(*, show_toast: bool = False) -> bool:
+    """Ensure ``st.session_state["dm"]`` is populated, auto-loading a default.
+
+    Used both by the Health Check home page (first-run UX) and by data-required
+    sub-pages (deep-link / launcher flow) so a user who lands on a sub-page
+    without visiting Home first still gets a working app.
+
+    Priority chain:
+
+    1. If ``dm`` is already in session_state, return ``True`` immediately.
+    2. Try the ``--data-path`` CLI flag via :func:`handle_data_path_hc`.
+    3. Fall back to the bundled CDH sample.
+
+    Parameters
+    ----------
+    show_toast : bool, default False
+        When True and a load actually happened (i.e. session_state was empty
+        on entry), surface a non-modal toast describing what was loaded.
+        The home page handles its own toasts to also drive ``st.rerun()``,
+        so it leaves this False; sub-pages set it True.
+
+    Returns
+    -------
+    bool
+        ``True`` when ``dm`` is in session_state on return, ``False`` when
+        every load attempt failed (no CLI path resolves, no sample bundled,
+        etc.). Callers fall back to a "please upload" warning on ``False``.
+    """
+    if "dm" in st.session_state:
+        return True
+
+    configured_path = get_data_path()
+    if configured_path:
+        with st.spinner(f"Loading data from `{configured_path}`…"):
+            dm = handle_data_path_hc()
+        if dm is not None:
+            if show_toast:
+                st.toast(f"Loaded data from `{configured_path}`.", icon="📂")
+            return True
+
+    try:
+        with st.spinner("Loading sample data…"):
+            st.session_state["dm"] = cached_sample()
+            st.session_state["prediction"] = cached_sample_prediction()
+            st.session_state["data_source"] = "CDH Sample"
+    except Exception:
+        logger.exception("Failed to auto-load CDH sample for Health Check")
+        return False
+
+    if show_toast:
+        st.toast("Loaded sample data — upload your own to replace it.", icon="📊")
+    return True
+
+
+def ensure_dm() -> ADMDatamart:
+    """Sub-page guard: auto-load ``dm`` or warn-and-stop.
+
+    Re-applies sidebar branding (sub-page navigation drops it) and tries
+    :func:`ensure_dm_loaded` first so deep-linked users don't hit a dead
+    "please configure your files" warning.
+    """
+    _apply_sidebar_logo()
+    if not ensure_dm_loaded(show_toast=True):
+        st.warning("Please configure your files on the Home page.")
+        st.stop()
+    return st.session_state["dm"]
 
 
 def _load_from_directory(dir_path: str) -> ADMDatamart | None:

--- a/python/pdstools/app/health_check/pages/1_Data_Filters.py
+++ b/python/pdstools/app/health_check/pages/1_Data_Filters.py
@@ -3,6 +3,7 @@ import json
 import polars as pl
 import streamlit as st
 
+from pdstools.app.health_check.hc_streamlit_utils import ensure_dm
 from pdstools.utils.cdh_utils import _apply_query
 from pdstools.utils.streamlit_utils import (
     filter_dataframe,
@@ -12,6 +13,8 @@ from pdstools.utils.streamlit_utils import (
 
 standard_page_config(page_title="Data Filters · ADM Health Check")
 
+ensure_dm()
+
 """# Add custom filters"""
 
 """You can easily add custom filters to specify the Health Check to your needs.
@@ -20,52 +23,48 @@ For each column, a new configuration screen will be added in which you can speci
 what values you want to keep in the Health Check.
 """
 
-if "dm" in st.session_state:
-    expr_list = []
-    uploaded_file = st.file_uploader(
-        "Upload Filters You Downloaded Earlier",
-        type=["json"],
-    )
-    if uploaded_file:
-        import io
+expr_list = []
+uploaded_file = st.file_uploader(
+    "Upload Filters You Downloaded Earlier",
+    type=["json"],
+)
+if uploaded_file:
+    import io
 
-        imported_filters = json.load(uploaded_file)
-        for key, val in imported_filters.items():
-            # Convert the JSON string to a StringIO object and specify the format as 'json'
-            json_str = json.dumps(val)
-            str_io = io.StringIO(json_str)
-            expr_list.append(pl.Expr.deserialize(str_io, format="json"))
+    imported_filters = json.load(uploaded_file)
+    for key, val in imported_filters.items():
+        # Convert the JSON string to a StringIO object and specify the format as 'json'
+        json_str = json.dumps(val)
+        str_io = io.StringIO(json_str)
+        expr_list.append(pl.Expr.deserialize(str_io, format="json"))
 
-    st.session_state["filters"] = filter_dataframe(
+st.session_state["filters"] = filter_dataframe(
+    st.session_state["dm"].model_data,
+    queries=expr_list,
+)
+if "unfiltered_counts" not in st.session_state.keys():
+    st.session_state["unfiltered_counts"] = model_and_row_counts(
         st.session_state["dm"].model_data,
-        queries=expr_list,
     )
-    if "unfiltered_counts" not in st.session_state.keys():
-        st.session_state["unfiltered_counts"] = model_and_row_counts(
-            st.session_state["dm"].model_data,
-        )
-    if st.session_state["filters"] != []:
-        filtered_modelid_count, filtered_row_count = model_and_row_counts(
-            _apply_query(st.session_state["dm"].model_data, st.session_state["filters"]),
-        )
-        serialized_exprs = {}
-        for i, expr in enumerate(st.session_state["filters"]):
-            serialized = expr.meta.serialize(format="json")
-            serialized_exprs[i] = json.loads(serialized)
-        data = json.dumps(serialized_exprs)
-        st.download_button(
-            label="Download Filters",
-            data=data,
-            file_name="datamart_filters.json",
-        )
-        row_count_bar = st.progress(
-            (filtered_row_count / st.session_state["unfiltered_counts"][1]),
-            text=f"{filtered_row_count} rows are left out of {st.session_state['unfiltered_counts'][1]}",
-        )
-        model_count_bar = st.progress(
-            (filtered_modelid_count / st.session_state["unfiltered_counts"][0]),
-            text=f"{filtered_modelid_count} models are left out of {st.session_state['unfiltered_counts'][0]}",
-        )
-
-else:
-    st.warning("Please load data on the Home page.")
+if st.session_state["filters"] != []:
+    filtered_modelid_count, filtered_row_count = model_and_row_counts(
+        _apply_query(st.session_state["dm"].model_data, st.session_state["filters"]),
+    )
+    serialized_exprs = {}
+    for i, expr in enumerate(st.session_state["filters"]):
+        serialized = expr.meta.serialize(format="json")
+        serialized_exprs[i] = json.loads(serialized)
+    data = json.dumps(serialized_exprs)
+    st.download_button(
+        label="Download Filters",
+        data=data,
+        file_name="datamart_filters.json",
+    )
+    row_count_bar = st.progress(
+        (filtered_row_count / st.session_state["unfiltered_counts"][1]),
+        text=f"{filtered_row_count} rows are left out of {st.session_state['unfiltered_counts'][1]}",
+    )
+    model_count_bar = st.progress(
+        (filtered_modelid_count / st.session_state["unfiltered_counts"][0]),
+        text=f"{filtered_modelid_count} models are left out of {st.session_state['unfiltered_counts'][0]}",
+    )

--- a/python/pdstools/app/health_check/pages/2_Reports.py
+++ b/python/pdstools/app/health_check/pages/2_Reports.py
@@ -7,6 +7,7 @@ import polars as pl
 import streamlit as st
 
 from pdstools import ADMDatamart
+from pdstools.app.health_check.hc_streamlit_utils import ensure_dm
 from pdstools.utils.cdh_utils import _apply_query
 from pdstools.utils.show_versions import show_versions
 from pdstools.utils.streamlit_utils import (
@@ -17,9 +18,7 @@ from pdstools.utils.streamlit_utils import (
 
 standard_page_config(page_title="Reports · ADM Health Check")
 
-if "dm" not in st.session_state:
-    st.warning("Please configure your files in the `data import` tab.")
-    st.stop()
+ensure_dm()
 logger = logging.getLogger(__name__)
 _cli_full_embed = get_full_embed()
 health_check, model_report = st.tabs(

--- a/python/pdstools/app/impact_analyzer/_home_page.py
+++ b/python/pdstools/app/impact_analyzer/_home_page.py
@@ -115,10 +115,9 @@ def _show_data_summary(ia, is_sample_data: bool = False):
 def home_page() -> None:
     """Render the Impact Analyzer home page."""
     from pdstools.app.impact_analyzer.ia_streamlit_utils import (
-        handle_data_path_ia,
+        ensure_ia_data_loaded,
         load_from_upload_auto,
         load_pdc_from_uploads,
-        load_sample_pdc,
         prepare_and_save_random,
         show_outcome_labels_section,
     )
@@ -210,37 +209,31 @@ zoom, and hover for details.
             else:
                 st.error("Upload a single file (JSON/NDJSON/ZIP) or multiple JSON/NDJSON files.")
 
-    # 2. Handle --data-path CLI flag
+    # 2. Handle --data-path CLI flag + sample fallback via shared helper.
+    # The helper drives the same priority chain used by data-required
+    # sub-pages on deep-link, so home and sub-pages stay in sync.
     has_existing_data = "impact_analyzer" in st.session_state
     configured_path = get_data_path()
 
-    if impact_analyzer is None and configured_path and not has_existing_data:
-        with st.spinner(f"Loading data from configured path: {configured_path}"):
-            impact_analyzer = _load_with_warning(
-                lambda: handle_data_path_ia(),
-                "CLI",
-            )
-            data_source_path = configured_path
-        if impact_analyzer is not None:
-            st.info(f"Loaded data from configured path: `{configured_path}`")
-
-    # 3. Fall back to sample data
     if impact_analyzer is None and not has_existing_data and not uploaded_files:
-        with st.spinner("Loading sample data"):
-            impact_analyzer = _load_with_warning(load_sample_pdc, "Sample")
-        if impact_analyzer is not None:
-            # Match the Decision Analyzer / Health Check first-run UX:
-            # write data to session state, surface a non-modal toast,
-            # and ``st.rerun()`` so any data-gated UI (and a clean
-            # render of the data summary) appears in the same user
-            # action instead of waiting for the next interaction.
-            st.session_state["impact_analyzer"] = impact_analyzer
-            st.session_state["ia_is_sample_data"] = True
-            st.toast(
-                "Loaded sample data — upload your own to replace it.",
-                icon="📊",
-            )
-            st.rerun()
+        if ensure_ia_data_loaded():
+            if st.session_state.get("ia_is_sample_data"):
+                # First-run sample path: surface the toast and rerun so the
+                # rest of the home page (data summary, outcome-label section)
+                # renders against populated state in the same user action.
+                st.toast(
+                    "Loaded sample data — upload your own to replace it.",
+                    icon="📊",
+                )
+                st.rerun()
+            else:
+                # CLI path: keep the local ``impact_analyzer`` populated so
+                # the pre-ingestion sampling block (which only runs for CLI
+                # paths) and downstream summary fall through naturally.
+                impact_analyzer = st.session_state["impact_analyzer"]
+                data_source_path = configured_path
+                if configured_path:
+                    st.info(f"Loaded data from configured path: `{configured_path}`")
 
     # Pre-ingestion sampling (only for CLI paths)
     sample_limit_raw = get_sample_limit() if data_source_path else None

--- a/python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
+++ b/python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
@@ -1,4 +1,7 @@
+"""Health Check-specific Streamlit helpers."""
+
 # python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
+import logging
 import tempfile
 import urllib.request
 from collections.abc import Iterable
@@ -9,20 +12,88 @@ import streamlit as st
 from pdstools import ImpactAnalyzer
 from pdstools.utils.streamlit_utils import (
     _apply_sidebar_logo,
-    ensure_session_data,
     get_data_path,
 )
+
+logger = logging.getLogger(__name__)
 
 SAMPLE_PDC_URL = "https://raw.githubusercontent.com/pegasystems/pega-datascientist-tools/master/data/ia/CDH_Metrics_ImpactAnalyzer.json"
 
 
-def ensure_impact_analyzer() -> ImpactAnalyzer:
-    """Guard: stop if Impact Analyzer data is not loaded.
+def ensure_ia_data_loaded(*, show_toast: bool = False) -> bool:
+    """Ensure ``st.session_state["impact_analyzer"]`` is populated.
 
-    Re-applies sidebar branding on sub-pages.
+    Mirrors :func:`pdstools.app.health_check.hc_streamlit_utils.ensure_dm_loaded`
+    so deep-linked sub-pages auto-load the bundled PDC sample (or a CLI path)
+    instead of dead-ending on a "please upload" warning.
+
+    Priority chain:
+
+    1. If ``impact_analyzer`` is already in session_state, return ``True``.
+    2. Try the ``--data-path`` CLI flag via :func:`handle_data_path_ia`.
+    3. Fall back to :func:`load_sample_pdc`.
+
+    Parameters
+    ----------
+    show_toast : bool, default False
+        When True and a load actually happened, surface a non-modal toast.
+        The home page handles its own toasts to drive ``st.rerun()`` so it
+        passes False; sub-pages set it True.
+
+    Returns
+    -------
+    bool
+        ``True`` when ``impact_analyzer`` is in session_state on return,
+        ``False`` when every load attempt failed.
+    """
+    if "impact_analyzer" in st.session_state:
+        return True
+
+    configured_path = get_data_path()
+    if configured_path:
+        try:
+            with st.spinner(f"Loading data from `{configured_path}`…"):
+                ia = handle_data_path_ia()
+        except Exception:
+            logger.exception("Failed to auto-load Impact Analyzer data from %s", configured_path)
+            ia = None
+        if ia is not None:
+            st.session_state["impact_analyzer"] = ia
+            st.session_state["ia_is_sample_data"] = False
+            st.session_state["ia_data_source_path"] = configured_path
+            if show_toast:
+                st.toast(f"Loaded data from `{configured_path}`.", icon="📂")
+            return True
+
+    try:
+        with st.spinner("Loading sample data…"):
+            ia = load_sample_pdc()
+    except Exception:
+        logger.exception("Failed to auto-load Impact Analyzer sample")
+        return False
+
+    if ia is None:
+        return False
+
+    st.session_state["impact_analyzer"] = ia
+    st.session_state["ia_is_sample_data"] = True
+    if show_toast:
+        st.toast("Loaded sample data — upload your own to replace it.", icon="📊")
+    return True
+
+
+def ensure_impact_analyzer() -> ImpactAnalyzer:
+    """Guard: auto-load Impact Analyzer data or warn-and-stop.
+
+    Re-applies sidebar branding on sub-pages, then tries
+    :func:`ensure_ia_data_loaded` so deep-link / launcher flows work without
+    visiting Home first. Falls back to the original "please upload" warning
+    when every load attempt fails (e.g. sample bundle missing offline).
     """
     _apply_sidebar_logo()
-    ensure_session_data("impact_analyzer", "Please upload your data in the Home page.")
+    if not ensure_ia_data_loaded(show_toast=True):
+        st.warning("Please upload your data in the Home page.")
+        st.stop()
     return st.session_state["impact_analyzer"]
 
 

--- a/python/tests/streamlit_apps/health_check/test_hc_pages.py
+++ b/python/tests/streamlit_apps/health_check/test_hc_pages.py
@@ -70,3 +70,68 @@ def test_hc_page_renders(
     for attr, minimum in widget_checks.items():
         actual = len(getattr(at, attr))
         assert actual >= minimum, f"{page} expected at least {minimum} {attr} widget(s), got {actual}"
+
+
+# Sub-pages that auto-load on deep-link — exclude the About page since
+# it's not data-gated.
+HC_DATA_REQUIRED_PAGES = [
+    ("1_Data_Filters.py", "# Add custom filters"),
+    ("2_Reports.py", "Generate Health Check"),
+]
+
+
+@pytest.mark.parametrize(
+    ("page", "heading"),
+    HC_DATA_REQUIRED_PAGES,
+    ids=[p[0].removesuffix(".py") for p in HC_DATA_REQUIRED_PAGES],
+)
+def test_hc_subpage_autoloads_sample_on_deep_link(page: str, heading: str, hc_app_dir: Path):
+    """Visiting a data-required sub-page directly auto-loads the bundled
+    CDH sample instead of dead-ending on a "please configure" warning.
+
+    Mirrors the launcher / deep-link flow: the user clicks a sub-page
+    without visiting Home first. The page should render and ``dm``
+    should be populated.
+    """
+    at = AppTest.from_file(str(hc_app_dir / "pages" / page), default_timeout=60)
+    at.run()
+    assert not at.exception, f"{page} raised: {at.exception}"
+
+    warnings = [w.value for w in at.warning]
+    assert not any("please configure" in w.lower() or "please load" in w.lower() for w in warnings), (
+        f"{page} showed a please-upload warning instead of auto-loading: {warnings}"
+    )
+    assert "dm" in at.session_state, f"{page} did not populate session_state['dm']"
+
+    rendered_text = [m.value for m in at.markdown] + [t.value for t in at.title]
+    assert any(heading in s for s in rendered_text), f"{page} missing heading {heading!r} — body did not render"
+
+
+def test_hc_subpage_warns_when_autoload_fails(hc_app_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    """When the sample loader raises, the sub-page falls back to the
+    original "please configure" warning instead of crashing.
+
+    Patches both the CLI-path helper (returns None — no path configured)
+    and ``cached_sample`` (raises) so the helper exhausts its priority
+    chain and returns False.
+    """
+    import streamlit as st
+
+    st.cache_resource.clear()
+
+    def _broken_sample():
+        raise RuntimeError("sample bundle unavailable")
+
+    monkeypatch.setattr(
+        "pdstools.app.health_check.hc_streamlit_utils.cached_sample",
+        _broken_sample,
+    )
+
+    at = AppTest.from_file(str(hc_app_dir / "pages" / "2_Reports.py"), default_timeout=30)
+    at.run()
+    assert not at.exception, f"page raised: {at.exception}"
+    warnings = [w.value for w in at.warning]
+    assert any("please configure" in w.lower() for w in warnings), (
+        f"expected please-configure warning when auto-load fails, got: {warnings}"
+    )
+    assert "dm" not in at.session_state

--- a/python/tests/streamlit_apps/impact_analyzer/test_ia_pages.py
+++ b/python/tests/streamlit_apps/impact_analyzer/test_ia_pages.py
@@ -155,3 +155,58 @@ def test_ia_page_renders(
     for attr, minimum in widget_checks.items():
         actual = len(getattr(at, attr))
         assert actual >= minimum, f"{page} expected at least {minimum} {attr} widget(s), got {actual}"
+
+
+IA_DATA_REQUIRED_PAGES = [
+    ("1_Overall_Summary.py", "# Overall Summary"),
+    ("2_Trend.py", "# Trend Analysis"),
+]
+
+
+@pytest.mark.parametrize(
+    ("page", "heading"),
+    IA_DATA_REQUIRED_PAGES,
+    ids=[p[0].removesuffix(".py") for p in IA_DATA_REQUIRED_PAGES],
+)
+def test_ia_subpage_autoloads_sample_on_deep_link(page: str, heading: str, ia_app_dir: Path):
+    """Visiting a data-required sub-page directly auto-loads the bundled
+    PDC sample instead of dead-ending on a "please upload" warning.
+    """
+    at = AppTest.from_file(str(ia_app_dir / "pages" / page), default_timeout=60)
+    at.run()
+    assert not at.exception, f"{page} raised: {at.exception}"
+
+    warnings = [w.value for w in at.warning]
+    assert not any("please upload" in w.lower() or "please load" in w.lower() for w in warnings), (
+        f"{page} showed a please-upload warning instead of auto-loading: {warnings}"
+    )
+    assert "impact_analyzer" in at.session_state, f"{page} did not populate session_state['impact_analyzer']"
+
+    rendered_text = [m.value for m in at.markdown] + [t.value for t in at.title]
+    assert any(heading in s for s in rendered_text), f"{page} missing heading {heading!r} — body did not render"
+
+
+def test_ia_subpage_warns_when_autoload_fails(ia_app_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    """When the sample loader raises, the sub-page falls back to the
+    original "please upload" warning instead of crashing.
+    """
+    import streamlit as st
+
+    st.cache_resource.clear()
+
+    def _broken_sample():
+        raise RuntimeError("sample bundle unavailable")
+
+    monkeypatch.setattr(
+        "pdstools.app.impact_analyzer.ia_streamlit_utils.load_sample_pdc",
+        _broken_sample,
+    )
+
+    at = AppTest.from_file(str(ia_app_dir / "pages" / "1_Overall_Summary.py"), default_timeout=30)
+    at.run()
+    assert not at.exception, f"page raised: {at.exception}"
+    warnings = [w.value for w in at.warning]
+    assert any("please upload" in w.lower() for w in warnings), (
+        f"expected please-upload warning when auto-load fails, got: {warnings}"
+    )
+    assert "impact_analyzer" not in at.session_state


### PR DESCRIPTION
Several Streamlit pages that require a loaded dataset previously showed a 'please configure' / 'please upload' warning instead of auto-loading the bundled CDH sample, even though the corresponding home page already did so. This broke deep-linking and the launcher flow (where users may click an app's sub-page without first visiting that app's home).

Adds two reusable helpers:

- pdstools.app.health_check.hc_streamlit_utils.ensure_dm_loaded / ensure_dm — try the --data-path CLI flag, then the bundled CDH sample; only show 'please configure' if every load attempt fails.
- pdstools.app.impact_analyzer.ia_streamlit_utils.ensure_ia_data_loaded — same priority chain for the IA app; ensure_impact_analyzer now delegates to it.

Each app's home page is refactored to call its new helper, so the home-page first-run UX and the sub-page deep-link UX share the same load logic and diverge only on toast wording / st.rerun().

Sub-pages affected:
- health_check/pages/1_Data_Filters.py
- health_check/pages/2_Reports.py
- impact_analyzer/pages/1_Overall_Summary.py (via ensure_impact_analyzer)
- impact_analyzer/pages/2_Trend.py (via ensure_impact_analyzer)

Tests: AppTest coverage for both apps verifies that (a) hitting a sub-page with no session_state auto-loads the sample and renders the page body, and (b) when the sample loader is patched to raise, the original 'please upload' warning still appears as a fallback.