### PR TITLE
Fix launcher upload flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,44 @@ sidebar logo and title (sub-pages re-apply it automatically).
   standardised About page. A page file can be as small as two lines
   (page config + `show_about_page()`).
 
+### Testing widget interactions, not just initial renders
+
+`streamlit.testing.v1.AppTest` is the right tool for *both* "page
+renders" smoke tests *and* state-transition tests. We have plenty of
+the first, and (historically) almost none of the second. That gap is
+how the v5.0.0 launcher shipped with two P1 upload-flow regressions
+that the existing AppTest suite happily green-lit:
+
+- HC: switching the data-source dropdown to "Direct file upload"
+  rendered no uploaders at all.
+- DA: dropping a file into the uploader after the sample auto-load
+  did nothing — analyzer kept pointing at the autoloaded data.
+
+Both are pure session-state interactions (an `on_change` callback
+deletes a key, the next-run guard then trips). They're invisible to
+sub-page tests that pre-seed `st.session_state["dm"]` /
+`st.session_state["decision_data"]` to bypass the home page entirely.
+
+**Rule:** every widget on a launcher home page whose `on_change`
+mutates session state needs a state-transition AppTest. Pattern:
+
+```python
+at = AppTest.from_file(str(home_py)).run()
+at.selectbox(key="data_source").set_value("Direct file upload").run()
+assert len(at.file_uploader) >= 1
+```
+
+Same for uploaders: simulate a value change, then assert the
+*post-state* (loaded analyzer's row count, detected format, etc.),
+not just that the file widget is present. See
+`tests/streamlit_apps/decision_analyzer/test_upload_replaces_autoload.py`
+and `tests/streamlit_apps/health_check/test_direct_upload_renders.py`
+for the reference pattern.
+
+If you change a launcher home page's data-source flow, autoload guard,
+or uploader handler, add (or update) one of these tests in the same
+PR.
+
 ### General Streamlit rules
 - Never use `st.experimental_*` APIs — they have been removed. Use
   the stable equivalents (`st.cache_data`, `st.cache_resource`, etc.).

--- a/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
+++ b/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
@@ -38,6 +38,7 @@ _DECISION_STATE_KEYS: tuple[str, ...] = (
     "sample_metadata",
     "page_channel_filter",
     "page_channel_expr",
+    "_da_uploaded_file_signature",
 )
 
 
@@ -649,11 +650,34 @@ def handle_file_upload() -> tuple[pl.LazyFrame | None, dict | None]:
         type=["zip", "parquet", "json", "csv", "arrow", "gz", "tgz", "tar"],
         accept_multiple_files=True,
     )
+
+    previous_signature = st.session_state.get("_da_uploaded_file_signature")
+
     if not uploaded_files:
+        # User cleared the uploader (or never uploaded). If a previous
+        # upload was processed, drop the now-stale data so the page
+        # falls back to the autoload sample on the next run.
+        if previous_signature is not None:
+            clear_decision_state()
         return None, None
 
-    # Clear stale data/filters before processing the new upload.
+    # Identity of the current upload set. Streamlit's UploadedFile keeps
+    # ``file_id`` stable across reruns for the same upload; size+name
+    # are a defensive fallback for stubs in tests.
+    signature = tuple((getattr(f, "file_id", None) or f.name, f.name, getattr(f, "size", None)) for f in uploaded_files)
+
+    # Same upload as last run and the resulting analyzer is still in
+    # session state — nothing to do. Without this guard, the file
+    # uploader's persistent value would re-trigger ingest on every
+    # rerun (clearing decision_data each time), causing the post-load
+    # ``st.rerun()`` to loop and the upload to never visibly take
+    # effect over a previously auto-loaded sample.
+    if signature == previous_signature and "decision_data" in st.session_state:
+        return None, None
+
+    # New (or replacement) upload: clear stale data/filters, then process.
     clear_decision_state()
+    st.session_state["_da_uploaded_file_signature"] = signature
 
     # Drop noise files that may appear when selecting from extracted archives.
     valid_files = [f for f in uploaded_files if not _is_upload_noise(f.name)]

--- a/python/pdstools/app/health_check/_home_page.py
+++ b/python/pdstools/app/health_check/_home_page.py
@@ -68,7 +68,14 @@ interactive visuals and an Excel export for further exploration.
     # data-required sub-pages can do the same on deep-link.
     # ``st.rerun()`` rebuilds the script with ``dm`` set so the rest of
     # the home page (data summary, etc.) renders in the same user action.
