### PR TITLE
refactor(explanations): pure __init__; move path loading to from_local_directory (v5 breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ guide.
 
 ### Changed
 
+- **`Explanations.__init__` no longer accepts filesystem paths.** The
+  `root_dir`, `data_folder`, and `data_file` parameters have moved to a
+  new `Explanations.from_local_directory(...)` classmethod. The
+  constructor now takes only configuration (`model_name`, `from_date`,
+  `to_date`) and performs no I/O — matching the pure-`__init__` pattern
+  used by `ADMDatamart`, `IH`, `Prediction`, and other analyzer classes.
+  All path-keyword arguments are now keyword-only on the classmethod.
+  **Migration:**
+  `Explanations(data_folder="...", model_name="...", from_date=..., to_date=...)`
+  → `Explanations.from_local_directory(data_folder="...", model_name="...", from_date=..., to_date=...)`.
+  Quarto report templates that previously did
+  `Explanations(root_dir="...")` followed by manual
+  `aggregate.data_folderpath = "..."` should drop the `root_dir`
+  argument and call `Explanations()` with no arguments.
 - `DecisionAnalyzer` reorganised into a namespace facade (matching the
   `ADMDatamart` pattern): 16 aggregation methods moved to
   `da.aggregates.*` and 12 scoring / ranking / lever methods moved to

--- a/docs/migration-v4-to-v5.md
+++ b/docs/migration-v4-to-v5.md
@@ -149,6 +149,63 @@ model=...)` directly.
 Previously `def __init__(self, *args, **kwargs)`. Now uses explicit
 parameters matching the documented constructor signature.
 
+### `Explanations.__init__` is pure config; loading moves to `from_local_directory`
+
+The `Explanations` constructor used to accept filesystem paths
+(`root_dir`, `data_folder`, `data_file`) and run the DuckDB
+pre-aggregation pipeline as a side effect of construction. This
+violated the project's pure-`__init__` rule (see AGENTS.md, "I/O lives
+in classmethods, not `__init__`").
+
+In v5 the constructor takes only configuration (`model_name`,
+`from_date`, `to_date`, all keyword-only) and performs no I/O. All
+path-driven loading moves to a new `from_local_directory` classmethod
+that mirrors `ADMDatamart.from_ds_export` / `from_s3`.
+
+```python
+# Before (v4.x):
+exp = Explanations(
+    data_folder="explanations_data",
+    model_name="AdaptiveBoostCT",
+    from_date=datetime(2025, 3, 28),
+    to_date=datetime(2025, 3, 28),
+)
+
+# After (v5):
+exp = Explanations.from_local_directory(
+    data_folder="explanations_data",
+    model_name="AdaptiveBoostCT",
+    from_date=datetime(2025, 3, 28),
+    to_date=datetime(2025, 3, 28),
+)
+```
+
+Single-file / remote-URL loading still works the same way, just on the
+classmethod:
+
+```python
+# Before:
+exp = Explanations(data_file="https://.../file.parquet", model_name="...")
+# After:
+exp = Explanations.from_local_directory(
+    data_file="https://.../file.parquet", model_name="...",
+)
+```
+
+Quarto report templates that previously did
+`Explanations(root_dir="...")` followed by manual
+`aggregate.data_folderpath = "..."` should drop the `root_dir` argument
+entirely — the bare constructor is now safe to call without I/O:
+
+```python
+# Before:
+explanations = Explanations(root_dir=ROOT_DIR)
+explanations.aggregate.data_folderpath = DATA_FOLDER
+# After:
+explanations = Explanations()
+explanations.aggregate.data_folderpath = DATA_FOLDER
+```
+
 ### Explanations: explicit filter parameters
 
 The `**filter_kwargs` catch-all on the Explanations `Plots`,

--- a/examples/articles/explanations/agb_global_explanations.ipynb
+++ b/examples/articles/explanations/agb_global_explanations.ipynb
@@ -76,7 +76,7 @@
     "# logging.basicConfig(level=logging.INFO) # Uncomment to see progress for large files\n",
     "\n",
     "\n",
-    "explanations = Explanations(\n",
+    "explanations = Explanations.from_local_directory(\n",
     "    # data_folder='../../data/explanations/', # Uncomment this line and provide folder location of exported explanations data\n",
     "    data_file=\"https://raw.githubusercontent.com/pegasystems/pega-datascientist-tools/master/data/explanations/AdaptiveBoostCT_20250328064604.parquet\", # Remove this argument when running locally with exported data\n",
     "    model_name='AdaptiveBoostCT',\n",

--- a/python/pdstools/explanations/Explanations.py
+++ b/python/pdstools/explanations/Explanations.py
@@ -15,57 +15,187 @@ logger = logging.getLogger(__name__)
 class Explanations:
     """Process and explore explanation data for Adaptive Gradient Boost models.
 
-    Class is initialied with data location, which should point to the location of the
-    model's explanation parquet files downloaded from the explanations file repository.
-    These parquet files can then be processed to create aggregates to explain the contribution
-    of different predictors on a global level.
+    The class is a thin orchestrator over four sub-namespaces (``preprocess``,
+    ``aggregate``, ``plot``, ``report``, ``filter``) that operate on the
+    parquet files produced by Pega's explanation file repository.
+
+    The constructor is **pure configuration** — it takes no filesystem paths
+    and performs no I/O. Use the ``from_local_directory`` classmethod to load
+    raw explanation parquet files from disk (or a remote URL) and run the
+    DuckDB aggregation step. After that, ``aggregate``, ``plot`` and
+    ``report`` can be used freely.
 
     Parameters
     ----------
-    data_folder: str
-        The path of the folder containing the model explanation parquet files for processing.
-    data_file : str, optional
-        Direct path to a single explanation file (URL or local path). When provided, this takes
-        precedence over data_folder. Useful for loading files from remote locations.
     model_name : str, optional
-        The name of the model rule. Will be used to identify files in the data folder
-        and to validate that the correct files are being processed.
-    end_date : datetime, optional, default = datetime.today()
-        Defines the end date of the duration over which aggregates will be collected.
-    start_date : datetime, optional, default = end_date - timedelta(7)
-        Defines the start date of the duration over which aggregaates wille be collected.
+        Name of the model rule. Used to identify and validate raw
+        explanation parquet files when loading via
+        :meth:`from_local_directory`.
+    from_date : datetime, optional
+        Start date of the period over which aggregates are computed.
+        Defaults to ``to_date - 7 days`` if only ``to_date`` is given,
+        or to ``today() - 7 days`` if both are omitted.
+    to_date : datetime, optional
+        End date of the period over which aggregates are computed.
+        Defaults to ``today()`` if only ``from_date`` is given, or to
+        ``today()`` if both are omitted.
 
-    Environment variables
-    -------------------
-    BATCH_LIMIT: int
-        The maximum number of unique contexts to process in a single batch. Default is 10.
-    MEMORY_LIMIT: int
-        Set the memory limit for the duckdb buffer manager.
-        If not set will use 80% of RAM. Default is 2(in GB).
-    THREAD_COUNT: int
-        Set the amount of threads for duck db parallel query execution. Default is 4.
-    PROGRESS_BAR: int
-        Show progress bar when running duckdb queries.
-        0 = no progress bar, 1 = show progress bar. Default is 0.
+    See Also
+    --------
+    Explanations.from_local_directory : Load raw explanation parquet files
+        from a local folder or remote URL and pre-aggregate them.
+
+    Notes
+    -----
+    Environment variables that influence the (lazy) DuckDB aggregation step:
+
+    ``MODEL_CONTEXT_LIMIT``
+        Maximum number of unique contexts processed in a single query.
+        Default: ``2500``.
+    ``QUERY_BATCH_LIMIT``
+        Number of contexts per DuckDB batch query. Default: ``10``.
+    ``FILE_BATCH_LIMIT``
+        Number of files per DuckDB batch. Default: ``10``.
+    ``MEMORY_LIMIT``
+        DuckDB buffer memory limit in GB. Default: ``8``.
+    ``THREAD_COUNT``
+        Number of DuckDB worker threads. Default: ``4``.
+    ``PROGRESS_BAR``
+        ``"1"`` to enable the DuckDB progress bar. Default: disabled.
+
+    Examples
+    --------
+    Load and explore a folder of raw explanation parquet files:
+
+    >>> from datetime import datetime
+    >>> exp = Explanations.from_local_directory(
+    ...     data_folder="explanations_data",
+    ...     model_name="AdaptiveBoostCT",
+    ...     from_date=datetime(2025, 3, 28),
+    ...     to_date=datetime(2025, 3, 28),
+    ... )
+    >>> df = exp.aggregate.get_df_overall().collect()  # doctest: +SKIP
+
+    Load a single remote parquet file:
+
+    >>> exp = Explanations.from_local_directory(
+    ...     data_file="https://example.com/AdaptiveBoostCT_20250328.parquet",
+    ...     model_name="AdaptiveBoostCT",
+    ... )  # doctest: +SKIP
+
+    Construct without I/O (e.g. inside a Quarto report that already points
+    ``aggregate.data_folderpath`` at pre-aggregated parquet files):
+
+    >>> exp = Explanations()
+    >>> exp.aggregate.data_folderpath = "/path/to/aggregated_data"  # doctest: +SKIP
 
     """
 
+    # Default storage locations used when no path overrides are provided.
+    # These are *internal* defaults — public path inputs go through
+    # ``from_local_directory``.
+    _DEFAULT_ROOT_DIR = ".tmp"
+    _DEFAULT_DATA_FOLDER = "explanations_data"
+
     def __init__(
         self,
-        root_dir: str = ".tmp",
-        data_folder: str = "explanations_data",
-        data_file: str | None = None,
-        model_name: str | None = "",
+        *,
+        model_name: str | None = None,
         from_date: datetime | None = None,
         to_date: datetime | None = None,
     ):
+        self._init_state(
+            root_dir=self._DEFAULT_ROOT_DIR,
+            data_folder=self._DEFAULT_DATA_FOLDER,
+            data_file=None,
+            model_name=model_name,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+    @classmethod
+    def from_local_directory(
+        cls,
+        root_dir: str = _DEFAULT_ROOT_DIR,
+        data_folder: str = _DEFAULT_DATA_FOLDER,
+        data_file: str | None = None,
+        *,
+        model_name: str | None = None,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+    ) -> "Explanations":
+        """Construct an ``Explanations`` from raw parquet files on disk or a URL.
+
+        This is the standard entry point: it wires the path configuration,
+        runs the DuckDB pre-aggregation step (writing the per-context and
+        per-overall aggregates to ``<root_dir>/aggregated_data/``) and
+        returns a ready-to-query instance.
+
+        Parameters
+        ----------
+        root_dir : str, default ".tmp"
+            Working directory under which the pre-aggregated parquet files
+            (and report scratch space) are written.
+        data_folder : str, default "explanations_data"
+            Folder containing the raw model-explanation parquet files
+            downloaded from the Pega explanation file repository. Used
+            when ``data_file`` is not provided.
+        data_file : str, optional
+            Direct path or URL to a single explanation parquet file. When
+            given, takes precedence over ``data_folder``. ``http://`` and
+            ``https://`` URLs are downloaded into ``root_dir`` before
+            aggregation.
+        model_name : str, optional
+            Name of the model rule. Used to filter files in ``data_folder``
+            and validate that the correct files are being processed.
+        from_date : datetime, optional
+            Start date of the period over which aggregates are collected.
+            See :class:`Explanations` for default behaviour.
+        to_date : datetime, optional
+            End date of the period over which aggregates are collected.
+            See :class:`Explanations` for default behaviour.
+
+        Returns
+        -------
+        Explanations
+            A fully initialised instance with pre-aggregation completed.
+
+        Raises
+        ------
+        ValueError
+            If ``from_date > to_date``, if no files match ``model_name``
+            within the date range, or if a remote ``data_file`` cannot be
+            downloaded.
+
+        """
+        instance = cls.__new__(cls)
+        instance._init_state(
+            root_dir=root_dir,
+            data_folder=data_folder,
+            data_file=data_file,
+            model_name=model_name,
+            from_date=from_date,
+            to_date=to_date,
+        )
+        instance.preprocess.generate()
+        return instance
+
+    def _init_state(
+        self,
+        *,
+        root_dir: str,
+        data_folder: str,
+        data_file: str | None,
+        model_name: str | None,
+        from_date: datetime | None,
+        to_date: datetime | None,
+    ) -> None:
+        """Set instance attributes and wire sub-namespaces. Pure (no I/O)."""
         self.root_dir = root_dir
         self.data_folder = data_folder
         self.data_file = data_file
 
         self.model_name = model_name
-        self.from_date = from_date
-        self.to_date = to_date
         self._set_date_range(from_date, to_date)
 
         self.preprocess = Preprocess(explanations=self)
@@ -79,36 +209,40 @@ class Explanations:
         from_date: datetime | None,
         to_date: datetime | None,
         days: int = 7,
-    ):
-        """Set the date range for processing explanation files.
+    ) -> None:
+        """Resolve the ``(from_date, to_date)`` window using the default rules.
 
         Parameters
         ----------
-        start_date : datetime, optional
-            The start date for the date range. If None, defaults to 7 days before end_date.
-        end_date : datetime, optional
-            The end date for the date range. If None, defaults to today.
+        from_date : datetime or None
+            Start of the date range. If ``None`` and ``to_date`` is given,
+            defaults to ``to_date - days``.
+        to_date : datetime or None
+            End of the date range. If ``None`` and ``from_date`` is given,
+            defaults to ``datetime.today()``.
+        days : int, default 7
+            Window length used to fill in the missing endpoint when only one
+            of ``from_date`` / ``to_date`` is provided.
+
+        Raises
+        ------
+        ValueError
+            If both endpoints are provided and ``from_date > to_date``.
 
         """
         if from_date is None and to_date is None:
             to_date = datetime.today()
             from_date = to_date - timedelta(days=days)
 
-        # if only `to_date` is provided, set `from_date` to 7 days before `to_date`
         if from_date is None and to_date is not None:
             from_date = to_date - timedelta(days=days)
 
-        # if only `from_date` is provided, set `to_date` to today
-        # it can process from any date until today. eg: from_date = 2023-01-01, to_date = today
         if from_date is not None and to_date is None:
             to_date = datetime.today()
 
-        # validate date range if both from_date and to_date are provided
         if from_date is not None and to_date is not None:
             if from_date > to_date:
                 raise ValueError("from_date cannot be after to_date")
-            # if (to_date - from_date).days > 30:
-            #     raise ValueError("Date range cannot be more than 30 days")
 
         self.from_date = from_date
         self.to_date = to_date

--- a/python/pdstools/explanations/Preprocess.py
+++ b/python/pdstools/explanations/Preprocess.py
@@ -70,8 +70,6 @@ class Preprocess(LazyNamespace):
 
         super().__init__()
 
-        self.generate()
-
     def generate(self):
         """Process explanation parquet files and save calculated aggregates.
 

--- a/python/pdstools/reports/GlobalExplanations/assets/templates/all_context_header.qmd
+++ b/python/pdstools/reports/GlobalExplanations/assets/templates/all_context_header.qmd
@@ -15,7 +15,7 @@ from IPython.display import display, Markdown
 logger = logging.getLogger(__name__)
 
 try:
-    explanations = Explanations(root_dir="{ROOT_DIR}")
+    explanations = Explanations()
     explanations.aggregate.data_folderpath = "{DATA_FOLDER}"
     explanations.aggregate.data_pattern = "{DATA_PATTERN}"
 except Exception as e:

--- a/python/pdstools/reports/GlobalExplanations/assets/templates/overview.qmd
+++ b/python/pdstools/reports/GlobalExplanations/assets/templates/overview.qmd
@@ -16,7 +16,7 @@ from pdstools.utils import report_utils, show_versions
 The top-{TOP_N} predictors over the entire model, selected by their {SORT_BY_TEXT} to predictions
 
 ```{{python}}
