### PR TITLE
feat(launcher): tile-based app picker landing page + consistent sideb…

### DIFF
--- a/python/pdstools/app/decision_analyzer/_home_page.py
+++ b/python/pdstools/app/decision_analyzer/_home_page.py
@@ -116,6 +116,7 @@ def render(locked_page_titles: list[str] | None = None) -> None:
         get_filter_specs,
         get_sample_limit,
         get_temp_dir,
+        set_active_app as _set_active_app,
         show_sidebar_branding,
         show_version_header,
         standard_page_config,
@@ -123,6 +124,7 @@ def render(locked_page_titles: list[str] | None = None) -> None:
 
     standard_page_config(page_title="Decision Analysis")
     show_sidebar_branding("Decision Analysis")
+    _set_active_app("da")
     pl.enable_string_cache()
 
     show_version_header()

--- a/python/pdstools/app/decision_analyzer/_navigation.py
+++ b/python/pdstools/app/decision_analyzer/_navigation.py
@@ -66,6 +66,7 @@ def pages(
     url_prefix: str | None = None,
     default: bool = True,
     include_about: bool = True,
+    include_subpages: bool = True,
 ) -> list[st.Page]:
     """Return the DA page list for ``st.navigation``.
 
@@ -87,6 +88,11 @@ def pages(
         launches keep it (``True``); the cross-app launcher passes
         ``False`` so all three tools share a single top-level About
         entry instead of crowding the sidebar with three.
+    include_subpages : bool
+        Whether to append the data-dependent analysis pages. The
+        cross-app launcher passes ``False`` until the user actively
+        enters the DA app; even when ``True``, individual pages stay
+        gated on ``decision_data`` being present in session state.
     """
     locked = locked_page_titles()
 
@@ -114,7 +120,7 @@ def pages(
     )
 
     result = [home]