-    if "dm" not in st.session_state:
+    #
+    # Gate on ``data_source`` being absent — i.e. *truly* first visit.
+    # Once the user has interacted with the data-source dropdown (which
+    # also deletes ``dm`` so the chosen branch can repopulate it), we must
+    # NOT silently reload the sample, because that would leave the
+    # uploader branch with ``dm`` set and the "Import Successful!" banner
+    # stuck on screen, while the file_uploader widgets are skipped.
+    if "dm" not in st.session_state and "data_source" not in st.session_state:
         configured_path = get_data_path()
         if ensure_dm_loaded():
             if configured_path and st.session_state.get("data_source") == "Direct file path":

--- a/python/tests/streamlit_apps/decision_analyzer/test_upload_replaces_autoload.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_upload_replaces_autoload.py
@@ -1,0 +1,107 @@
+"""Regression test: explicit upload must override the autoloaded sample.
+
+PR #762 added an autoload of the bundled sample on first visit so the
+home page is no longer blank. A side-effect: the file uploader's
+persistent value re-fired ``handle_file_upload`` on every rerun, which
+called ``clear_decision_state()`` and reloaded the analyzer. Combined
+with the post-load ``st.rerun()``, this looped indefinitely (rendering
+multiple "Data loaded" banners) and left ``decision_data`` reflecting
+whichever load won the race — typically the autoloaded sample, not the
+user's upload.
+
+This test seeds the autoload sample, then simulates a file_uploader
+value change to a small synthetic parquet and asserts that
+``session_state.decision_data`` reflects the uploaded file's row count,
+not the sample's.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+from streamlit.testing.v1 import AppTest
+
+
+# Distinctive row count — must not collide with the bundled sample's
+# size, the minimal CSV fixture's size, or any other dataset that
+# appears in DA tests, so the assertion proves which file actually
+# made it into ``decision_data``.
+_FIXTURE_ROW_COUNT = 17
+
+
+@pytest.fixture
+def upload_fixture_bytes(tmp_path: Path, da_sample_path: Path) -> bytes:
+    """Tiny EEV2-shaped parquet for upload simulation.
+
+    Reuses the minimal CSV fixture's schema and trims to a unique row
+    count so the test can distinguish "loaded the upload" from "still
+    showing the autoload sample".
+    """
+    df = pl.read_csv(da_sample_path).head(_FIXTURE_ROW_COUNT)
+    if df.height < _FIXTURE_ROW_COUNT:
+        # Repeat rows if the fixture is smaller than our target — we
+        # only care that the row count is distinctive, not the values.
+        repeats = (_FIXTURE_ROW_COUNT // max(df.height, 1)) + 1
+        df = pl.concat([df] * repeats).head(_FIXTURE_ROW_COUNT)
+    out = tmp_path / "upload_fixture.parquet"
+    df.write_parquet(out)
+    return out.read_bytes()
+
+
+def test_upload_replaces_autoloaded_sample(da_app_dir: Path, upload_fixture_bytes: bytes) -> None:
+    """Dropping a file into the uploader must replace the autoloaded sample.
+
+    Steps:
+    1. Run Home — sample autoloads, ``decision_data`` populated.
+    2. Simulate the user dropping a small parquet into the uploader.
+    3. Re-run — the analyzer must rebuild from the upload, not the sample.
+
+    Asserts:
+    - No exception bubbled out.
+    - ``decision_data`` row count equals the upload fixture's row
+      count (proves the upload won, not the autoloaded sample).
+    - Exactly one ``st.success`` "Data loaded" banner is rendered on
+      the post-upload run (no rerun-loop duplicate alerts).
+    """
+    at = AppTest.from_file(str(da_app_dir / "Home.py"), default_timeout=120)
+    at.run()
+    assert not at.exception, f"Initial autoload raised: {at.exception}"
+    assert "decision_data" in at.session_state, "Autoload should populate decision_data"
+
+    autoload_rows = at.session_state["decision_data"].decision_data.select(pl.len()).collect().item()
+    assert autoload_rows != _FIXTURE_ROW_COUNT, (
+        "Test fixture row count must differ from the autoload sample's row count to be a meaningful assertion"
+    )
+
+    uploaders = at.get("file_uploader")
+    assert list(uploaders), "Expected a file_uploader on the Home page"
+    uploaders[0].upload("upload_fixture.parquet", upload_fixture_bytes, "application/octet-stream")
+    at.run()
+
+    assert not at.exception, f"Post-upload run raised: {at.exception}"
+    assert "decision_data" in at.session_state
+
+    upload_rows = at.session_state["decision_data"].decision_data.select(pl.len()).collect().item()
+    assert upload_rows == _FIXTURE_ROW_COUNT, (
+        f"Expected uploaded file ({_FIXTURE_ROW_COUNT} rows) to override autoloaded "
+        f"sample ({autoload_rows} rows), but decision_data has {upload_rows} rows"
+    )
+
+    success_banners = [s for s in at.success if "data loaded successfully" in str(s.value).lower()]
+    assert len(success_banners) == 1, (
+        f"Expected exactly one 'Data loaded successfully' banner, got {len(success_banners)}: "
+        f"{[s.value for s in success_banners]}"
+    )
+
+    # A subsequent rerun without changing the uploader must be a no-op
+    # for ingest — the dedup guard should short-circuit. If it didn't,
+    # decision_data would either be cleared or rebuilt with a fresh
+    # cache key (still 17 rows, but a different object identity).
+    da_id_before = id(at.session_state["decision_data"])
+    at.run()
+    assert not at.exception, f"Idle rerun raised: {at.exception}"
+    assert id(at.session_state["decision_data"]) == da_id_before, (
+        "Idle rerun must not rebuild the analyzer when the upload signature is unchanged"
+    )

--- a/python/tests/streamlit_apps/health_check/test_direct_upload_renders.py
+++ b/python/tests/streamlit_apps/health_check/test_direct_upload_renders.py
@@ -1,0 +1,55 @@
+"""Regression test: switching to "Direct file upload" must show uploaders.
+
+Reproduces the bug where the auto-load on first visit (CDH Sample) left
+the file_uploader branch unrendered when the user later flipped the
+data-source dropdown to "Direct file upload" — because the home page's
+"if dm not in session_state, auto-load" guard re-fired on every
+selection change and silently put dm + data_source back to CDH Sample,
+while the selectbox widget held the user's chosen "Direct file upload"
+value.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from streamlit.testing.v1 import AppTest
+
+
+def test_direct_file_upload_renders_uploaders(hc_app_dir: Path):
+    """Selecting "Direct file upload" renders the model + predictor uploaders.
+
+    First run auto-loads the bundled CDH sample. The second run mimics
+    the user picking "Direct file upload": the on_change callback in
+    ``import_datamart`` deletes ``dm`` and sets ``data_source`` to the
+    new selection. The home page must NOT re-trigger auto-load — it
+    must let the upload branch render its file_uploader widgets.
+    """
+    at = AppTest.from_file(str(hc_app_dir / "Home.py"), default_timeout=60)
+    at.run()
+    assert not at.exception, f"HC Home raised on first run: {at.exception}"
+    assert "dm" in at.session_state, "auto-load should have populated dm on first run"
+    assert at.session_state["data_source"] == "CDH Sample"
+
+    # Mimic the dropdown's on_change callback: delete dm, switch source.
+    del at.session_state["dm"]
+    at.session_state["data_source"] = "Direct file upload"
+    at.session_state["_data_source"] = "Direct file upload"
+    at.run()
+    assert not at.exception, f"HC Home raised after switching source: {at.exception}"
+
+    assert "dm" not in at.session_state, "Switching to 'Direct file upload' should not silently re-load CDH Sample"
+    assert at.session_state["data_source"] == "Direct file upload"
+
+    uploader_labels = [u.label for u in at.get("file_uploader")]
+    assert any("Model Snapshot" in lbl for lbl in uploader_labels), (
+        f"expected a 'Model Snapshot' uploader, got: {uploader_labels}"
+    )
+    assert any("Predictor" in lbl for lbl in uploader_labels), (
+        f"expected a 'Predictor' uploader, got: {uploader_labels}"
+    )
+
+    success_messages = [s.value for s in at.success]
+    assert not any("Import Successful" in m for m in success_messages), (
+        f"stale 'Import Successful!' banner should be gone, got: {success_messages}"
+    )