-explanations = Explanations(root_dir="{ROOT_DIR}")
+explanations = Explanations()
 explanations.aggregate.data_folderpath = "{DATA_FOLDER}"
 
 try:

--- a/python/tests/explanations/test_Explanations.py
+++ b/python/tests/explanations/test_Explanations.py
@@ -3,9 +3,23 @@
 import os
 import shutil
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import pytest
 from pdstools.explanations import Explanations
+
+basePath = Path(__file__).parent.parent.parent.parent
+
+
+def _clean_up(root_dir):
+    _root_dir = Path(f"{basePath}/{root_dir}")
+    if _root_dir.exists():
+        for file in _root_dir.iterdir():
+            if file.is_file():
+                file.unlink()
+            elif file.is_dir():
+                shutil.rmtree(file)
+        _root_dir.rmdir()
 
 
 @pytest.fixture(scope="module")
@@ -101,3 +115,94 @@ class TestExplanationsDateRange:
 
         assert explanations.from_date.date() == expected_from_date
         assert explanations.to_date.date() == expected_to_date
+
+
+class TestPureInit:
+    """The Explanations constructor must be pure config (no I/O)."""
+
+    def test_init_does_not_touch_filesystem(self, tmp_path, monkeypatch):
+        """Default-constructed Explanations must not create any files."""
+        monkeypatch.chdir(tmp_path)
+        exp = Explanations()
+        # No directories should have been created from a bare construction.
+        assert list(tmp_path.iterdir()) == []
+        # Defaults should be exposed but not acted upon.
+        assert exp.root_dir == ".tmp"
+        assert exp.data_folder == "explanations_data"
+        assert exp.data_file is None
+
+    def test_init_rejects_positional_paths(self):
+        """root_dir / data_folder / data_file must not be constructor params."""
+        with pytest.raises(TypeError):
+            Explanations("some_root_dir")  # type: ignore[misc]
+        with pytest.raises(TypeError):
+            Explanations(data_folder="some_folder")  # type: ignore[call-arg]
+
+    def test_namespaces_attached(self):
+        """The five sub-namespace facades must be present after init."""
+        exp = Explanations()
+        assert exp.preprocess is not None
+        assert exp.aggregate is not None
+        assert exp.plot is not None
+        assert exp.report is not None
+        assert exp.filter is not None
+
+
+class TestFromLocalDirectory:
+    """Exact-value tests for Explanations.from_local_directory."""
+
+    def test_loads_real_sample_parquet(self):
+        """Load the shipped sample data and verify aggregates were produced."""
+        data_folder = f"{basePath}/data/explanations"
+        try:
+            exp = Explanations.from_local_directory(
+                data_folder=data_folder,
+                model_name="AdaptiveBoostCT",
+                from_date=datetime(2025, 3, 28),
+                to_date=datetime(2025, 3, 28),
+            )
+
+            # The classmethod must wire all path config exactly as given.
+            assert exp.root_dir == ".tmp"
+            assert exp.data_folder == data_folder
+            assert exp.data_file is None
+            assert exp.model_name == "AdaptiveBoostCT"
+            assert exp.from_date == datetime(2025, 3, 28)
+            assert exp.to_date == datetime(2025, 3, 28)
+
+            # Pre-aggregation must have produced parquet files in
+            # <root_dir>/aggregated_data/.
+            agg_dir = Path(exp.root_dir) / "aggregated_data"
+            assert agg_dir.is_dir()
+            parquets = sorted(p.name for p in agg_dir.glob("*.parquet"))
+            assert len(parquets) > 0, "Expected at least one aggregated parquet file"
+
+            # The aggregate namespace must be wired to that folder.
+            assert str(exp.aggregate.data_folderpath) == str(agg_dir)
+        finally:
+            _clean_up(".tmp")
+
+    def test_invalid_data_folder_raises(self):
+        with pytest.raises(
+            ValueError,
+            match="Explanations folder invalid_path does not exist or is empty.",
+        ):
+            Explanations.from_local_directory(data_folder="invalid_path")
+
+    def test_data_file_overrides_data_folder(self, tmp_path, monkeypatch):
+        """When data_file is given, data_folder is not consulted."""
+        monkeypatch.chdir(tmp_path)
+        sample = basePath / "data" / "explanations" / "AdaptiveBoostCT_20250328064604.parquet"
+        try:
+            exp = Explanations.from_local_directory(
+                data_file=str(sample),
+                model_name="AdaptiveBoostCT",
+                from_date=datetime(2025, 3, 28),
+                to_date=datetime(2025, 3, 28),
+            )
+            assert exp.data_file == str(sample)
+            agg_dir = Path(exp.root_dir) / "aggregated_data"
+            assert agg_dir.is_dir()
+        finally:
+            if Path(".tmp").exists():
+                shutil.rmtree(".tmp")