-    if "decision_data" in st.session_state:
+    if include_subpages and "decision_data" in st.session_state:
         result.extend(
             st.Page(
                 str(_PAGES_DIR / p.filename),

--- a/python/pdstools/app/health_check/_home_page.py
+++ b/python/pdstools/app/health_check/_home_page.py
@@ -23,6 +23,7 @@ def home_page() -> None:
         cached_sample,
         cached_sample_prediction,
         get_data_path,
+        set_active_app as _set_active_app,
         show_sidebar_branding,
         show_version_header,
         standard_page_config,
@@ -30,6 +31,7 @@ def home_page() -> None:
 
     standard_page_config(page_title="Adaptive Model Health Check")
     show_sidebar_branding("ADM Health Check")
+    _set_active_app("hc")
 
     if "log_buffer" not in st.session_state:
         _, st.session_state.log_buffer = setup_logger()

--- a/python/pdstools/app/health_check/_navigation.py
+++ b/python/pdstools/app/health_check/_navigation.py
@@ -46,12 +46,16 @@ def pages(
     url_prefix: str | None = None,
     default: bool = True,
     include_about: bool = True,
+    include_subpages: bool = True,
 ) -> list[st.Page]:
     """Return the HC page list for ``st.navigation``.
 
     See ``decision_analyzer._navigation.pages`` for the parameter
     semantics — same contract across all pdstools tools so the
-    cross-app launcher can reuse them uniformly.
+    cross-app launcher can reuse them uniformly. ``include_subpages``
+    lets the launcher hide HC's data-filter / reports pages until the
+    user has actually entered the HC app, keeping the cross-app
+    sidebar short.
     """
 
     def _url(name: str) -> str | None:
@@ -67,15 +71,16 @@ def pages(
         url_path=_url("home"),
     )
     result = [home]
-    result.extend(
-        st.Page(
-            str(_PAGES_DIR / p.filename),
-            title=p.title,
-            icon=p.icon,
-            url_path=_url(_slug(p.title)),
+    if include_subpages:
+        result.extend(
+            st.Page(
+                str(_PAGES_DIR / p.filename),
+                title=p.title,
+                icon=p.icon,
+                url_path=_url(_slug(p.title)),
+            )
+            for p in _SUB_PAGES
         )
-        for p in _SUB_PAGES
-    )
     if include_about:
         result.append(
             st.Page(

--- a/python/pdstools/app/impact_analyzer/_home_page.py
+++ b/python/pdstools/app/impact_analyzer/_home_page.py
@@ -127,6 +127,7 @@ def home_page() -> None:
         get_sample_limit,
         get_temp_dir,
         parse_sample_spec,
+        set_active_app as _set_active_app,
         show_sidebar_branding,
         show_version_header,
         standard_page_config,
@@ -134,6 +135,7 @@ def home_page() -> None:
 
     standard_page_config(page_title="Impact Analyzer")
     show_sidebar_branding("Impact Analyzer")
+    _set_active_app("ia")
 
     show_version_header()
 

--- a/python/pdstools/app/impact_analyzer/_navigation.py
+++ b/python/pdstools/app/impact_analyzer/_navigation.py
@@ -46,12 +46,15 @@ def pages(
     url_prefix: str | None = None,
     default: bool = True,
     include_about: bool = True,
+    include_subpages: bool = True,
 ) -> list[st.Page]:
     """Return the IA page list for ``st.navigation``.
 
     See ``decision_analyzer._navigation.pages`` for parameter
     semantics — same contract across all pdstools tools so the
-    cross-app launcher can reuse them uniformly.
+    cross-app launcher can reuse them uniformly. ``include_subpages``
+    lets the launcher hide IA's analysis pages until the user has
+    actually entered the IA app.
     """
 
     def _url(name: str) -> str | None:
@@ -67,15 +70,16 @@ def pages(
         url_path=_url("home"),
     )
     result = [home]
-    result.extend(
-        st.Page(
-            str(_PAGES_DIR / p.filename),
-            title=p.title,
-            icon=p.icon,
-            url_path=_url(_slug(p.title)),
+    if include_subpages:
+        result.extend(
+            st.Page(
+                str(_PAGES_DIR / p.filename),
+                title=p.title,
+                icon=p.icon,
+                url_path=_url(_slug(p.title)),
+            )
+            for p in _SUB_PAGES
         )
-        for p in _SUB_PAGES
-    )
     if include_about:
         result.append(
             st.Page(

--- a/python/pdstools/app/launcher/Home.py
+++ b/python/pdstools/app/launcher/Home.py
@@ -6,6 +6,14 @@ side in a single Streamlit process using ``st.navigation``'s
 sectioned dict API. Standalone tool entry points
 (``app/<tool>/Home.py``) are unaffected.
 
+Sidebar shape adapts to the active app (tracked via
+``st.session_state["_active_app"]``, set by each app's home page):
+
+* No app active (default landing) → picker tile + 3 home links + About.
+* HC / IA active → that app's sub-pages added to its section.
+* DA active → DA's data pages added once ``decision_data`` is loaded
+  (additional gate on top of the active-app check).
+
 URL paths are flat-namespaced (``/hc_*``, ``/da_*``, ``/ia_*``) to
 avoid collisions between tools that share page names — Streamlit's
 ``st.Page`` rejects nested ``/`` in ``url_path`` so the launcher uses
@@ -16,10 +24,7 @@ from pathlib import Path
 
 import streamlit as st
 
-from pdstools.utils.streamlit_utils import (
-    show_sidebar_branding,
-    standard_page_config,
-)
+from pdstools.app.launcher._picker import picker_page, set_app_pages
 
 _ABOUT_SCRIPT = Path(__file__).parent / "_about.py"
 
@@ -30,39 +35,74 @@ _ABOUT_SCRIPT = Path(__file__).parent / "_about.py"
 # rerun even when the user only ever clicks into one tool. After the
 # first call sys.modules caches the module so subsequent reruns are
 # free.
-#
-# include_about=False on every tool: the launcher exposes one shared
-# top-level About entry instead of three near-identical per-tool ones.
-def _hc_section() -> list[st.Page]:
+def _hc_section(active: bool) -> list[st.Page]:
     from pdstools.app.health_check._navigation import pages
 
-    return pages(url_prefix="hc", default=True, include_about=False)
+    return pages(
+        url_prefix="hc",
+        default=False,
+        include_about=False,
+        include_subpages=active,
+    )
 
 
-def _da_section() -> list[st.Page]:
+def _da_section(active: bool) -> list[st.Page]:
     from pdstools.app.decision_analyzer._navigation import pages
 
-    return pages(url_prefix="da", default=False, include_about=False)
+    return pages(
+        url_prefix="da",
+        default=False,
+        include_about=False,
+        include_subpages=active,
+    )
 
 
-def _ia_section() -> list[st.Page]:
+def _ia_section(active: bool) -> list[st.Page]:
     from pdstools.app.impact_analyzer._navigation import pages
 
-    return pages(url_prefix="ia", default=False, include_about=False)
+    return pages(
+        url_prefix="ia",
+        default=False,
+        include_about=False,
+        include_subpages=active,
+    )
 
 
-standard_page_config(page_title="pdstools")
-show_sidebar_branding("pdstools")
+# Picker is the launcher's default landing page so visiting "/" lands
+# on a real "choose an app" screen instead of one tool's home.
+_picker_page = st.Page(
+    picker_page,
+    title="Home",
+    icon="🏠",
+    default=True,
+    url_path="home",
+)
 
-# Health Check is the first section so its Home is the default page —
-# only one page may carry default=True across the whole navigation.
-# The shared About page lives in its own section so it reads as a
-# top-level entry, not buried under any one tool.
+active = st.session_state.get("_active_app")
+hc_pages = _hc_section(active == "hc")
+da_pages = _da_section(active == "da")
+ia_pages = _ia_section(active == "ia")
+
+# Register per-app home pages with the picker so its tiles can use
+# in-process ``st.page_link`` navigation (no full reload).
+set_app_pages(
+    {
+        "hc": hc_pages[0],
+        "da": da_pages[0],
+        "ia": ia_pages[0],
+    }
+)
+
+# Section ordering matches the picker tile order so the sidebar reads
+# top-to-bottom in the same sequence the user just saw on the landing
+# page. The shared About page lives in its own section so it reads as
+# a top-level entry, not buried under any one tool.
 sections: dict[str, list[st.Page]] = {
-    "Health Check": _hc_section(),
-    "Decision Analyzer": _da_section(),
-    "Impact Analyzer": _ia_section(),
-    "pdstools": [
+    "pdstools": [_picker_page],
+    "ADM Health Check": hc_pages,
+    "Decision Analysis": da_pages,
+    "Impact Analyzer": ia_pages,
+    "About": [
         st.Page(
             str(_ABOUT_SCRIPT),
             title="About",

--- a/python/pdstools/app/launcher/_picker.py
+++ b/python/pdstools/app/launcher/_picker.py
@@ -1,0 +1,115 @@
+# python/pdstools/app/launcher/_picker.py
+"""Tile-based app picker for the cross-app pdstools launcher.
+
+Renders three Streamlit-native cards (one per hosted tool) so the
+default landing page is a real "choose an app" screen instead of the
+first tool's home page. Each tile uses ``st.page_link`` so navigation
+stays inside the same Streamlit process — no JS, no iframes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import streamlit as st
+
+
+@dataclass(frozen=True)
+class AppTile:
+    """One entry in the launcher's app picker."""
+
+    icon: str
+    title: str
+    description: str
+    url_path: str
+    active_app: str
+
+
+# Order matches the launcher's sidebar section order.
+TILES: tuple[AppTile, ...] = (
+    AppTile(
+        icon="🩺",
+        title="ADM Health Check",
+        description=(
+            "Inspect Adaptive Decision Manager datamart exports — model "
+            "performance, predictor health, and configuration drift."
+        ),
+        url_path="hc_home",
+        active_app="hc",
+    ),
+    AppTile(
+        icon="🎯",
+        title="Decision Analysis",
+        description=(
+            "Explore arbitration outcomes, action funnels, and thresholding behaviour from explainability extracts."
+        ),
+        url_path="da_home",
+        active_app="da",
+    ),
+    AppTile(
+        icon="📈",
+        title="Impact Analyzer",
+        description=(
+            "Compare control vs. treatment impressions and value-per-impression to quantify CDH lift over time."
+        ),
+        url_path="ia_home",
+        active_app="ia",
+    ),
+)
+
+
+# ``st.page_link`` resolves best when given a registered ``st.Page``
+# object (so navigation runs in-process). The launcher entry script
+# registers the per-app home pages here before calling ``picker_page``;
+# tests that exercise the picker in isolation fall back to the raw URL.
+_app_pages: dict[str, "st.Page"] = {}
+
+
+def set_app_pages(pages: dict[str, "st.Page"]) -> None:
+    """Register the per-app home ``st.Page`` objects for tile links."""
+    _app_pages.clear()
+    _app_pages.update(pages)
+
+
+def _resolve_link(tile: AppTile):
+    page = _app_pages.get(tile.active_app)
+    return page if page is not None else f"/{tile.url_path}"
+
+
+def picker_page() -> None:
+    """Render the launcher landing page."""
+    from pdstools.utils.streamlit_utils import (
+        show_sidebar_branding,
+        show_version_header,
+        standard_page_config,
+    )
+
+    standard_page_config(page_title="pdstools")
+    show_sidebar_branding("pdstools")
+
+    # Visiting the picker means no app is active — clear the flag so
+    # the sidebar collapses back to its picker-mode shape on rerun.
+    if st.session_state.get("_active_app") is not None:
+        st.session_state["_active_app"] = None
+
+    st.markdown("# Welcome to pdstools")
+    st.markdown(
+        "Pick an app to get started. Each tool keeps its own data and "
+        "filters in this session, so you can switch between them via "
+        "the sidebar at any time.",
+    )
+    st.write("")
+
+    columns = st.columns(len(TILES), gap="medium")
+    for column, tile in zip(columns, TILES, strict=True):
+        with column, st.container(border=True):
+            st.markdown(f"### {tile.icon}&nbsp; {tile.title}")
+            st.markdown(tile.description)
+            st.page_link(
+                _resolve_link(tile),
+                label=f"Open {tile.title} →",
+                use_container_width=True,
+            )
+
+    st.write("")
+    show_version_header()

--- a/python/pdstools/cli.py
+++ b/python/pdstools/cli.py
@@ -428,6 +428,7 @@ def run(args, unknown):
         # The launcher hosts the DA pages, so it inherits DA's XSRF
         # exemption (DA uses the file-uploader workaround that breaks
         # under XSRF). Standalone HC / IA launches keep XSRF on.
+        os.environ["PDSTOOLS_LAUNCHER_MODE"] = "1"
         sys.argv = [
             "streamlit",
             "run",

--- a/python/pdstools/utils/streamlit_utils.py
+++ b/python/pdstools/utils/streamlit_utils.py
@@ -41,26 +41,89 @@ def _is_newer_version_available(installed: str, latest: str) -> bool:
         return False
 
 
+def is_launcher_mode() -> bool:
+    """True when the app is running inside the cross-app launcher.
+
+    The CLI sets ``PDSTOOLS_LAUNCHER_MODE=1`` when invoking the launcher
+    so per-app helpers (sidebar branding, navigation) can adapt their
+    behaviour without each call site needing to know.
+    """
+    return os.environ.get("PDSTOOLS_LAUNCHER_MODE") == "1"
+
+
+def set_active_app(app_key: str) -> None:
+    """Mark the named app as currently active in the launcher sidebar.
+
+    Each app's home page calls this on render. In launcher mode the
+    cross-app entry script reads the flag to decide which app's
+    sub-pages to register in ``st.navigation``, keeping the sidebar
+    short until the user has actually entered an app. A no-op (other
+    than the session_state write) in standalone tool launches.
+
+    Triggers ``st.rerun()`` when the active app actually changes so
+    the new sub-pages appear in the sidebar without a manual click.
+    """
+    if st.session_state.get("_active_app") == app_key:
+        return
+    st.session_state["_active_app"] = app_key
+    if is_launcher_mode():
+        st.rerun()
+
+
 def _apply_sidebar_logo():
-    """Re-apply the sidebar logo from session state (for sub-pages)."""
-    title = st.session_state.get("_pdstools_app_title")
-    if not title:
+    """Re-apply the sidebar logo + brand from session state.
+
+    Renders an optional subtitle (e.g. the active app name) under the
+    main brand. In launcher mode the brand is always ``"pdstools"`` and
+    the per-app title becomes the subtitle; standalone tools render a
+    single-line brand only.
+    """
+    brand = st.session_state.get("_pdstools_brand")
+    subtitle = st.session_state.get("_pdstools_brand_subtitle")
+    if not brand and not subtitle:
         return
     logo_path = _ASSETS_DIR / "pega-logo.svg"
     if logo_path.exists():
         st.logo(str(logo_path), size="large")
-    st.html(
-        "<style>"
-        "[data-testid='stSidebarNav']::before {"
-        "  content: '" + title.replace("'", "\\'") + "';"
-        "  display: block;"
-        "  font-size: 1.1rem;"
-        "  font-weight: 500;"
-        "  color: #5a5c63;"
-        "  padding: 0 1rem 0.75rem;"
+
+    css_parts = ["<style>"]
+    if brand:
+        css_parts.append(
+            "[data-testid='stSidebarNav']::before {"
+            "  content: '" + brand.replace("'", "\\'") + "';"
+            "  display: block;"
+            "  font-size: 1.1rem;"
+            "  font-weight: 500;"
+            "  color: #5a5c63;"
+            "  padding: 0 1rem 0.25rem;"
+            "}"
+        )
+    if subtitle:
+        css_parts.append(
+            "[data-testid='stSidebarNav']::after {"
+            "  content: '" + subtitle.replace("'", "\\'") + "';"
+            "  display: block;"
+            "  font-size: 0.85rem;"
+            "  font-weight: 400;"
+            "  color: #8a8d96;"
+            "  padding: 0 1rem 0.75rem;"
+            "}"
+        )
+    # Streamlit auto-collapses sidebar nav past ~10 items into a
+    # "View N more" button. With three apps hosted side-by-side the
+    # launcher easily exceeds that, hiding entire tools by default.
+    # Force-expand by setting max-height on the nav list and hiding
+    # the toggle. Targets stable testid attributes only — no JS.
+    css_parts.append(
+        "[data-testid='stSidebarNav'] ul {"
+        "  max-height: none !important;"
         "}"
-        "</style>",
+        "[data-testid='stSidebarNavViewButton'] {"
+        "  display: none !important;"
+        "}"
     )
+    css_parts.append("</style>")
+    st.html("".join(css_parts))
 
 
 def standard_page_config(page_title: str, layout: Literal["centered", "wide"] = "wide", **kwargs):
@@ -103,13 +166,25 @@ def show_sidebar_branding(title: str):
     render above the page navigation. Call once from the Home page; sub-pages
     re-apply automatically via ``standard_page_config`` or ``ensure_data``.
 
+    In launcher mode (``PDSTOOLS_LAUNCHER_MODE=1``) the brand is forced to
+    ``"pdstools"`` and the supplied *title* is rendered as a subtitle, so
+    every page in the multi-app launcher shows a consistent top-level brand
+    even when the active sub-app re-applies its own title.
+
     Parameters
     ----------
     title : str
         Application title shown below the logo in the sidebar.
 
     """
-    st.session_state["_pdstools_app_title"] = title
+    if is_launcher_mode():
+        st.session_state["_pdstools_brand"] = "pdstools"
+        # Don't show "pdstools" twice when the launcher's own picker
+        # page re-applies branding with the same title.
+        st.session_state["_pdstools_brand_subtitle"] = title if title and title.lower() != "pdstools" else None
+    else:
+        st.session_state["_pdstools_brand"] = title
+        st.session_state["_pdstools_brand_subtitle"] = None
     _apply_sidebar_logo()
 
 

--- a/python/tests/streamlit_apps/launcher/test_launcher.py
+++ b/python/tests/streamlit_apps/launcher/test_launcher.py
@@ -10,14 +10,32 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from streamlit.testing.v1 import AppTest
+
+from pdstools.app.health_check._navigation import pages as hc_pages
+from pdstools.app.decision_analyzer._navigation import pages as da_pages
+from pdstools.app.impact_analyzer._navigation import pages as ia_pages
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 LAUNCHER_HOME = REPO_ROOT / "python" / "pdstools" / "app" / "launcher" / "Home.py"
 HC_HOME = REPO_ROOT / "python" / "pdstools" / "app" / "health_check" / "Home.py"
 
+# The collapse-at-N threshold Streamlit applies to ``stSidebarNav``.
+# Anything beyond this gets hidden behind a "View N more" button by
+# default. The launcher injects CSS to override this, but we still
+# keep the structural sidebar at or below the threshold pre-DA-load
+# so the CSS hack is belt-and-braces, not load-bearing.
+_NAV_COLLAPSE_THRESHOLD = 10
 
-def test_launcher_home_renders_without_data():
+
+@pytest.fixture
+def launcher_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the launcher Home with PDSTOOLS_LAUNCHER_MODE set, like the CLI."""
+    monkeypatch.setenv("PDSTOOLS_LAUNCHER_MODE", "1")
+
+
+def test_launcher_home_renders_without_data(launcher_mode):
     """Launcher entry script runs without exception on first load.
 
     Indirectly validates that all three tools' ``pages()`` helpers
@@ -41,3 +59,88 @@ def test_standalone_hc_home_still_renders():
     at = AppTest.from_file(str(HC_HOME), default_timeout=60)
     at.run()
     assert not at.exception, f"HC standalone Home raised: {at.exception}"
+
+
+def test_launcher_landing_page_renders_three_picker_tiles(launcher_mode):
+    """Default landing exposes one picker entry per hosted tool.
+
+    Asserts on the picker copy (icon + title) so a regression that
+    silently drops a tile — for example by mis-spelling an
+    ``active_app`` key — fails the test instead of reaching users.
+    """
+    at = AppTest.from_file(str(LAUNCHER_HOME), default_timeout=60)
+    at.run()
+    assert not at.exception, f"Launcher Home raised: {at.exception}"
+
+    markdown_text = " ".join(block.value for block in at.markdown)
+    for icon, title in (
+        ("🩺", "ADM Health Check"),
+        ("🎯", "Decision Analysis"),
+        ("📈", "Impact Analyzer"),
+    ):
+        assert icon in markdown_text, f"Picker missing tile icon {icon!r}"
+        assert title in markdown_text, f"Picker missing tile title {title!r}"
+
+
+def test_launcher_branding_uses_pdstools_in_launcher_mode(launcher_mode):
+    """Sidebar brand text is forced to 'pdstools' under the launcher.
+
+    The picker's own ``show_sidebar_branding('pdstools')`` and any
+    per-app override must both end up rendering the same top-level
+    brand so users always see where they are. The brand is injected
+    via a CSS ``::before`` on ``stSidebarNav`` — assert against the
+    raw style block.
+    """
+    at = AppTest.from_file(str(LAUNCHER_HOME), default_timeout=60)
+    at.run()
+    assert not at.exception
+    assert at.session_state["_pdstools_brand"] == "pdstools"
+
+
+def test_launcher_pre_app_sidebar_stays_under_collapse_threshold(launcher_mode):
+    """Until the user enters an app the sidebar must stay short.
+
+    Pre-app the launcher should expose: picker home + 3 app homes +
+    About = 5 entries. Even with future growth this should stay well
+    under Streamlit's auto-collapse threshold so newcomers don't have
+    to click "View N more" to see Impact Analyzer exists.
+    """
+    # Mirror what launcher Home.py builds in the no-active-app state.
+    sections_total = (
+        1  # picker
+        + len(hc_pages(url_prefix="hc", default=False, include_about=False, include_subpages=False))
+        + len(da_pages(url_prefix="da", default=False, include_about=False, include_subpages=False))
+        + len(ia_pages(url_prefix="ia", default=False, include_about=False, include_subpages=False))
+        + 1  # About
+    )
+    assert sections_total <= _NAV_COLLAPSE_THRESHOLD, (
+        f"Pre-app sidebar has {sections_total} entries — exceeds the "
+        f"{_NAV_COLLAPSE_THRESHOLD}-item collapse threshold and "
+        "newcomers will lose discoverability of one or more apps."
+    )
+
+
+def test_launcher_subpage_sidebar_growth_is_documented(launcher_mode):
+    """Document where each app's worst-case sidebar size lands.
+
+    HC and IA stay tiny (2 sub-pages each → 7 total). DA's data-pages
+    (10) push the total to 15 *only after a dataset is loaded* —
+    that's intentional and beyond the collapse threshold, so the
+    launcher injects CSS to keep all entries visible. This test
+    pins the numbers so future page additions trip a clear failure
+    rather than silently re-introducing the collapse problem.
+    """
+    base = 1 + 1 + 1 + 1 + 1  # picker + 3 home links + About
+
+    hc_active = base + len(hc_pages(url_prefix="hc", default=False, include_about=False)) - 1
+    ia_active = base + len(ia_pages(url_prefix="ia", default=False, include_about=False)) - 1
+    # DA data-pages are gated on session_state["decision_data"] which
+    # AppTest doesn't populate here — count only the home entry.
+    da_active_no_data = base + len(da_pages(url_prefix="da", default=False, include_about=False)) - 1
+
+    # HC active: picker + HC home + 2 HC sub-pages + 2 other home links + About = 7
+    assert hc_active == 7, hc_active
+    # IA active: same shape as HC = 7
+    assert ia_active == 7, ia_active
+    # DA active without data loaded behaves like the picker case = 5
+    assert da_active_no_data == 5, da_active_no_data


### PR DESCRIPTION
…ar branding

The cross-app launcher previously dumped every page from every hosted tool directly into the sidebar (~18 entries) and chose the Health Check home as its default landing page. Streamlit's auto-collapse threshold (10 items) hid the entire Impact Analyzer section behind a 'View N more' button by default, and visiting '/' landed on a tool home page rather than a real launcher screen. The 'pdstools' brand text injected by show_sidebar_branding was also overwritten on every tool page (e.g. by 'ADM Health Check'), so users lost the cross-app context.

Changes
-------
* Add a real launcher landing page with three Streamlit-native tile cards (st.container(border=True) + st.page_link) — one per tool. Replaces the implicit 'first tool wins' default.
* Hide each tool's sub-pages from the launcher sidebar until the user has actually entered that tool, tracked via a session_state '_active_app' flag set by each app's home page. Pre-app sidebar: picker + 3 home links + About = 5 entries.
* Force the brand to 'pdstools' in launcher mode (detected via the PDSTOOLS_LAUNCHER_MODE env var the CLI now sets), with the active app rendered as a smaller subtitle below it. Standalone tool launches keep their single-line brand.
* Inject CSS to override Streamlit's nav-collapse and 'View N more' toggle, so even the worst-case post-data DA sidebar (15 entries) stays fully visible. Belt-and-braces — the structural sidebar is already at or below the threshold pre-DA-data-load.
* New tests cover: picker tile rendering, brand state under launcher mode, and pre-app / per-app sidebar size budgets.