### PR DESCRIPTION
Two related regressions, both introduced when sample auto-load (https://github.com/pegasystems/pega-datascientist-tools/pull/762)
was added to the launcher pages.

DA — explicit upload ignored after auto-load
--------------------------------------------
After the bundled sample auto-loaded on Decision Analyzer home,
dropping a different parquet into the file uploader had no effect:
the file appeared in the dropzone but row counts and downstream
sub-pages still reflected the auto-loaded sample, with three
duplicate "Data loaded successfully" alerts.

Fix in handle_file_upload(): dedup uploads by a (file_id, name, size)
signature kept in session state. Re-ingest only when the signature
changes; on identical reruns return (None, None) so the post-load
st.rerun() doesn't loop and clobber the upload with a fresh
tempfile/cache miss. Clearing the uploader drops the signature and
stale state, so the autoload sample returns.

HC — "Direct file upload" rendered no widgets
---------------------------------------------
Selecting "Direct file upload" from the data-source dropdown rendered
from CDH Sample. The auto-load was gated on `"dm" not in session_state`,
but the dropdown's on_change deletes `dm` — so the auto-load re-fired on
every dropdown change, silently reloading CDH Sample and overwriting
`data_source = "CDH Sample"` while the selectbox kept the user's choice.

Fix: gate the auto-load on `"data_source" not in session_state` so it
only fires on first visit. Manual switches now flow into the chosen
branch correctly.

Adds streamlit AppTest regression tests for both flows. Both fail on
master, pass with this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>