--- a/python/tests/explanations/test_ExplanationsAggregate.py
+++ b/python/tests/explanations/test_ExplanationsAggregate.py
@@ -28,7 +28,7 @@ def clean_up(root_dir):
 @pytest.fixture(scope="class")
 def aggregate():
     """Fixture to serve as class to call functions from."""
-    explanations = Explanations(
+    explanations = Explanations.from_local_directory(
         data_folder=f"{basePath}/data/explanations",
         model_name="AdaptiveBoostCT",
         from_date=datetime(2025, 3, 28),

--- a/python/tests/explanations/test_ExplanationsPlots.py
+++ b/python/tests/explanations/test_ExplanationsPlots.py
@@ -30,7 +30,7 @@ def clean_up(root_dir):
 @pytest.fixture(scope="module")
 def plots():
     """Fixture to serve as class to call functions from."""
-    explanations = Explanations(
+    explanations = Explanations.from_local_directory(
         data_folder=f"{basePath}/data/explanations",
         model_name="AdaptiveBoostCT",
         from_date=datetime(2025, 3, 28),

--- a/python/tests/explanations/test_ExplanationsPreprocess.py
+++ b/python/tests/explanations/test_ExplanationsPreprocess.py
@@ -30,7 +30,7 @@ def clean_up(root_dir):
 @pytest.fixture
 def preprocess_instance():
     """Fixture to serve as class to call functions from."""
-    explanations = Explanations(
+    explanations = Explanations.from_local_directory(
         data_folder=f"{basePath}/data/explanations",
         model_name="AdaptiveBoostCT",
         from_date=datetime(2025, 3, 28),
@@ -101,7 +101,7 @@ class TestAggregatesGenerate:
             ValueError,
             match="Explanations folder invalid_path does not exist or is empty.",
         ):
-            Explanations(data_folder="invalid_path")
+            Explanations.from_local_directory(data_folder="invalid_path")
 
     def test_generate_empty_explanations_folder(self, empty_folder):
         """Test that an empty explanations folder raises an error."""
@@ -110,18 +110,18 @@ class TestAggregatesGenerate:
             ValueError,
             match=f"Explanations folder {data_folder} does not exist or is empty.",
         ):
-            Explanations(data_folder=data_folder)
+            Explanations.from_local_directory(data_folder=data_folder)
 
     def test_generate_uses_cache(self, dummy_explanations_data, dummy_aggregate_data):
         """Test that the generate method uses cached data if available."""
         with mock.patch("pdstools.explanations.Preprocess.logger") as logger_mock:
-            Explanations(data_folder="explanations_data")
+            Explanations.from_local_directory(data_folder="explanations_data")
             logger_mock.debug.assert_called_with("Using cached data for preprocessing.")
 
     def test_generate_no_files(self, dummy_explanations_data):
         """Test that generate raises an error when no files are found to aggregate."""
         with pytest.raises(ValueError, match="No files found to aggregate!"):
-            Explanations(data_folder="explanations_data")
+            Explanations.from_local_directory(data_folder="explanations_data")
 
 
 class TestAggregatesQueryOperations:

--- a/python/tests/explanations/test_ExplanationsReports.py
+++ b/python/tests/explanations/test_ExplanationsReports.py
@@ -30,7 +30,7 @@ def clean_up(root_dir):
 @pytest.fixture(scope="module")
 def reports():
     """Fixture to serve as class to call functions from."""
-    explanations = Explanations(
+    explanations = Explanations.from_local_directory(
         data_folder=f"{basePath}/data/explanations",
         model_name="AdaptiveBoostCT",
         from_date=datetime(2025, 3, 28),

--- a/python/tests/explanations/test_explanations_report.py
+++ b/python/tests/explanations/test_explanations_report.py
@@ -33,11 +33,11 @@ def clean_up(root_dir):
 def explanations():
     """Create an Explanations instance with sample data.
 
-    The Explanations constructor automatically runs the preprocessing
+    The ``from_local_directory`` classmethod runs the preprocessing
     and aggregation pipeline, producing the aggregated parquet files
     and unique_contexts.json needed for report generation.
     """
-    exp = Explanations(
+    exp = Explanations.from_local_directory(
         data_folder=f"{basePath}/data/explanations",
         model_name="AdaptiveBoostCT",
         from_date=datetime(2025, 3, 28),

--- a/python/tests/reports/test_global_explanations_templates.py
+++ b/python/tests/reports/test_global_explanations_templates.py
@@ -18,7 +18,6 @@ TEMPLATE_PLACEHOLDERS: dict[str, set[str]] = {
         "{MODEL_CONTEXT_LIMIT}",
     },
     "overview.qmd": {
-        "{ROOT_DIR}",
         "{DATA_FOLDER}",
         "{TOP_N}",
         "{TOP_K}",
@@ -34,7 +33,6 @@ TEMPLATE_PLACEHOLDERS: dict[str, set[str]] = {
         "{SORT_BY_TEXT}",
     },
     "all_context_header.qmd": {
-        "{ROOT_DIR}",
         "{DATA_FOLDER}",
         "{DATA_PATTERN}",
         "{TOP_N}",


### PR DESCRIPTION
The Explanations constructor previously accepted filesystem paths (root_dir, data_folder, data_file) and ran the DuckDB pre-aggregation pipeline as a side effect of construction. This violated the pure-__init__ rule (AGENTS.md: 'I/O lives in classmethods, not __init__') and meant constructing an Explanations always touched the filesystem.

This commit:

- Makes Explanations.__init__ pure configuration: only accepts model_name, from_date, to_date (all keyword-only). No I/O.
- Adds Explanations.from_local_directory(root_dir, data_folder, data_file=None, *, model_name, from_date, to_date) classmethod that configures the path attrs and runs preprocess.generate(). Mirrors ADMDatamart.from_ds_export / from_s3.
- Removes the auto-call to self.generate() from Preprocess.__init__ — preprocessing is now driven only by the classmethod.
- Updates the GlobalExplanations Quarto templates (overview.qmd, all_context_header.qmd) to construct Explanations() with no args, since they always overrode aggregate.data_folderpath manually anyway. Removes the unused {ROOT_DIR} placeholder.
- Migrates all tests, the agb_global_explanations notebook, and the template-placeholder test to the new API.
- Adds exact-value tests for from_local_directory: verifies the bare __init__ is filesystem-pure, that path kwargs are rejected positionally, that loading the shipped sample data produces real parquet aggregates wired to aggregate.data_folderpath, and that data_file overrides data_folder.
- CHANGELOG and docs/migration-v4-to-v5.md updated with a clear before/after migration block.

Migration:
  Explanations(data_folder='...', model_name='...', from_date=..., to_date=...) → Explanations.from_local_directory(data_folder='...', model_name='...', from_date=..., to_date=...)