### PR TITLE
v5: tighten ruff lint config + remove # type: ignore that hide real bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,17 +100,71 @@ line-length = 120
 extend-select = [
     "UP006",   # deprecated-collection-type (Dict -> dict, List -> list, etc.)
     "UP007",   # non-pep604-annotation (Union[X, Y] -> X | Y)
+    "UP012",   # unnecessary-encode-utf8 (.encode("utf-8") -> .encode())
+    "UP024",   # os-error-alias (replace bare OSError aliases)
     "UP035",   # deprecated-import (typing.Dict -> dict, etc.)
     "UP045",   # non-pep604-isinstance (Optional[X] -> X | None)
+    "B904",    # raise-without-from-inside-except (preserve exception chain)
     "B905",    # zip-without-explicit-strict (require explicit strict= on zip)
+    "B006",    # mutable-argument-default
+    "B007",    # unused-loop-control-variable
+    "B008",    # function-call-in-default-argument
+    "B019",    # cached-instance-method (functools.lru_cache on methods)
+    "B024",    # abstract-base-class-without-abstract-method
+    "B028",    # no-explicit-stacklevel (warnings.warn without stacklevel)
+    "RET504",  # unnecessary-assign (return temporary variable)
+    "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
+    "SIM108",  # if-else-block-instead-of-if-exp (ternary)
+    "TC001",   # typing-only-first-party-import
+    "TC002",   # typing-only-third-party-import
+    "TC003",   # typing-only-standard-library-import
+    "LOG015",  # root-logger-call (use logger = logging.getLogger(__name__))
+    "RUF001",  # ambiguous-unicode-character-string
+    "RUF002",  # ambiguous-unicode-character-docstring
+    "RUF003",  # ambiguous-unicode-character-comment
+    "RUF005",  # collection-literal-concatenation ([*a, *b] over a + b)
+    "RUF012",  # mutable-class-default (require ClassVar)
+    "RUF015",  # unnecessary-iterable-allocation-for-first-element
+    "RUF022",  # unsorted-dunder-all
+    "RUF100",  # unused-noqa
+    "D101",    # missing docstring in public class
+    "D102",    # missing docstring in public method
+    "D103",    # missing docstring in public function
     "D406",    # section-name-ends-in-colon (catches Google-style `Args:` blocks)
     "D407",    # dashed-underline-after-section (catches missing `------` underlines)
     "D410",    # no-blank-line-after-section (numpy section spacing)
     "D411",    # no-blank-line-before-section (numpy section spacing)
 ]
+# These typographic glyphs are intentional in user-facing strings, docstrings
+# and test fixtures (e.g. "5 × 10 grid", "ℹ info" headers, en-dashes in ranges).
+allowed-confusables = ["×", "ℹ", "–", "‑"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.lint.flake8-bugbear]
+extend-immutable-calls = [
+    "polars.col",
+    "polars.lit",
+    "polars.sum",
+    "polars.first",
+    "polars.last",
+    "polars.len",
+    "polars.count",
+    "pathlib.Path",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"python/pdstools/app/*" = ["D100", "D101", "D102", "D103", "T20"]
+"python/pdstools/ih/*" = ["D100", "D101", "D102", "D103"]
+"python/pdstools/infinity/*" = ["D100", "D101", "D102", "D103"]
+"python/pdstools/cli.py" = ["T20"]
+"python/tests/*" = ["D100", "D101", "D102", "D103", "RUF012"]
+"python/docs/*" = ["D100", "D101", "D102", "D103"]
+# Notebooks and one-off scripts: relax docstring + style rules outside the library
+"examples/**/*.ipynb" = ["D100", "D101", "D102", "D103", "E401", "E402", "E703", "E722", "F401", "F541", "F811", "F821", "B905", "RUF005", "RUF015", "RET505"]
+"scripts/*" = ["D100", "D101", "D102", "D103", "T20"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/python/pdstools/__init__.py
+++ b/python/pdstools/__init__.py
@@ -1,5 +1,7 @@
 """Pega Data Scientist Tools Python library"""
 
+from __future__ import annotations
+
 __version__ = "5.0.0"
 
 from pathlib import Path

--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -5,10 +5,8 @@ __all__ = ["ADMDatamart"]
 import datetime
 import logging
 import os
-from collections.abc import Iterable
 from functools import cached_property
 from pathlib import Path
-from collections.abc import Callable
 
 import polars as pl
 import polars.selectors as cs
@@ -17,13 +15,18 @@ from .. import pega_io
 from ..pega_io.File import read_dataflow_output, read_ds_export
 from ..utils import cdh_utils
 from ..utils.cdh_utils import _polars_capitalize
-from ..utils.types import QUERY
 from . import Schema
 from .trees import AGB
 from .Aggregates import Aggregates
 from .BinAggregator import BinAggregator
 from .Plots import Plots
 from .Reports import Reports
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    from collections.abc import Callable
+    from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -363,7 +366,7 @@ class ADMDatamart:
                     ["boto3"],
                     namespace="ADMDatamart.from_s3",
                     deps_group="pega_io",
-                )
+                ) from None
             boto3_client = boto3.client("s3", region_name=region)
 
         import tempfile
@@ -634,9 +637,7 @@ class ADMDatamart:
 
         df = cdh_utils._apply_schema_types(df, Schema.ADMModelSnapshot)
 
-        df = self._normalize_performance_scale(df)
-
-        return df
+        return self._normalize_performance_scale(df)
 
     def _validate_predictor_data(
         self,
@@ -667,8 +668,7 @@ class ADMDatamart:
             )  # actual categorization not passed in?
         df = cdh_utils._apply_schema_types(df, Schema.ADMPredictorBinningSnapshot)
 
-        df = self._normalize_performance_scale(df)
-        return df
+        return self._normalize_performance_scale(df)
 
     @staticmethod
     def _normalize_performance_scale(df: pl.LazyFrame) -> pl.LazyFrame:

--- a/python/pdstools/adm/Aggregates.py
+++ b/python/pdstools/adm/Aggregates.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 __all__ = ["Aggregates"]
-import datetime
 import logging
 from typing import TYPE_CHECKING, Literal
 
@@ -13,15 +12,18 @@ from ..utils.metric_limits import (
     get_standard_NBAD_channels,
     is_standard_NBAD_configuration,
 )
-from ..utils.types import QUERY
 
 if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    import datetime
     from .ADMDatamart import ADMDatamart
 
 logger = logging.getLogger(__name__)
 
 
 class Aggregates:
+    """Aggregates."""
+
     def __init__(self, datamart: "ADMDatamart"):
         self.datamart = datamart
 
@@ -133,10 +135,7 @@ class Aggregates:
 
         # Handle case where there are no predictors
         if len(unique_predictors) == 0:
-            if isinstance(by, str):
-                by_name = by
-            else:
-                by_name = by.meta.output_name()
+            by_name = by if isinstance(by, str) else by.meta.output_name()
             return pl.LazyFrame({by_name: []})
 
         if isinstance(by, str):
@@ -145,7 +144,7 @@ class Aggregates:
         else:
             by_col = by
             by_name = by.meta.output_name()
-        action_predictor = by_col.meta.root_names() + ["PredictorName"]
+        action_predictor = [*by_col.meta.root_names(), "PredictorName"]
 
         # Filter out null values in the grouping column to avoid transpose errors
         q = (
@@ -276,7 +275,7 @@ class Aggregates:
             return df
         if facets:
             return df.join(
-                df.group_by(facets + ["PredictorName"])
+                df.group_by([*facets, "PredictorName"])
                 .agg(cdh_utils.weighted_average_polars(metric, "ResponseCountBin"))
                 .filter(pl.col(metric).is_not_nan())
                 .group_by(*facets)
@@ -853,7 +852,7 @@ class Aggregates:
             )
             data = data.join(active_model_ids, on="ModelID", how="semi")
 
-        global_overview = (
+        return (
             data.filter(pl.col("EntryType") != "Classifier")
             .filter(BinIndex=1)
             .group_by("PredictorName", "PredictorCategory")
@@ -871,7 +870,6 @@ class Aggregates:
             )
             .sort("PredictorName")
         )
-        return global_overview
 
     def predictors_overview(
         self,
@@ -960,13 +958,11 @@ class Aggregates:
             default_aggs.extend(additional_aggregations)
 
         result = data.group_by(group_cols).agg(*default_aggs)
-        result = result.sort(
+        return result.sort(
             ["GroupIndex", "isActive", "Univariate Performance"],
             descending=[False, True, True],
             nulls_last=True,
         )
-
-        return result
 
         if model_id is not None:
             data = data.filter(pl.col("ModelID") == model_id)
@@ -999,13 +995,11 @@ class Aggregates:
             default_aggs.extend(additional_aggregations)
 
         result = data.group_by(group_cols).agg(*default_aggs)
-        result = result.sort(
+        return result.sort(
             ["GroupIndex", "isActive", "Univariate Performance"],
             descending=[False, True, True],
             nulls_last=True,
         )
-
-        return result
 
     def overall_summary(
         self,

--- a/python/pdstools/adm/BinAggregator.py
+++ b/python/pdstools/adm/BinAggregator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 __all__ = ["BinAggregator"]
 import logging
 from functools import cached_property
-from typing import TYPE_CHECKING, Literal, cast
+from typing import ClassVar, Literal, TYPE_CHECKING, cast
 
 import polars as pl
 
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class BinAggregator(LazyNamespace):
     """A class to generate rolled up insights from ADM predictor binning."""
 
-    dependencies = ["plotly", "numpy"]
+    dependencies: ClassVar[list[str]] = ["plotly", "numpy"]
     dependency_group = "adm"
 
     def __init__(self, datamart: "ADMDatamart") -> None:
@@ -34,6 +34,7 @@ class BinAggregator(LazyNamespace):
 
     @cached_property
     def all_predictorbinning(self):
+        """All predictorbinning."""
         data = self.dm.aggregates.last(table="combined_data")
         return self.normalize_all_binnings(data)
 
@@ -217,6 +218,7 @@ class BinAggregator(LazyNamespace):
         modelids,
         target_binning,
     ) -> pl.DataFrame:
+        """Accumulate num binnings."""
         for id in modelids:
             logger.debug(f"Model ID: {id}")
 
@@ -255,6 +257,7 @@ class BinAggregator(LazyNamespace):
         n_symbols,
         musthave_symbols,
     ) -> list:
+        """Create symbol list."""
         symbol_frequency = (
             self.all_predictorbinning.filter(pl.col("Type") != "numeric")
             .filter(pl.col("PredictorName") == predictor)
@@ -281,6 +284,7 @@ class BinAggregator(LazyNamespace):
         symbollist,
     ) -> pl.DataFrame:
         # All the bins for the given predictor, for the given models
+        """Accumulate sym binnings."""
         symbins = (
             self.all_predictorbinning.filter(pl.col("Type") != "numeric")
             .filter(pl.col("PredictorName") == predictor)
@@ -339,7 +343,7 @@ class BinAggregator(LazyNamespace):
         if "Lift" not in molten.columns:
             molten = molten.with_columns(Lift=pl.lit(0.0))
 
-        aggregate_binning = (
+        return (
             molten
             # take the mean lift for each symbol
             .group_by(["PredictorName", "Symbol"])
@@ -380,8 +384,6 @@ class BinAggregator(LazyNamespace):
         #         (pl.col("Lift") - pl.sum("Lift") / pl.len()).alias("Lift"),
         #     )
 
-        return aggregate_binning
-
     def normalize_all_binnings(self, combined_dm: pl.LazyFrame) -> pl.LazyFrame:
         """Prepare all predictor binning
 
@@ -392,7 +394,7 @@ class BinAggregator(LazyNamespace):
             r"[+\-]?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+\-]?\d+)?"  # matches numbers also with scientific notation
         )
 
-        binnings = (
+        return (
             combined_dm.filter(pl.col("EntryType") != "Classifier")
             .filter(pl.col("BinType") != "MISSING")  # ignore those on purpose
             .with_columns(
@@ -474,8 +476,6 @@ class BinAggregator(LazyNamespace):
             )
         ).sort(["ModelID", "PredictorName", "BinIndex"])
 
-        return binnings
-
     def create_empty_numbinning(
         self,
         predictor: str,
@@ -485,6 +485,7 @@ class BinAggregator(LazyNamespace):
         minimum: float | None = None,
         maximum: float | None = None,
     ) -> pl.DataFrame:
+        """Create empty numbinning."""
         import numpy as np
 
         # take min/max across all models
@@ -559,7 +560,7 @@ class BinAggregator(LazyNamespace):
 
         boundaries_arr = np.array(boundaries, dtype=np.float64)
 
-        target_binning = pl.DataFrame(
+        return pl.DataFrame(
             {
                 "PredictorName": predictor,
                 "BinIndex": list(range(1, len(boundaries_arr))),
@@ -579,9 +580,8 @@ class BinAggregator(LazyNamespace):
             pl.lit(0).alias("Models"),
         )
 
-        return target_binning
-
     def get_source_numbinning(self, predictor: str, modelid: str) -> pl.DataFrame:
+        """Get source numbinning."""
         is_model_immature = ((pl.sum("BinPositives") + pl.sum("BinNegatives")) < 200) | (pl.max("BinIndex") < 2)
 
         return (
@@ -611,6 +611,8 @@ class BinAggregator(LazyNamespace):
         source: pl.DataFrame,
         target: pl.DataFrame,
     ) -> pl.DataFrame:
+        """Combine two numbinnings."""
+
         class Interval:
             def __init__(self, lo, hi):
                 self.lo_ = lo
@@ -769,6 +771,7 @@ class BinAggregator(LazyNamespace):
         source: pl.DataFrame,
         target: pl.DataFrame,
     ) -> Figure:
+        """Plot binning attribution."""
         import plotly.express as px
 
         # create "long" dataframe with the upper and lower bounds of source and target
@@ -867,10 +870,14 @@ class BinAggregator(LazyNamespace):
         binning,
         col_facet=None,
         row_facet=None,
-        custom_data=["PredictorName", "BinSymbol"],
+        custom_data: list[str] | None = None,
         return_df=False,
     ) -> pl.DataFrame | Figure:
+        """Plot binning lift."""
         import plotly.express as px
+
+        if custom_data is None:
+            custom_data = ["PredictorName", "BinSymbol"]
 
         if not isinstance(binning, pl.LazyFrame):
             binning = binning.lazy()
@@ -968,6 +975,7 @@ class BinAggregator(LazyNamespace):
         return fig
 
     def plot_lift_binning(self, binning: pl.DataFrame) -> Figure:
+        """Plot lift binning."""
         if binning.columns[-1] == "Models":  # assuming Models is always the last column when not rolled up
             # printing a single binning, not rolled up
             topic = None

--- a/python/pdstools/adm/Plots/__init__.py
+++ b/python/pdstools/adm/Plots/__init__.py
@@ -25,7 +25,7 @@ Layout
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import ClassVar, TYPE_CHECKING
 
 from ...utils.namespaces import LazyNamespace
 from ...utils.plot_utils import fig_update_facet
@@ -74,7 +74,7 @@ class Plots(
     :class:`~pdstools.adm.ADMDatamart` instance.
     """
 
-    dependencies = ["plotly"]
+    dependencies: ClassVar[list[str]] = ["plotly"]
     dependency_group = "adm"
 
     def __init__(self, datamart: "ADMDatamart"):

--- a/python/pdstools/adm/Plots/_binning.py
+++ b/python/pdstools/adm/Plots/_binning.py
@@ -11,9 +11,12 @@ from ...utils.plot_utils import (
     abbreviate_label_expr,
     simplify_facet_titles,
 )
-from ...utils.types import QUERY
 from ._base import _PlotsBase
 from ._helpers import distribution_graph, requires
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...utils.types import QUERY
 
 
 class _BinningPlotsMixin(_PlotsBase):

--- a/python/pdstools/adm/Plots/_helpers.py
+++ b/python/pdstools/adm/Plots/_helpers.py
@@ -8,7 +8,6 @@ plotly building blocks reused by multiple mixins.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Iterable
 from functools import wraps
 from typing import (
     TYPE_CHECKING,
@@ -22,9 +21,10 @@ import polars as pl
 from typing_extensions import ParamSpec
 
 from ...utils.metric_limits import MetricLimits
-from ...utils.plot_utils import Figure
 
 if TYPE_CHECKING:
+    from ...utils.plot_utils import Figure
+    from collections.abc import Callable, Iterable
     from ._base import _PlotsBase
 
 logger = logging.getLogger(__name__)

--- a/python/pdstools/adm/Plots/_overview.py
+++ b/python/pdstools/adm/Plots/_overview.py
@@ -2,20 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Literal
-from collections.abc import Callable
+from typing import Literal, TYPE_CHECKING
 
 import polars as pl
 
 from ...utils import cdh_utils
 from ...utils.plot_utils import get_colorscale
-from ...utils.types import QUERY
 from ._base import _PlotsBase
 from ._helpers import (
     add_bottom_left_text_to_bubble_plot,
     add_metric_limit_lines,
     requires,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from ...utils.types import QUERY
 
 
 class _OverviewPlotsMixin(_PlotsBase):
@@ -127,7 +129,7 @@ class _OverviewPlotsMixin(_PlotsBase):
             facet_col=facet_name,
             facet_col_wrap=2,
             hover_name="Name",
-            hover_data=["ModelID"] + self.datamart.context_keys + ["LastUpdate"],
+            hover_data=["ModelID", *self.datamart.context_keys, "LastUpdate"],
             title=f"Bubble Chart {title}",
             template="pega",
             facet_row_spacing=0.01,
@@ -203,7 +205,7 @@ class _OverviewPlotsMixin(_PlotsBase):
 
         import plotly.express as px
 
-        context_keys = [px.Constant("All contexts")] + group_by
+        context_keys = [px.Constant("All contexts"), *group_by]
 
         colorscale = get_colorscale(metric)
 
@@ -224,7 +226,7 @@ class _OverviewPlotsMixin(_PlotsBase):
             "Weighted average Performance": ":.2%",
         }
 
-        fig = px.treemap(
+        return px.treemap(
             df.collect(),
             path=context_keys,
             color=label_map.get(metric),
@@ -234,8 +236,6 @@ class _OverviewPlotsMixin(_PlotsBase):
             color_continuous_scale=colorscale,
             range_color=[0.5, 1] if metric == "Performance" else None,
         )
-
-        return fig
 
     def action_overlap(
         self,
@@ -382,10 +382,7 @@ class _OverviewPlotsMixin(_PlotsBase):
         for facet in facets:
             combined_query = existing_query
             for k, v in facet.items():
-                if v is None:
-                    new_query = pl.col(k).is_null()
-                else:
-                    new_query = pl.col(k).eq(v)
+                new_query = pl.col(k).is_null() if v is None else pl.col(k).eq(v)
                 if combined_query is not None:
                     combined_query = cdh_utils._combine_queries(
                         combined_query,

--- a/python/pdstools/adm/Plots/_performance.py
+++ b/python/pdstools/adm/Plots/_performance.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
 
 import polars as pl
 
 from ...utils import cdh_utils
-from ...utils.plot_utils import Figure
-from ...utils.types import QUERY
 from ._base import _PlotsBase
 from ._helpers import add_metric_limit_lines, requires
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...utils.types import QUERY
+    from ...utils.plot_utils import Figure
+    from datetime import timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +147,7 @@ class _PerformancePlotsMixin(_PlotsBase):
 
         df = (
             df.with_columns(pl.col("SnapshotTime"))
-            .group_by(grouping_columns + ["SnapshotTime"])
+            .group_by([*grouping_columns, "SnapshotTime"])
             .agg(agg_expr)
             .sort("SnapshotTime", by_col)
         )
@@ -419,7 +422,7 @@ class _PerformancePlotsMixin(_PlotsBase):
         )
 
         # Configure axes and layout
-        fig = (
+        return (
             fig.update_yaxes(scaleanchor="x", scaleratio=1)
             .update_layout(
                 autosize=False,
@@ -430,8 +433,6 @@ class _PerformancePlotsMixin(_PlotsBase):
             .update_xaxes(tickformat=",.0%", constrain="domain", title="% of Population")
             .update_yaxes(tickformat=",.0%")
         )
-
-        return fig
 
     def performance_volume_distribution(
         self,
@@ -512,7 +513,7 @@ class _PerformancePlotsMixin(_PlotsBase):
                 .cut(breaks=[p for p in range(50, 100, bin_width)], left_closed=True)
                 .alias("PerformanceBinned"),
             )
-            .group_by(group_cols + ["PerformanceBinned"])
+            .group_by([*group_cols, "PerformanceBinned"])
             .agg(
                 pl.sum("ResponseCount"),
                 (pl.min("Performance") * 100).round(2).alias("break_label"),
@@ -527,7 +528,7 @@ class _PerformancePlotsMixin(_PlotsBase):
         else:
             df = df.with_columns((pl.col("ResponseCount") / pl.col("ResponseCount").sum()).alias("Proportion"))
 
-        collected_df: pl.DataFrame = df.sort(group_cols + ["PerformanceBinned", "Proportion"]).collect()
+        collected_df: pl.DataFrame = df.sort([*group_cols, "PerformanceBinned", "Proportion"]).collect()
 
         if return_df:
             return collected_df.lazy()
@@ -578,6 +579,4 @@ class _PerformancePlotsMixin(_PlotsBase):
         )
 
         # Apply legend color ordering
-        fig = cdh_utils.legend_color_order(fig)
-
-        return fig
+        return cdh_utils.legend_color_order(fig)

--- a/python/pdstools/adm/Plots/_predictors.py
+++ b/python/pdstools/adm/Plots/_predictors.py
@@ -7,9 +7,12 @@ import polars.selectors as cs
 
 from ...utils import cdh_utils
 from ...utils.plot_utils import get_colorscale
-from ...utils.types import QUERY
 from ._base import _PlotsBase
 from ._helpers import requires
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...utils.types import QUERY
 
 
 class _PredictorPlotsMixin(_PlotsBase):
@@ -80,7 +83,7 @@ class _PredictorPlotsMixin(_PlotsBase):
         legend_added = set()
 
         # Create a box plot for each predictor
-        for i, row in enumerate(pre_aggs.iter_rows(named=True)):
+        for _i, row in enumerate(pre_aggs.iter_rows(named=True)):
             show_in_legend = row[legend_col] not in legend_added
             if show_in_legend:
                 legend_added.add(row[legend_col])
@@ -376,7 +379,7 @@ class _PredictorPlotsMixin(_PlotsBase):
 
         import plotly.express as px
 
-        fig = px.bar(
+        return px.bar(
             df.collect(),
             x="Contribution",
             y=by,
@@ -385,7 +388,6 @@ class _PredictorPlotsMixin(_PlotsBase):
             template="pega",
             title="Contribution of different sources",
         )
-        return fig
 
     @requires(
         combined_columns={
@@ -500,7 +502,7 @@ class _PredictorPlotsMixin(_PlotsBase):
     def predictor_count(
         self,
         *,
-        by: str | list[str] = ["EntryType", "Type"],
+        by: str | list[str] | None = None,
         query: QUERY | None = None,
         return_df: bool = False,
     ):
@@ -532,6 +534,8 @@ class _PredictorPlotsMixin(_PlotsBase):
         >>> df = dm.plot.predictor_count(return_df=True)
 
         """
+        if by is None:
+            by = ["EntryType", "Type"]
         # Normalize to list[str] — if `by` is a bare string, treating it as
         # Iterable[str] would iterate over characters, giving wrong group_by keys.
         by_list: list[str] = [by] if isinstance(by, str) else by
@@ -541,13 +545,13 @@ class _PredictorPlotsMixin(_PlotsBase):
             query,
         ).filter(pl.col("EntryType") != "Classifier")
 
-        collected = df.group_by(["ModelID"] + by_list).agg(Count=pl.n_unique("PredictorName")).collect()
+        collected = df.group_by(["ModelID", *by_list]).agg(Count=pl.n_unique("PredictorName")).collect()
 
         if len(by_list) > 1:
             collected = pl.concat(
                 [
                     collected,
-                    collected.group_by(["ModelID"] + by_list[1:])
+                    collected.group_by(["ModelID", *by_list[1:]])
                     .agg(pl.col("Count").sum())
                     .with_columns(pl.lit("Overall").alias(by_list[0])),
                 ],

--- a/python/pdstools/adm/Plots/_score.py
+++ b/python/pdstools/adm/Plots/_score.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import polars as pl
 
 from ...utils import cdh_utils
-from ...utils.plot_utils import Figure
-from ...utils.types import QUERY
 from ._base import _PlotsBase
 from ._helpers import distribution_graph, requires
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...utils.types import QUERY
+    from ...utils.plot_utils import Figure
 
 
 class _ScorePlotsMixin(_PlotsBase):

--- a/python/pdstools/adm/Reports.py
+++ b/python/pdstools/adm/Reports.py
@@ -10,10 +10,8 @@ __all__ = ["ReportOptions", "Reports"]
 
 import logging
 import shutil
-from collections.abc import Callable
-from os import PathLike
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import ClassVar, Literal, TYPE_CHECKING
 
 import polars as pl
 from typing_extensions import TypedDict, Unpack
@@ -27,9 +25,11 @@ from ..utils.report_utils import (
     run_quarto,
     serialize_query,
 )
-from ..utils.types import QUERY
 
 if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    from os import PathLike
+    from collections.abc import Callable
     from ..prediction.Prediction import Prediction
     from .ADMDatamart import ADMDatamart
 
@@ -126,7 +126,7 @@ _HEALTH_CHECK_DEFAULTS: ReportOptions = {
 class Reports(LazyNamespace):
     """Report generation namespace attached to :class:`ADMDatamart` as ``dm.generate``."""
 
-    dependencies = ["yaml"]
+    dependencies: ClassVar[list[str]] = ["yaml"]
     dependency_group = "healthcheck"
 
     def __init__(self, datamart: ADMDatamart):

--- a/python/pdstools/adm/Schema.py
+++ b/python/pdstools/adm/Schema.py
@@ -4,6 +4,8 @@ import polars as pl
 
 
 class ADMModelSnapshot:
+    """Admmodel snapshot."""
+
     pxApplication = pl.Categorical
     pyAppliesToClass = pl.Categorical
     pyModelID = pl.Utf8
@@ -41,6 +43,8 @@ class ADMModelSnapshot:
 
 
 class ADMPredictorBinningSnapshot:
+    """Admpredictor binning snapshot."""
+
     pxCommitDateTime = pl.Datetime
     pxSaveDateTime = pl.Datetime
     pyModelID = pl.Utf8

--- a/python/pdstools/adm/__init__.py
+++ b/python/pdstools/adm/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .ADMDatamart import ADMDatamart
 
 __all__ = ["ADMDatamart"]

--- a/python/pdstools/adm/trees/_agb.py
+++ b/python/pdstools/adm/trees/_agb.py
@@ -11,11 +11,11 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from ...utils import cdh_utils
-from ...utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from ...utils.types import QUERY
     from ..ADMDatamart import ADMDatamart
     from ._multi import MultiTrees
 

--- a/python/pdstools/adm/trees/_model.py
+++ b/python/pdstools/adm/trees/_model.py
@@ -9,7 +9,6 @@ import logging
 import math
 import threading
 import zlib
-from collections.abc import Callable
 from functools import cached_property
 from math import exp
 from pathlib import Path
@@ -17,6 +16,7 @@ from statistics import mean, median, stdev
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     cast,
 )
 
@@ -31,6 +31,7 @@ from ._nodes import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     import pydot
 
 # Pinned to the original module path so existing log filters and the
@@ -154,10 +155,7 @@ class ADMTreesModel:
         context_keys: list | None = None,
     ) -> ADMTreesModel:
         """Load from a base64-encoded zlib-compressed datamart ``Modeldata`` blob."""
-        if isinstance(blob, str):
-            raw_bytes = base64.b64decode(blob)
-        else:
-            raw_bytes = blob
+        raw_bytes = base64.b64decode(blob) if isinstance(blob, str) else blob
         decompressed = zlib.decompress(raw_bytes)
         data = json.loads(decompressed)
         if not data.get("_serialClass", "").endswith("GbModel"):
@@ -211,8 +209,8 @@ class ADMTreesModel:
                 )
             variable = encoderkeys[int(predictor)]
             encoder = encoders[variable]
-            variable_type = list(encoder["encoder"].keys())[0]
-            to_decode = list(encoder["encoder"].values())[0]
+            variable_type = next(iter(encoder["encoder"].keys()))
+            to_decode = next(iter(encoder["encoder"].values()))
             if variable_type == "quantileArray":
                 val = quantile_decoder(to_decode, int(splitval))
             elif variable_type == "stringTranslator":
@@ -304,8 +302,8 @@ class ADMTreesModel:
         raise ValueError(f"Unsupported operator: {operator}")
 
     # Class-level dedupe so repeated per-row scoring failures don't spam logs.
-    _safe_eval_seen_errors: set[tuple[str, str]] = set()
-    _safe_eval_lock: threading.Lock = threading.Lock()
+    _safe_eval_seen_errors: ClassVar[set[tuple[str, str]]] = set()
+    _safe_eval_lock: ClassVar[threading.Lock] = threading.Lock()
 
     @staticmethod
     def _safe_condition_evaluate(
@@ -866,10 +864,7 @@ class ADMTreesModel:
         def _sign_and_values(raw: str) -> dict[str, Any]:
             split = parse_split(raw)
             sign = "in" if split.operator == "is" else split.operator
-            if isinstance(split.value, tuple):
-                values = set(split.value)
-            else:
-                values = {str(split.value)}
+            values = set(split.value) if isinstance(split.value, tuple) else {str(split.value)}
             return {"sign": sign, "values": values}
 
         return (
@@ -896,7 +891,7 @@ class ADMTreesModel:
             import plotly.graph_objects as go
             from plotly.subplots import make_subplots
         except ImportError:  # pragma: no cover
-            raise MissingDependenciesException(["plotly"], "AGB", deps_group="adm")
+            raise MissingDependenciesException(["plotly"], "AGB", deps_group="adm") from None
         figlist = []
         for (name,), data in self.gains_per_split.group_by("predictor"):
             if subset is None or name in subset:
@@ -1015,7 +1010,7 @@ class ADMTreesModel:
         try:
             import pydot
         except ImportError:  # pragma: no cover
-            raise MissingDependenciesException(["pydot"], "AGB", deps_group="adm")
+            raise MissingDependenciesException(["pydot"], "AGB", deps_group="adm") from None
         if isinstance(highlighted, dict):
             highlighted = self.get_visited_nodes(tree_number, highlighted)[0]
         else:  # pragma: no cover
@@ -1033,7 +1028,7 @@ class ADMTreesModel:
                         members_label: str = str(set(members))
                     else:
                         totallen = len(self.all_values_per_split[split_obj.variable])
-                        members_label = f"{list(members[:2]) + ['...']} ({len(members)}/{totallen})"
+                        members_label = f"{[*list(members[:2]), '...']} ({len(members)}/{totallen})"
                     label += f"\nSplit: {split_obj.variable} in {members_label}\nGain: {node['gain']}"
                 else:
                     label += f"\nSplit: {node['split']}\nGain: {node['gain']}"
@@ -1065,7 +1060,7 @@ class ADMTreesModel:
             except ImportError:
                 raise ValueError(
                     "IPython not installed, please install it using your package manager (e.g. `pip install IPython`).",
-                )
+                ) from None
             try:
                 # pydot.Dot.create_png is generated dynamically (one method per
                 # Graphviz output format) and isn't visible to static type
@@ -1163,7 +1158,7 @@ class ADMTreesModel:
             import plotly.express as px
             import plotly.graph_objects as go
         except ImportError:  # pragma: no cover
-            raise MissingDependenciesException(["plotly"], "AGB", deps_group="adm")
+            raise MissingDependenciesException(["plotly"], "AGB", deps_group="adm") from None
 
         scores = (
             self.get_all_visited_nodes(x)
@@ -1242,7 +1237,7 @@ class ADMTreesModel:
         try:
             import plotly.express as px
         except ImportError:  # pragma: no cover
-            raise MissingDependenciesException(["plotly"], "AGB", deps_group="adm")
+            raise MissingDependenciesException(["plotly"], "AGB", deps_group="adm") from None
         if predictor_categorization is not None:  # pragma: no cover
             to_plot = self.compute_categorization_over_time(predictor_categorization)[0]
         else:

--- a/python/pdstools/adm/trees/_multi.py
+++ b/python/pdstools/adm/trees/_multi.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import logging
 import multiprocessing
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import polars as pl
 
 from ._model import ADMTreesModel
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/adm/trees/_nodes.py
+++ b/python/pdstools/adm/trees/_nodes.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 SplitOperator = Literal["<", ">", "==", "in", "is"]
 _SPLIT_OPERATORS: frozenset[str] = frozenset({"<", ">", "==", "in", "is"})
@@ -140,8 +142,5 @@ def _traverse(d: Any, path: tuple) -> Any:
     """Walk a nested dict/list using the given key/index path; raise KeyError on miss."""
     cur = d
     for key in path:
-        if isinstance(key, int):
-            cur = cur[key]
-        else:
-            cur = cur[key]
+        cur = cur[key] if isinstance(key, int) else cur[key]
     return cur

--- a/python/pdstools/adm/trees/_nodes.py
+++ b/python/pdstools/adm/trees/_nodes.py
@@ -88,7 +88,7 @@ def parse_split(raw: str) -> Split:
         # Single-value 'in', 'is', '==' — keep as a string.
         value = value_text
 
-    return Split(variable=variable, operator=cast(SplitOperator, op), value=value, raw=raw)
+    return Split(variable=variable, operator=cast("SplitOperator", op), value=value, raw=raw)
 
 
 @dataclass(frozen=True)

--- a/python/pdstools/app/decision_analyzer/Home.py
+++ b/python/pdstools/app/decision_analyzer/Home.py
@@ -5,6 +5,8 @@ Thin router on top of ``st.navigation()`` — keeps actual page content
 out of the script body so navigation can choose which page to run.
 """
 
+from __future__ import annotations
+
 from pdstools.app.decision_analyzer._navigation import build_navigation
 
 build_navigation().run()

--- a/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
+++ b/python/pdstools/app/decision_analyzer/da_streamlit_utils.py
@@ -142,7 +142,7 @@ def stage_selectbox(
     stage_options = options if options is not None else da.get_possible_stage_values()
     mapping = da.stage_to_group_mapping  # empty dict when level != "Stage"
 
-    if mapping:
+    if mapping:  # noqa: SIM108 — lambda assignment reads better as if/else
         format_func = lambda s: f"{mapping.get(s, '?')}  ·  {s}"  # noqa: E731
     else:
         format_func = str
@@ -763,11 +763,10 @@ def get_available_channel_directions(sample_df: pl.LazyFrame) -> list[str]:
     if "Direction" in schema:
         combos = sample_df.select(pl.struct("Channel", "Direction")).unique().collect().to_series().to_list()
         return sorted([f"{c['Channel']}/{c['Direction']}" for c in combos])
-    elif "Channel" in schema:
+    if "Channel" in schema:
         channels = sample_df.select("Channel").unique().collect().to_series().to_list()
         return sorted(channels)
-    else:
-        return []
+    return []
 
 
 def collect_page_filters() -> list[pl.Expr]:
@@ -840,7 +839,7 @@ def channel_direction_selector():
         st.session_state.page_channel_filter = "Any"
         st.session_state.page_channel_expr = None
 
-    options = ["Any"] + available
+    options = ["Any", *available]
 
     st.selectbox(
         "Channel / Direction",

--- a/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/10_Arbitration_Distribution.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/decision_analyzer/pages/11_Arbitration_Distribution.py
 import polars as pl
 import streamlit as st

--- a/python/pdstools/app/decision_analyzer/pages/11_Single_Decision.py
+++ b/python/pdstools/app/decision_analyzer/pages/11_Single_Decision.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/decision_analyzer/pages/12_Single_Decision.py
 import html as html_mod
 from itertools import groupby

--- a/python/pdstools/app/decision_analyzer/pages/12_About.py
+++ b/python/pdstools/app/decision_analyzer/pages/12_About.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/decision_analyzer/pages/13_About.py
 from pdstools.utils.streamlit_utils import show_about_page, standard_page_config
 

--- a/python/pdstools/app/decision_analyzer/pages/2_Overview.py
+++ b/python/pdstools/app/decision_analyzer/pages/2_Overview.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import polars as pl
 import streamlit as st
 from pdstools.app.decision_analyzer.da_streamlit_utils import (

--- a/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
+++ b/python/pdstools/app/decision_analyzer/pages/3_Action_Distribution.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import polars as pl
 import streamlit as st
 

--- a/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
+++ b/python/pdstools/app/decision_analyzer/pages/4_Action_Funnel.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/decision_analyzer/pages/5_Action_Funnel.py
 import polars as pl
 import streamlit as st

--- a/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
+++ b/python/pdstools/app/decision_analyzer/pages/5_Global_Sensitivity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import polars as pl
 import streamlit as st
 from pdstools.app.decision_analyzer.da_streamlit_utils import collect_page_filters, contextual_filters, ensure_data

--- a/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import polars as pl
 import streamlit as st
 from pdstools.app.decision_analyzer.da_streamlit_utils import (

--- a/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/6_Win_Loss_Analysis.py
@@ -275,7 +275,7 @@ if st.session_state.local_filters != []:
             col_data = arb_data
             for prev in others_filters:
                 col_data = col_data.filter(prev)
-            options = ["All"] + sorted(col_data.select(col_name).unique().collect().get_column(col_name).to_list())
+            options = ["All", *sorted(col_data.select(col_name).unique().collect().get_column(col_name).to_list())]
             with selector_cols[idx]:
                 selected = st.selectbox(
                     col_name,

--- a/python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/decision_analyzer/pages/7_Optionality_Analysis.py
 import polars as pl
 import streamlit as st

--- a/python/pdstools/app/decision_analyzer/pages/8_Offer_Quality_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/8_Offer_Quality_Analysis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/decision_analyzer/pages/8_Offer_Quality_Analysis.py
 import polars as pl
 import streamlit as st

--- a/python/pdstools/app/decision_analyzer/pages/9_Thresholding_Analysis.py
+++ b/python/pdstools/app/decision_analyzer/pages/9_Thresholding_Analysis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/decision_analyzer/pages/9_Thresholding_Analysis.py
 import math
 

--- a/python/pdstools/app/health_check/Home.py
+++ b/python/pdstools/app/health_check/Home.py
@@ -5,6 +5,8 @@ Thin router on top of ``st.navigation()`` — keeps actual page content
 out of the script body so navigation can choose which page to run.
 """
 
+from __future__ import annotations
+
 from pdstools.app.health_check._navigation import build_navigation
 
 build_navigation().run()

--- a/python/pdstools/app/health_check/hc_streamlit_utils.py
+++ b/python/pdstools/app/health_check/hc_streamlit_utils.py
@@ -15,7 +15,6 @@ from pathlib import Path
 import streamlit as st
 
 from pdstools import pega_io
-from pdstools.adm.ADMDatamart import ADMDatamart
 from pdstools.utils.streamlit_utils import (
     _apply_sidebar_logo,
     cached_datamart,
@@ -24,6 +23,10 @@ from pdstools.utils.streamlit_utils import (
     cached_sample_prediction,
     get_data_path,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pdstools.adm.ADMDatamart import ADMDatamart
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/app/health_check/pages/1_Data_Filters.py
+++ b/python/pdstools/app/health_check/pages/1_Data_Filters.py
@@ -32,7 +32,7 @@ if uploaded_file:
     import io
 
     imported_filters = json.load(uploaded_file)
-    for key, val in imported_filters.items():
+    for _key, val in imported_filters.items():
         # Convert the JSON string to a StringIO object and specify the format as 'json'
         json_str = json.dumps(val)
         str_io = io.StringIO(json_str)

--- a/python/pdstools/app/health_check/pages/1_Data_Filters.py
+++ b/python/pdstools/app/health_check/pages/1_Data_Filters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import polars as pl

--- a/python/pdstools/app/health_check/pages/2_Reports.py
+++ b/python/pdstools/app/health_check/pages/2_Reports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 from datetime import datetime

--- a/python/pdstools/app/health_check/pages/2_Reports.py
+++ b/python/pdstools/app/health_check/pages/2_Reports.py
@@ -167,7 +167,7 @@ if st.session_state["dm"].predictor_data is not None:
             st.write("Please choose the models for which you wish to generate a report")
             edited_df = st.data_editor(
                 st.session_state["model_selection_df"],
-                disabled=st.session_state["dm"].context_keys + ["Name"],
+                disabled=[*st.session_state["dm"].context_keys, "Name"],
             )
             st.session_state["only_active_predictors"] = st.checkbox(
                 label="Show only active predictors",

--- a/python/pdstools/app/health_check/pages/3_About.py
+++ b/python/pdstools/app/health_check/pages/3_About.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/health_check/pages/3_About.py
 from pdstools.utils.streamlit_utils import show_about_page, standard_page_config
 

--- a/python/pdstools/app/impact_analyzer/Home.py
+++ b/python/pdstools/app/impact_analyzer/Home.py
@@ -5,6 +5,8 @@ Thin router on top of ``st.navigation()`` — keeps actual page content
 out of the script body so navigation can choose which page to run.
 """
 
+from __future__ import annotations
+
 from pdstools.app.impact_analyzer._navigation import build_navigation
 
 build_navigation().run()

--- a/python/pdstools/app/impact_analyzer/_home_page.py
+++ b/python/pdstools/app/impact_analyzer/_home_page.py
@@ -88,10 +88,7 @@ def _show_data_summary(ia, is_sample_data: bool = False):
         # and VBD data has Application, Value, Outcome columns)
         has_vbd_markers = {"Application", "Value", "Outcome"}.issubset(schema_names)
 
-        if has_vbd_markers:
-            format_label = "**VBD Scenario Planner**"
-        else:
-            format_label = "**PDC Export**"
+        format_label = "**VBD Scenario Planner**" if has_vbd_markers else "**PDC Export**"
     except (pl.exceptions.PolarsError, AttributeError, KeyError):
         format_label = "**Unknown format**"
 
@@ -101,10 +98,7 @@ def _show_data_summary(ia, is_sample_data: bool = False):
             ia.ia_data.select(pl.col("Channel").n_unique()).collect().item() if "Channel" in schema_names else "N/A"
         )
 
-        if is_sample_data:
-            prefix = "Sample data loaded"
-        else:
-            prefix = "Data loaded successfully"
+        prefix = "Sample data loaded" if is_sample_data else "Data loaded successfully"
 
         st.success(f"{prefix}. Detected format: {format_label}\n\n**{rows:,}** rows · **{channels}** channels")
     except (pl.exceptions.PolarsError, AttributeError, KeyError):

--- a/python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
+++ b/python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
@@ -1,10 +1,11 @@
 """Health Check-specific Streamlit helpers."""
 
+from __future__ import annotations
+
 # python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
 import logging
 import tempfile
 import urllib.request
-from collections.abc import Iterable
 from pathlib import Path
 
 import streamlit as st
@@ -14,6 +15,10 @@ from pdstools.utils.streamlit_utils import (
     _apply_sidebar_logo,
     get_data_path,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
+++ b/python/pdstools/app/impact_analyzer/ia_streamlit_utils.py
@@ -191,15 +191,13 @@ def load_from_upload_auto(uploaded_file, outcome_labels_json: str | None = None)
 
     if format_type == "pdc":
         return load_pdc_from_uploads([uploaded_file])
-    elif format_type == "vbd":
+    if format_type == "vbd":
         return load_vbd_from_upload(uploaded_file, outcome_labels_json=outcome_labels_json)
-    else:
-        # Fall back to extension-based detection
-        if suffix == ".zip":
-            return load_vbd_from_upload(uploaded_file, outcome_labels_json=outcome_labels_json)
-        else:
-            # Try PDC as default for .json/.ndjson
-            return load_pdc_from_uploads([uploaded_file])
+    # Fall back to extension-based detection
+    if suffix == ".zip":
+        return load_vbd_from_upload(uploaded_file, outcome_labels_json=outcome_labels_json)
+    # Try PDC as default for .json/.ndjson
+    return load_pdc_from_uploads([uploaded_file])
 
 
 @st.cache_resource
@@ -530,9 +528,9 @@ def handle_data_path_ia() -> ImpactAnalyzer | None:
     suffix = p.suffix.lower()
     if suffix in {".json", ".ndjson"}:
         return load_pdc_from_paths((str(p),))
-    elif suffix == ".xlsx":
+    if suffix == ".xlsx":
         return load_excel_from_path(str(p))
-    elif suffix == ".zip":
+    if suffix == ".zip":
         # Auto-load persisted outcome aliases from sidecar file
         st.session_state["ia_data_source_path"] = str(p)
         persisted = load_outcome_aliases(str(p))
@@ -543,12 +541,11 @@ def handle_data_path_ia() -> ImpactAnalyzer | None:
             loaded_from = next((c for c in _outcome_aliases_candidates(str(p)) if c.exists()), None)
             st.session_state["ia_outcome_aliases_loaded_from"] = str(loaded_from) if loaded_from else str(p)
         return load_vbd_from_path(str(p), outcome_labels_json=outcome_labels_json)
-    else:
-        st.error(
-            f"Unsupported file type: {suffix}. Use JSON/NDJSON (monitoring export), "
-            "XLSX (Excel monitoring export), or ZIP (scenario-planner export)."
-        )
-        return None
+    st.error(
+        f"Unsupported file type: {suffix}. Use JSON/NDJSON (monitoring export), "
+        "XLSX (Excel monitoring export), or ZIP (scenario-planner export)."
+    )
+    return None
 
 
 def prepare_and_save_random(

--- a/python/pdstools/app/impact_analyzer/pages/1_Overall_Summary.py
+++ b/python/pdstools/app/impact_analyzer/pages/1_Overall_Summary.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/impact_analyzer/pages/1_Overall_Summary.py
 import streamlit as st
 

--- a/python/pdstools/app/impact_analyzer/pages/2_Trend.py
+++ b/python/pdstools/app/impact_analyzer/pages/2_Trend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/impact_analyzer/pages/2_Trend.py
 import streamlit as st
 

--- a/python/pdstools/app/impact_analyzer/pages/3_About.py
+++ b/python/pdstools/app/impact_analyzer/pages/3_About.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/app/impact_analyzer/pages/3_About.py
 from pdstools.utils.streamlit_utils import show_about_page, standard_page_config
 

--- a/python/pdstools/app/launcher/Home.py
+++ b/python/pdstools/app/launcher/Home.py
@@ -20,6 +20,8 @@ avoid collisions between tools that share page names — Streamlit's
 an underscore separator instead.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import streamlit as st

--- a/python/pdstools/app/launcher/__init__.py
+++ b/python/pdstools/app/launcher/__init__.py
@@ -7,3 +7,5 @@ Each tool keeps its own per-section sidebar group via
 that share page names. Standalone tool launches keep their original
 URLs intact so existing bookmarks don't break.
 """
+
+from __future__ import annotations

--- a/python/pdstools/app/launcher/_about.py
+++ b/python/pdstools/app/launcher/_about.py
@@ -7,6 +7,8 @@ sidebar (one per tool section). Standalone tool launches keep
 their own About page via ``pages(include_about=True)``.
 """
 
+from __future__ import annotations
+
 from pdstools.utils.streamlit_utils import show_about_page, standard_page_config
 
 standard_page_config(page_title="About · pdstools")

--- a/python/pdstools/cli.py
+++ b/python/pdstools/cli.py
@@ -50,6 +50,7 @@ ALIASES = {
 
 
 def create_parser():
+    """Create parser."""
     parser = argparse.ArgumentParser(
         description="Command line utility to run pdstools apps.",
     )
@@ -228,6 +229,7 @@ def main():
     # Formalised subcommand shape. Backwards-compat: ``pdstools [app]`` and
     # bare ``pdstools`` (interactive) still work — anything that isn't a
     # known subcommand is routed to ``run``.
+    """Main."""
     if len(sys.argv) > 1 and sys.argv[1] in _SUBCOMMANDS:
         sub = sys.argv[1]
         if sub == "doctor":
@@ -265,7 +267,7 @@ def main():
 
     if typos:
         print("\n⚠️  Warning: Possible typo(s) in pdstools arguments:\n", file=sys.stderr)
-        for typo, suggestion, similarity in typos:
+        for typo, suggestion, _similarity in typos:
             print(f"  '{typo}' → Did you mean '{suggestion}'?", file=sys.stderr)
 
         print("\nAvailable pdstools arguments:", file=sys.stderr)
@@ -280,6 +282,7 @@ def main():
 
 def run(args, unknown):
     # Configure logging based on environment variable
+    """Run."""
     log_level = os.environ.get("PDSTOOLS_LOG_LEVEL", "WARNING").upper()
     numeric_level = getattr(logging, log_level, logging.WARNING)
     logging.basicConfig(

--- a/python/pdstools/cli.py
+++ b/python/pdstools/cli.py
@@ -13,6 +13,10 @@ import logging
 import os
 import sys
 from importlib import resources
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 from pdstools import __version__
 
@@ -316,10 +320,11 @@ def run(args, unknown):
     # back to the numeric prompt only when questionary isn't installed
     # or stdin isn't a TTY.
     if args.app is None and sys.stdin.isatty():
+        questionary: ModuleType | None
         try:
             import questionary
         except ImportError:
-            questionary = None  # type: ignore[assignment]
+            questionary = None
         if questionary is not None:
             choice = questionary.select(
                 "Select an app to run:",

--- a/python/pdstools/cli.py
+++ b/python/pdstools/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 # python/pdstools/decision_analyzer/DecisionAnalyzer.py
-from typing import ClassVar
+from typing import ClassVar, TYPE_CHECKING
 from functools import cached_property
 import logging
-import os
 import warnings
 
 import polars as pl
@@ -26,6 +27,9 @@ from .utils import (
     resolve_aliases,
 )
 from ..pega_io.File import read_ds_export
+
+if TYPE_CHECKING:
+    import os
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1,4 +1,5 @@
 # python/pdstools/decision_analyzer/DecisionAnalyzer.py
+from typing import ClassVar
 from functools import cached_property
 import logging
 import os
@@ -166,7 +167,7 @@ class DecisionAnalyzer:
 
     # Preferred fields for data filtering, in display order.
     # Subsetting to actual available columns happens in __init__.
-    _default_filter_fields = [
+    _default_filter_fields: ClassVar[list[str]] = [
         "Decision Time",
         "Channel",
         "Direction",
@@ -281,7 +282,7 @@ class DecisionAnalyzer:
         validation_result, validation_error = validate_columns(raw_data, table_def)
         self.validation_error = validation_error if not validation_result else None
         if not validation_result and validation_error is not None:
-            warnings.warn(validation_error, UserWarning)
+            warnings.warn(validation_error, UserWarning, stacklevel=2)
         # Bail out early if critical columns are missing — _cleanup_raw_data
         # would crash with an opaque ColumnNotFoundError otherwise.
         # Check using display names; account for both raw keys and display
@@ -954,14 +955,13 @@ class DecisionAnalyzer:
                 ]
             )
 
-        preproc_df = (
+        return (
             df.with_columns(pl.col(pl.Categorical).cast(pl.Utf8))
             .with_columns(
                 pl.col(self.level).cast(pl.Categorical),
             )
             .filter(pl.col("Action").is_not_null())  # Drop rows with null Action; this takes some processing time
         )
-        return preproc_df
 
     def get_possible_scope_values(self) -> list[str]:
         """Return scope hierarchy columns present in the data (e.g. Issue, Group, Action)."""
@@ -970,14 +970,13 @@ class DecisionAnalyzer:
 
     def get_possible_stage_values(self) -> list[str]:
         """Return the list of available stage values for the current level."""
-        options = self.AvailableNBADStages
+        return self.AvailableNBADStages
         # TODO figure out how to get the actual possible values, should be available from the enum directly
         # [
         #     stage
         #     for stage in self.NBADStages_FilterView
         #     if stage in df['pxEgagementStage'].categories
         # ]
-        return options
 
     @property
     def stage_to_group_mapping(self) -> dict[str, str]:

--- a/python/pdstools/decision_analyzer/__init__.py
+++ b/python/pdstools/decision_analyzer/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from . import plots, utils
 from .DecisionAnalyzer import DecisionAnalyzer
 

--- a/python/pdstools/decision_analyzer/_aggregates.py
+++ b/python/pdstools/decision_analyzer/_aggregates.py
@@ -65,13 +65,11 @@ class Aggregates:
             stage: aggregate_over_remaining_stages(df, stage, self.da.AvailableNBADStages[i:])
             for (i, stage) in enumerate(self.da.AvailableNBADStages)
         }
-        remaining_view = (
+        return (
             pl.concat(aggs.values())
             .with_columns(pl.col(self.da.level).cast(stage_orders.collect_schema()[self.da.level]))
             .join(stage_orders, on=self.da.level, how="left")
         )
-
-        return remaining_view
 
     def get_distribution_data(
         self,
@@ -95,7 +93,7 @@ class Aggregates:
         pl.LazyFrame
             Columns from *grouping_levels* plus ``Decisions``, sorted descending.
         """
-        distribution_data = (
+        return (
             apply_filter(self.da.preaggregated_remaining_view, additional_filters)
             .filter(pl.col(self.da.level) == stage)
             .group_by(grouping_levels)
@@ -103,8 +101,6 @@ class Aggregates:
             .sort("Decisions", descending=True)
             .filter(pl.col("Decisions") > 0)
         )
-
-        return distribution_data
 
     def get_funnel_data(
         self, scope: str, additional_filters: pl.Expr | list[pl.Expr] | None = None
@@ -326,9 +322,9 @@ class Aggregates:
             )
             summary = pl.concat([synthetic_row, summary], how="diagonal_relaxed")
 
-        display_stage_order = [synthetic_label] + stages
+        display_stage_order = [synthetic_label, *stages]
         display_stage_index = {name: idx for idx, name in enumerate(display_stage_order)}
-        summary = (
+        return (
             summary.with_columns(
                 (pl.col("Filtered Actions") / pl.col("Filtered Actions").sum() * 100)
                 .round(1)
@@ -354,7 +350,6 @@ class Aggregates:
                 "% Decisions without Actions",
             )
         )
-        return summary
 
     def get_optionality_data(self, df: pl.LazyFrame | None = None, by_day: bool = False) -> pl.LazyFrame:
         """Average number of actions per stage, optionally broken down by day.
@@ -411,14 +406,12 @@ class Aggregates:
             )
             .drop("interaction_count")
         )
-        optionality_data = pl.concat(
+        return pl.concat(
             [
                 per_offer_count_and_stage,
                 zero_actions.select(per_offer_count_and_stage.collect_schema().names()),
             ]
         ).sort("nOffers", descending=True)
-
-        return optionality_data
 
     def get_optionality_funnel(self, df: pl.LazyFrame | None = None) -> pl.LazyFrame:
         """Optionality funnel: interaction counts bucketed by available-action count.
@@ -437,7 +430,7 @@ class Aggregates:
         """
         if df is None:
             df = self.da.sample
-        optionality_funnel = (
+        return (
             self.get_optionality_data(df)
             .with_columns(
                 pl.when(pl.col("nOffers") >= 7)
@@ -452,7 +445,6 @@ class Aggregates:
             .agg(pl.sum("Interactions"))
             .sort([self.da.level, "available_actions"])
         )
-        return optionality_funnel
 
     def get_action_variation_data(
         self,
@@ -668,7 +660,7 @@ class Aggregates:
 
             # Add stage to all customers and join
             stage_customers = all_customers.with_columns(pl.lit(stage).cast(pl.Categorical).alias(self.da.level))
-            stage_df = stage_customers.join(stage_df, on=group_by + [self.da.level], how="left").with_columns(
+            stage_df = stage_customers.join(stage_df, on=[*group_by, self.da.level], how="left").with_columns(
                 pl.col(
                     "no_of_offers", "new_models", "poor_propensity_offers", "poor_priority_offers", "good_offers"
                 ).fill_null(0)
@@ -680,7 +672,7 @@ class Aggregates:
         # Determine if stage has propensity scores available (ActionPropensity and later)
         has_propensity = pl.col(self.da.level).is_in(self.da.stages_with_propensity)
 
-        stage_df = stage_df.with_columns(
+        return stage_df.with_columns(
             has_no_offers=pl.when(pl.col("no_of_offers") == 0).then(pl.lit(1)).otherwise(pl.lit(0)),
             # For stages WITH propensity: classify as relevant (green) or irrelevant (orange)
             atleast_one_relevant_action=pl.when(has_propensity & (pl.col("good_offers") >= 1))
@@ -696,7 +688,6 @@ class Aggregates:
             .then(pl.lit(1))
             .otherwise(pl.lit(0)),
         )
-        return stage_df
 
     def filtered_action_counts(
         self,
@@ -790,15 +781,13 @@ class Aggregates:
         stages = self.da.AvailableNBADStages[self.da.AvailableNBADStages.index(stage) :]
         group_by = ["day"] if scope is None else ["day", scope]
 
-        trend_data = (
+        return (
             apply_filter(self.da.sample, additional_filters)
             .filter(pl.col(self.da.level).is_in(stages))
             .group_by(group_by)
             .agg(pl.n_unique("Interaction ID").alias("Decisions"))
             .sort(group_by)
         )
-
-        return trend_data
 
     def get_filter_component_data(
         self, top_n: int, additional_filters: pl.Expr | list[pl.Expr] | None = None
@@ -836,7 +825,7 @@ class Aggregates:
             )
             .collect()
         )
-        result = pl.concat(
+        return pl.concat(
             pl.collect_all(
                 [
                     x.lazy().top_k(top_n, by="Filtered Decisions").sort("Filtered Decisions", descending=False)
@@ -844,8 +833,6 @@ class Aggregates:
                 ]
             )
         ).with_columns(pl.col(pl.Categorical).cast(pl.Utf8))
-
-        return result
 
     def get_component_action_impact(
         self,
@@ -883,7 +870,7 @@ class Aggregates:
         scope_idx = scope_hierarchy.index(scope) if scope in scope_hierarchy else 2
         scope_cols = scope_hierarchy[: scope_idx + 1]
 
-        group_cols = ["Component Name", self.da.level] + scope_cols
+        group_cols = ["Component Name", self.da.level, *scope_cols]
         available = set(filtered_data.collect_schema().names())
         group_cols = [c for c in group_cols if c in available]
 
@@ -1006,9 +993,8 @@ class Aggregates:
         stage_order = pl.DataFrame(
             {self.da.level: self.da.AvailableNBADStages, "_stage_order": list(range(len(self.da.AvailableNBADStages)))}
         )
-        tbl = (
+        return (
             tbl.join(stage_order, on=self.da.level, how="left")
             .sort("_stage_order", nulls_last=True)
             .drop("_stage_order")
         )
-        return tbl

--- a/python/pdstools/decision_analyzer/_scoring.py
+++ b/python/pdstools/decision_analyzer/_scoring.py
@@ -88,7 +88,7 @@ class Scoring:
             else:
                 fill_exprs.append(pl.lit(default).alias(col_name))
 
-        rank_df = (
+        return (
             apply_filter(
                 self.da.sample.with_columns(fill_exprs),
                 additional_filters,
@@ -104,8 +104,6 @@ class Scoring:
             )
             .with_columns(*rank_exprs)
         )
-
-        return rank_df
 
     def get_selected_group_rank_boundaries(
         self,
@@ -228,7 +226,7 @@ class Scoring:
                 self.da._sensitivity_cache[win_rank] = sensitivity
         return sensitivity
 
-    def get_thresholding_data(self, fld: str, quantile_range=range(10, 100, 10)) -> pl.DataFrame:
+    def get_thresholding_data(self, fld: str, quantile_range: range | None = None) -> pl.DataFrame:
         """Quantile-based thresholding analysis at Arbitration.
 
         Computes counts and threshold values at each quantile for the given
@@ -247,6 +245,8 @@ class Scoring:
             Long-format table with columns ``Decile``, ``Count``,
             ``Threshold``, and the stage-level column.
         """
+        if quantile_range is None:
+            quantile_range = range(10, 100, 10)
         cache_key = (fld, tuple(quantile_range))
         if cache_key in self.da._thresholding_cache:
             return self.da._thresholding_cache[cache_key]
@@ -335,7 +335,7 @@ class Scoring:
         available = set(self.da.sample.collect_schema().names())
         cols = [c for c in PRIO_COMPONENTS if c in available]
         df = self._remaining_at_stage(stage, additional_filters=additional_filters)
-        return df.select([granularity] + cols).sort(granularity)
+        return df.select([granularity, *cols]).sort(granularity)
 
     def get_win_loss_distribution_data(
         self,
@@ -391,14 +391,12 @@ class Scoring:
                 )
             )
 
-            group_level_win_losses = group_level_win_losses.unpivot(
+            return group_level_win_losses.unpivot(
                 index=level,
                 on=["Wins", "Losses"],
                 variable_name="Status",
                 value_name="Percentage",
             ).sort(["Status", "Percentage"], descending=True)
-
-            return group_level_win_losses
 
         if status not in {"Wins", "Losses"}:
             raise ValueError("When group_filter is provided, status must be either 'Wins' or 'Losses'.")
@@ -761,7 +759,7 @@ class Scoring:
             # Return baseline distribution only
             original_winners = self.re_rank(
                 additional_filters=pl.col(self.da.level).is_in(self.da.stages_from_arbitration_down),
-            ).select(["Issue", "Group", "Action"] + ["Interaction ID", "Rank"])
+            ).select(["Issue", "Group", "Action", "Interaction ID", "Rank"])
 
             result = (
                 original_winners.group_by(["Issue", "Group", "Action"])
@@ -798,52 +796,49 @@ class Scoring:
                 result = pl.concat([result, no_winner_row])
 
             return result
-        else:
-            # Return both baseline and lever-adjusted distribution
-            recalculated_winners = self.re_rank(
-                overrides=[
-                    (pl.when(lever_condition).then(pl.lit(lever_value)).otherwise(pl.col("Levers"))).alias("Levers")
-                ],
-                additional_filters=pl.col(self.da.level).is_in(self.da.stages_from_arbitration_down),
-            ).select(["Issue", "Group", "Action"] + ["Interaction ID", "Rank", "rank_PVCL"])
+        # Return both baseline and lever-adjusted distribution
+        recalculated_winners = self.re_rank(
+            overrides=[
+                (pl.when(lever_condition).then(pl.lit(lever_value)).otherwise(pl.col("Levers"))).alias("Levers")
+            ],
+            additional_filters=pl.col(self.da.level).is_in(self.da.stages_from_arbitration_down),
+        ).select(["Issue", "Group", "Action", "Interaction ID", "Rank", "rank_PVCL"])
 
-            result_lf = (
-                recalculated_winners.group_by(["Issue", "Group", "Action"])
-                .agg(
-                    original_win_count=pl.col("Rank").filter(pl.col("Rank") == 1).len(),
-                    new_win_count=pl.col("rank_PVCL").filter(pl.col("rank_PVCL") == 1).len(),
-                    n_decisions_survived_to_arbitration=pl.col("Interaction ID").n_unique(),
-                )
-                .with_columns(
-                    selected_action=pl.when(lever_condition).then(pl.lit("Selected")).otherwise(pl.lit("Rest"))
-                )
+        result_lf = (
+            recalculated_winners.group_by(["Issue", "Group", "Action"])
+            .agg(
+                original_win_count=pl.col("Rank").filter(pl.col("Rank") == 1).len(),
+                new_win_count=pl.col("rank_PVCL").filter(pl.col("rank_PVCL") == 1).len(),
+                n_decisions_survived_to_arbitration=pl.col("Interaction ID").n_unique(),
             )
-            result = result_lf.collect().sort("new_win_count", descending=True)
+            .with_columns(selected_action=pl.when(lever_condition).then(pl.lit("Selected")).otherwise(pl.lit("Rest")))
+        )
+        result = result_lf.collect().sort("new_win_count", descending=True)
 
-            # Add no winner count if all_interactions is provided
-            if all_interactions is not None:
-                # Calculate no winner count based on new ranking
-                new_winner_df = recalculated_winners.filter(pl.col("rank_PVCL") == 1).select("Interaction ID").collect()
-                interactions_with_new_winners = new_winner_df.n_unique()
-                no_winner_count = max(0, all_interactions - interactions_with_new_winners)  # Ensure non-negative
+        # Add no winner count if all_interactions is provided
+        if all_interactions is not None:
+            # Calculate no winner count based on new ranking
+            new_winner_df = recalculated_winners.filter(pl.col("rank_PVCL") == 1).select("Interaction ID").collect()
+            interactions_with_new_winners = new_winner_df.n_unique()
+            no_winner_count = max(0, all_interactions - interactions_with_new_winners)  # Ensure non-negative
 
-                # Create a row with the same data types as the result
-                no_winner_data = {
-                    "Issue": ["No Winner"],
-                    "Group": ["No Winner"],
-                    "Action": ["No Winner"],
-                    "original_win_count": [0],  # No winner has no original wins
-                    "new_win_count": [no_winner_count],
-                    "n_decisions_survived_to_arbitration": [0],
-                    "selected_action": ["No Winner"],
-                }
+            # Create a row with the same data types as the result
+            no_winner_data = {
+                "Issue": ["No Winner"],
+                "Group": ["No Winner"],
+                "Action": ["No Winner"],
+                "original_win_count": [0],  # No winner has no original wins
+                "new_win_count": [no_winner_count],
+                "n_decisions_survived_to_arbitration": [0],
+                "selected_action": ["No Winner"],
+            }
 
-                # Cast to match result schema
-                no_winner_row = pl.DataFrame(no_winner_data).cast({k: v for k, v in result.schema.items()})
+            # Cast to match result schema
+            no_winner_row = pl.DataFrame(no_winner_data).cast({k: v for k, v in result.schema.items()})
 
-                result = pl.concat([result, no_winner_row])
+            result = pl.concat([result, no_winner_row])
 
-            return result
+        return result
 
     def find_lever_value(
         self,
@@ -899,8 +894,7 @@ class Scoring:
             selected_wins = selected_wins_df.height
             selected_total_df = ranked_df.select("Interaction ID").collect()
             selected_total = selected_total_df.height
-            percentage = (selected_wins / selected_total) * 100
-            return percentage
+            return (selected_wins / selected_total) * 100
 
         beginning_high = high
         beginning_low = low
@@ -914,7 +908,7 @@ class Scoring:
                 f"Target {target_win_percentage}% is too low. Even at lever {beginning_low}, your actions win in {low_percentage:.1f}% of interactions at arbitration."
                 "You might have interactions where only your selected actions survive until arbitration. So they will win no matter what."
             )
-        elif target_win_percentage > high_percentage:
+        if target_win_percentage > high_percentage:
             raise ValueError(
                 f"Target {target_win_percentage}% is too high. Even at lever {beginning_high}, you only get {high_percentage:.1f}%. "
                 f"You can increase the search range."
@@ -930,5 +924,4 @@ class Scoring:
             else:
                 high = mid
 
-        final_lever = (low + high) / 2
-        return final_lever
+        return (low + high) / 2

--- a/python/pdstools/decision_analyzer/column_schema.py
+++ b/python/pdstools/decision_analyzer/column_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/decision_analyzer/column_schema.py
 from typing import TypedDict
 

--- a/python/pdstools/decision_analyzer/column_schema.py
+++ b/python/pdstools/decision_analyzer/column_schema.py
@@ -7,6 +7,8 @@ import polars as pl
 
 
 class TableConfig(TypedDict):
+    """Table config."""
+
     display_name: str
     default: bool
     type: type[pl.DataType]

--- a/python/pdstools/decision_analyzer/data_read_utils.py
+++ b/python/pdstools/decision_analyzer/data_read_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/decision_analyzer/data_read_utils.py
 import gzip
 import logging
@@ -8,8 +10,11 @@ from pathlib import Path
 import polars as pl
 
 from ..pega_io.File import _is_artifact
-from .column_schema import TableConfig
 from .utils import ColumnResolver
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .column_schema import TableConfig
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/decision_analyzer/plots/__init__.py
+++ b/python/pdstools/decision_analyzer/plots/__init__.py
@@ -19,6 +19,8 @@ supported import surface. Imports such as
 unchanged.
 """
 
+from __future__ import annotations
+
 # ruff: noqa: F401
 # Re-export the module-level imports that the legacy single-file module
 # exposed via ``dir(plots)``. Some downstream code relied on these

--- a/python/pdstools/decision_analyzer/plots/_common.py
+++ b/python/pdstools/decision_analyzer/plots/_common.py
@@ -1,5 +1,7 @@
 """Shared constants and helpers for decision-analyzer plot submodules."""
 
+from __future__ import annotations
+
 DEFAULT_BOXPLOT_POINT_CAP = 20000
 
 

--- a/python/pdstools/decision_analyzer/plots/_components.py
+++ b/python/pdstools/decision_analyzer/plots/_components.py
@@ -1,5 +1,7 @@
 """Component / filter analysis plots."""
 
+from __future__ import annotations
+
 import plotly.express as px
 import plotly.graph_objects as go
 import polars as pl

--- a/python/pdstools/decision_analyzer/plots/_components.py
+++ b/python/pdstools/decision_analyzer/plots/_components.py
@@ -353,7 +353,7 @@ def plot_component_overview(value_data: pl.LazyFrame, components: list[str], gra
         fig.add_annotation(text="No component columns available", showarrow=False)
         return fig
 
-    collected = value_data.select([granularity] + components).collect()
+    collected = value_data.select([granularity, *components]).collect()
     groups = collected.get_column(granularity).unique().sort().to_list()
 
     n_cols = min(3, len(components))

--- a/python/pdstools/decision_analyzer/plots/_distribution.py
+++ b/python/pdstools/decision_analyzer/plots/_distribution.py
@@ -15,15 +15,14 @@ def distribution_as_treemap(self, df: pl.LazyFrame, stage: str, scope_options: l
         primary_scope = scope_options[0]
         color_discrete_map = self._decision_data.color_mappings.get(primary_scope)
 
-    fig = px.treemap(
+    return px.treemap(
         df.collect(),
-        path=[px.Constant(f"All Actions {stage}")] + scope_options,
+        path=[px.Constant(f"All Actions {stage}"), *scope_options],
         values="Decisions",
         template="pega",
         color=scope_options[0] if scope_options else None,
         color_discrete_map=color_discrete_map,
     ).update_traces(root_color="lightgrey")
-    return fig
 
 
 def action_variation(self, stage="Final", color_by=None, return_df=False):

--- a/python/pdstools/decision_analyzer/plots/_distribution.py
+++ b/python/pdstools/decision_analyzer/plots/_distribution.py
@@ -1,5 +1,7 @@
 """Distribution-style plots: treemap, action variation, histograms, rank/parameter boxplots."""
 
+from __future__ import annotations
+
 import plotly.express as px
 import plotly.graph_objects as go
 import polars as pl

--- a/python/pdstools/decision_analyzer/plots/_funnel.py
+++ b/python/pdstools/decision_analyzer/plots/_funnel.py
@@ -1,5 +1,7 @@
 """Funnel plots: optionality funnel, decision funnel, decisions-without-actions."""
 
+from __future__ import annotations
+
 import plotly.express as px
 import plotly.graph_objects as go
 import polars as pl

--- a/python/pdstools/decision_analyzer/plots/_funnel.py
+++ b/python/pdstools/decision_analyzer/plots/_funnel.py
@@ -85,7 +85,7 @@ def decision_funnel(
     synthetic_first_stage = "Available Actions"
     passing_stage_order = stage_order
     if stage_order and stage_order[0] != synthetic_first_stage:
-        passing_stage_order = [synthetic_first_stage] + stage_order
+        passing_stage_order = [synthetic_first_stage, *stage_order]
 
     available_collected = available_df.with_columns(
         pl.col(self._decision_data.level).cast(pl.Utf8),

--- a/python/pdstools/decision_analyzer/plots/_offer_quality.py
+++ b/python/pdstools/decision_analyzer/plots/_offer_quality.py
@@ -1,5 +1,7 @@
 """Offer-quality pie charts and trend chart (free functions, not Plot methods)."""
 
+from __future__ import annotations
+
 import math
 
 import plotly.express as px

--- a/python/pdstools/decision_analyzer/plots/_optionality.py
+++ b/python/pdstools/decision_analyzer/plots/_optionality.py
@@ -1,5 +1,7 @@
 """Optionality / propensity-vs-optionality plots."""
 
+from __future__ import annotations
+
 import plotly.express as px
 import plotly.graph_objects as go
 import polars as pl

--- a/python/pdstools/decision_analyzer/plots/_sensitivity.py
+++ b/python/pdstools/decision_analyzer/plots/_sensitivity.py
@@ -150,7 +150,7 @@ def prio_factor_boxplots(
         keep_selected = pl.col("segment") == "Comparison Group"
         others_match = others_filter if isinstance(others_filter, pl.Expr) else pl.all_horizontal(others_filter)
         tagged = tagged.filter(keep_selected | others_match)
-    segmented_df = tagged.select(prio_factors + ["segment"]).collect()
+    segmented_df = tagged.select([*prio_factors, "segment"]).collect()
     warning_message = None
     if segmented_df.height > point_cap:
         segmented_df = segmented_df.sample(n=point_cap, shuffle=True, seed=1)

--- a/python/pdstools/decision_analyzer/plots/_sensitivity.py
+++ b/python/pdstools/decision_analyzer/plots/_sensitivity.py
@@ -1,5 +1,7 @@
 """Sensitivity / threshold / prioritization-factor boxplot methods."""
 
+from __future__ import annotations
+
 import plotly.express as px
 import plotly.graph_objects as go
 import polars as pl

--- a/python/pdstools/decision_analyzer/plots/_trend.py
+++ b/python/pdstools/decision_analyzer/plots/_trend.py
@@ -1,5 +1,7 @@
 """Trend plots."""
 
+from __future__ import annotations
+
 import plotly.express as px
 import plotly.graph_objects as go
 import polars as pl

--- a/python/pdstools/decision_analyzer/plots/_winloss.py
+++ b/python/pdstools/decision_analyzer/plots/_winloss.py
@@ -158,7 +158,7 @@ def create_win_distribution_plot(
 
             if no_winner_data.height > 0:
                 group_cols = list(cast(list[str], scope_config["group_cols"]))
-                columns_to_keep = group_cols + [win_count_col]
+                columns_to_keep = [*group_cols, win_count_col]
                 no_winner_data_selected = no_winner_data.select(columns_to_keep)
                 plot_data = pl.concat([aggregated_regular, no_winner_data_selected])
             else:
@@ -166,7 +166,7 @@ def create_win_distribution_plot(
         else:
             if no_winner_data.height > 0:
                 group_cols = list(cast(list[str], scope_config["group_cols"]))
-                columns_to_keep = group_cols + [win_count_col]
+                columns_to_keep = [*group_cols, win_count_col]
                 plot_data = no_winner_data.select(columns_to_keep)
             else:
                 plot_data = pl.DataFrame()

--- a/python/pdstools/decision_analyzer/plots/_winloss.py
+++ b/python/pdstools/decision_analyzer/plots/_winloss.py
@@ -1,5 +1,7 @@
 """Win/loss distribution plots."""
 
+from __future__ import annotations
+
 from typing import cast
 
 import plotly.graph_objects as go
@@ -157,7 +159,7 @@ def create_win_distribution_plot(
             )
 
             if no_winner_data.height > 0:
-                group_cols = list(cast(list[str], scope_config["group_cols"]))
+                group_cols = list(cast("list[str]", scope_config["group_cols"]))
                 columns_to_keep = [*group_cols, win_count_col]
                 no_winner_data_selected = no_winner_data.select(columns_to_keep)
                 plot_data = pl.concat([aggregated_regular, no_winner_data_selected])
@@ -165,7 +167,7 @@ def create_win_distribution_plot(
                 plot_data = aggregated_regular
         else:
             if no_winner_data.height > 0:
-                group_cols = list(cast(list[str], scope_config["group_cols"]))
+                group_cols = list(cast("list[str]", scope_config["group_cols"]))
                 columns_to_keep = [*group_cols, win_count_col]
                 plot_data = no_winner_data.select(columns_to_keep)
             else:

--- a/python/pdstools/decision_analyzer/stage_grouping.py
+++ b/python/pdstools/decision_analyzer/stage_grouping.py
@@ -11,6 +11,8 @@ from typing import TypedDict
 
 
 class StageGroupDef(TypedDict):
+    """Stage group def."""
+
     display_name: str
     stages: dict[str, str]  # internal Stage_pyName -> display name
 

--- a/python/pdstools/decision_analyzer/stage_grouping.py
+++ b/python/pdstools/decision_analyzer/stage_grouping.py
@@ -7,6 +7,8 @@ If a value from the data has no entry here, ``get_display_name`` falls back
 to the raw value so future pipeline stages are handled gracefully.
 """
 
+from __future__ import annotations
+
 from typing import TypedDict
 
 

--- a/python/pdstools/decision_analyzer/utils.py
+++ b/python/pdstools/decision_analyzer/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # python/pdstools/decision_analyzer/utils.py
 import logging
 import os

--- a/python/pdstools/decision_analyzer/utils.py
+++ b/python/pdstools/decision_analyzer/utils.py
@@ -107,7 +107,7 @@ class ColumnResolver:
             if raw_col in remaining_columns:
                 self.rename_mapping[raw_col] = display_name
 
-        for raw_col, config in self.table_definition.items():
+        for _raw_col, config in self.table_definition.items():
             display_name = config["display_name"]
             if display_name in resolved_targets and display_name not in self.final_columns:
                 self.final_columns.append(display_name)
@@ -141,7 +141,7 @@ SCOPE_HIERARCHY = ["Issue", "Group", "Action"]
 PRIO_FACTORS = ["Propensity", "Value", "Context Weight", "Levers"]
 
 # All prioritization components including the computed Priority itself.
-PRIO_COMPONENTS = PRIO_FACTORS + ["Priority"]
+PRIO_COMPONENTS = [*PRIO_FACTORS, "Priority"]
 
 
 def apply_filter(df: pl.LazyFrame, filters: pl.Expr | list[pl.Expr] | None = None):
@@ -162,7 +162,7 @@ def apply_filter(df: pl.LazyFrame, filters: pl.Expr | list[pl.Expr] | None = Non
 
     if filters is None:
         return df
-    elif isinstance(filters, pl.Expr):
+    if isinstance(filters, pl.Expr):
         df = _apply(filters, df)
 
     elif isinstance(filters, list) and all(isinstance(i, pl.Expr) for i in filters):
@@ -175,6 +175,7 @@ def apply_filter(df: pl.LazyFrame, filters: pl.Expr | list[pl.Expr] | None = Non
 
 
 def area_under_curve(df: pl.DataFrame, col_x: str, col_y: str):
+    """Area under curve."""
     return (
         df.with_columns(
             ((pl.col(col_y) + pl.col(col_y).shift(1)) / 2).alias("MeanY"),
@@ -187,6 +188,7 @@ def area_under_curve(df: pl.DataFrame, col_x: str, col_y: str):
 
 
 def gini_coefficient(df: pl.DataFrame, col_x: str, col_y: str):
+    """Gini coefficient."""
     return area_under_curve(df, col_x, col_y) * 2 - 1
 
 
@@ -363,6 +365,7 @@ def _cast_columns(df: pl.LazyFrame, type_mapping: dict[str, type[pl.DataType]]) 
 
 
 def get_table_definition(table: str):
+    """Get table definition."""
     mapping = {
         "decision_analyzer": DecisionAnalyzer,
         "explainability_extract": ExplainabilityExtract,
@@ -417,7 +420,7 @@ def create_hierarchical_selectors(
     filtered_by_issue = data.filter(pl.col("Issue") == current_issue)
     groups_df = filtered_by_issue.select("Group").unique().collect()
     available_groups = groups_df.get_column("Group").to_list()
-    group_options = ["All"] + available_groups
+    group_options = ["All", *available_groups]
     group_index = 0  # Default to "All"
     if selected_group and selected_group in group_options:
         group_index = group_options.index(selected_group)
@@ -433,7 +436,7 @@ def create_hierarchical_selectors(
 
     actions_df = filtered_by_issue_group.select("Action").unique().collect()
     available_actions = actions_df.get_column("Action").to_list()
-    action_options = ["All"] + available_actions
+    action_options = ["All", *available_actions]
     action_index = 0  # Default to "All"
     if selected_action and selected_action in action_options:
         action_index = action_options.index(selected_action)
@@ -480,7 +483,7 @@ def get_scope_config(
             "selected_value": selected_action,
             "plot_title_prefix": "Win Count by Action",
         }
-    elif selected_group != "All":
+    if selected_group != "All":
         return {
             "level": "Group",
             "lever_condition": (pl.col("Issue") == selected_issue) & (pl.col("Group") == selected_group),
@@ -489,15 +492,14 @@ def get_scope_config(
             "selected_value": selected_group,
             "plot_title_prefix": "Win Count by Group",
         }
-    else:
-        return {
-            "level": "Issue",
-            "lever_condition": pl.col("Issue") == selected_issue,
-            "group_cols": ["Issue"],
-            "x_col": "Issue",
-            "selected_value": selected_issue,
-            "plot_title_prefix": "Win Count by Issue",
-        }
+    return {
+        "level": "Issue",
+        "lever_condition": pl.col("Issue") == selected_issue,
+        "group_cols": ["Issue"],
+        "x_col": "Issue",
+        "selected_value": selected_issue,
+        "plot_title_prefix": "Win Count by Issue",
+    }
 
 
 _INTERACTION_ID_RAW_KEY = "pxInteractionID"
@@ -576,8 +578,7 @@ def _determine_output_directory(source_path: str | None, output_dir: str | None)
                 if os.access(parent_dir, os.W_OK):
                     logger.info("Using source parent directory for output: %s", parent_dir)
                     return parent_dir
-                else:
-                    logger.debug("Source parent directory %s is not writeable, using fallback", parent_dir)
+                logger.debug("Source parent directory %s is not writeable, using fallback", parent_dir)
             except Exception as e:
                 logger.debug("Error checking writeability of %s: %s", parent_dir, e)
 
@@ -962,7 +963,7 @@ def prepare_and_save(
     new_metadata = {
         **existing_metadata,
         b"pdstools:source_file": original_source.encode("utf-8"),
-        b"pdstools:sample_percentage": f"{sample_percentage:.2f}".encode("utf-8"),
+        b"pdstools:sample_percentage": f"{sample_percentage:.2f}".encode(),
         b"pdstools:sample_percentage_method": method.encode("utf-8"),
     }
 
@@ -1024,7 +1025,7 @@ def resolve_filter_column(
         for raw_key, config in schema.items():
             display = config["display_name"]
             aliases = config.get("aliases", [])
-            all_names = [display] + aliases
+            all_names = [display, *aliases]
 
             if any(n.lower() == name_lower for n in all_names):
                 # Found a schema match -- check if raw_key is in the data
@@ -1186,7 +1187,7 @@ def format_count_for_filename(count: int) -> str:
     """
     if count < 1000:
         return str(count)
-    elif count < 1_000_000:
+    if count < 1_000_000:
         # Thousands
         value = count / 1000
         rounded = round(value)
@@ -1197,19 +1198,17 @@ def format_count_for_filename(count: int) -> str:
             rounded_m = round(millions)
             if rounded_m >= 10:
                 return f"{rounded_m}M"
-            elif rounded_m >= 1:
+            if rounded_m >= 1:
                 # For values 1-9M, show as integer if it rounds cleanly
                 return f"{rounded_m}M"
-            else:
-                formatted = f"{millions:.1f}".rstrip("0").rstrip(".")
-                return f"{formatted}M"
-        elif rounded >= 10:
+            formatted = f"{millions:.1f}".rstrip("0").rstrip(".")
+            return f"{formatted}M"
+        if rounded >= 10:
             return f"{rounded}k"
-        else:
-            # Use 1 decimal for < 10
-            formatted = f"{value:.1f}".rstrip("0").rstrip(".")
-            return f"{formatted}k"
-    elif count < 1_000_000_000:
+        # Use 1 decimal for < 10
+        formatted = f"{value:.1f}".rstrip("0").rstrip(".")
+        return f"{formatted}k"
+    if count < 1_000_000_000:
         # Millions
         value = count / 1_000_000
         rounded = round(value)
@@ -1220,27 +1219,23 @@ def format_count_for_filename(count: int) -> str:
             rounded_b = round(billions)
             if rounded_b >= 10:
                 return f"{rounded_b}B"
-            elif rounded_b >= 1:
+            if rounded_b >= 1:
                 # For values 1-9B, show as integer if it rounds cleanly
                 return f"{rounded_b}B"
-            else:
-                formatted = f"{billions:.1f}".rstrip("0").rstrip(".")
-                return f"{formatted}B"
-        elif rounded >= 10:
-            return f"{rounded}M"
-        else:
-            formatted = f"{value:.1f}".rstrip("0").rstrip(".")
-            return f"{formatted}M"
-    else:
-        # Billions
-        value = count / 1_000_000_000
-        rounded = round(value)
-
-        if rounded >= 10:
-            return f"{rounded}B"
-        else:
-            formatted = f"{value:.1f}".rstrip("0").rstrip(".")
+            formatted = f"{billions:.1f}".rstrip("0").rstrip(".")
             return f"{formatted}B"
+        if rounded >= 10:
+            return f"{rounded}M"
+        formatted = f"{value:.1f}".rstrip("0").rstrip(".")
+        return f"{formatted}M"
+    # Billions
+    value = count / 1_000_000_000
+    rounded = round(value)
+
+    if rounded >= 10:
+        return f"{rounded}B"
+    formatted = f"{value:.1f}".rstrip("0").rstrip(".")
+    return f"{formatted}B"
 
 
 def should_cache_source(source_path: str | None) -> bool:

--- a/python/pdstools/explanations/Aggregate.py
+++ b/python/pdstools/explanations/Aggregate.py
@@ -2,7 +2,7 @@ __all__ = ["Aggregate"]
 
 import logging
 import pathlib
-from typing import TYPE_CHECKING, cast
+from typing import ClassVar, TYPE_CHECKING, cast
 
 import polars as pl
 
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
 
 
 class Aggregate(LazyNamespace):
-    dependencies = ["polars"]
+    """Aggregate."""
+
+    dependencies: ClassVar[list[str]] = ["polars"]
     dependency_group = "explanations"
 
     def __init__(self, explanations: "Explanations"):
@@ -193,6 +195,7 @@ class Aggregate(LazyNamespace):
         context_infos: list[ContextInfo] | None = None,
         with_partition_col: bool = False,
     ) -> list[ContextInfo]:
+        """Get unique contexts list."""
         return self.context_operations.get_list(context_infos, with_partition_col)
 
     def _load_data(self):

--- a/python/pdstools/explanations/Aggregate.py
+++ b/python/pdstools/explanations/Aggregate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = ["Aggregate"]
 
 import logging

--- a/python/pdstools/explanations/Explanations.py
+++ b/python/pdstools/explanations/Explanations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = ["Explanations"]
 
 import logging

--- a/python/pdstools/explanations/ExplanationsUtils.py
+++ b/python/pdstools/explanations/ExplanationsUtils.py
@@ -13,7 +13,7 @@ __all__ = [
 
 import json
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, TypedDict, cast
+from typing import ClassVar, Literal, TYPE_CHECKING, TypedDict, cast
 
 import polars as pl
 
@@ -134,6 +134,8 @@ ContributionType = SortBy
 
 
 class ContextInfo(TypedDict):
+    """Context info."""
+
     context_key: str
     context_value: str
 
@@ -190,7 +192,7 @@ class ContextOperations(LazyNamespace):
 
     """
 
-    dependencies = ["polars"]
+    dependencies: ClassVar[list[str]] = ["polars"]
     dependency_group = "explanations"
 
     def __init__(self, aggregate: "Aggregate"):
@@ -224,6 +226,7 @@ class ContextOperations(LazyNamespace):
         self.initialized = True
 
     def get_context_keys(self) -> list[str]:
+        """Get context keys."""
         self._load()
         assert self._context_keys is not None
         return self._context_keys
@@ -286,4 +289,5 @@ class ContextOperations(LazyNamespace):
 
     @staticmethod
     def get_context_info_str(context_info: ContextInfo, sep: str = "-") -> str:
+        """Get context info str."""
         return sep.join(f"{value}".strip() for value in context_info.values())

--- a/python/pdstools/explanations/ExplanationsUtils.py
+++ b/python/pdstools/explanations/ExplanationsUtils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = [
     "_COL",
     "_CONTRIBUTION_TYPE",

--- a/python/pdstools/explanations/FilterWidget.py
+++ b/python/pdstools/explanations/FilterWidget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = ["FilterWidget"]
 
 from collections import OrderedDict
@@ -7,9 +9,9 @@ from IPython.display import display
 from ipywidgets import widgets
 
 from ..utils.namespaces import LazyNamespace
-from .ExplanationsUtils import ContextInfo, ContextOperations
 
 if TYPE_CHECKING:
+    from .ExplanationsUtils import ContextInfo, ContextOperations
     from .Explanations import Explanations
 
 

--- a/python/pdstools/explanations/FilterWidget.py
+++ b/python/pdstools/explanations/FilterWidget.py
@@ -1,7 +1,7 @@
 __all__ = ["FilterWidget"]
 
 from collections import OrderedDict
-from typing import TYPE_CHECKING, cast
+from typing import ClassVar, TYPE_CHECKING, cast
 
 from IPython.display import display
 from ipywidgets import widgets
@@ -14,7 +14,9 @@ if TYPE_CHECKING:
 
 
 class FilterWidget(LazyNamespace):
-    dependencies = ["ipywidgets"]
+    """Filter widget."""
+
+    dependencies: ClassVar[list[str]] = ["ipywidgets"]
     dependency_group = "explanations"
 
     _ANY_CONTEXT = "Any"
@@ -162,10 +164,12 @@ class FilterWidget(LazyNamespace):
 
     def _get_context_combobox_widgets(self) -> dict[str, widgets.Combobox]:
         ctx_options = {
-            ctx_key_name: [self._ANY_CONTEXT]
-            + sorted(
-                set(cast("dict[str, str]", context_info)[ctx_key_name] for context_info in self._filtered_list),
-            )
+            ctx_key_name: [
+                self._ANY_CONTEXT,
+                *sorted(
+                    set(cast("dict[str, str]", context_info)[ctx_key_name] for context_info in self._filtered_list)
+                ),
+            ]
             for ctx_key_name in (self._selected_context_key or {}).keys()
         }
 

--- a/python/pdstools/explanations/Plots.py
+++ b/python/pdstools/explanations/Plots.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 __all__ = ["Plots"]
 
 import logging
-from typing import TYPE_CHECKING, Literal, cast, overload
+from typing import ClassVar, Literal, TYPE_CHECKING, cast, overload
 
 import polars as pl
 
@@ -26,7 +26,9 @@ if TYPE_CHECKING:
 
 
 class Plots(LazyNamespace):
-    dependencies = ["numpy", "plotly"]
+    """Plots."""
+
+    dependencies: ClassVar[list[str]] = ["numpy", "plotly"]
     dependency_group = "explanations"
 
     X_AXIS_TITLE_DEFAULT = "Contribution"
@@ -112,8 +114,8 @@ class Plots(LazyNamespace):
                 **common_kwargs,
             )
 
-            plots = [overall_plot] + predictor_plots
-            for plot in [context_plot] + plots:
+            plots = [overall_plot, *predictor_plots]
+            for plot in [context_plot, *plots]:
                 plot.show()
 
             return context_plot, plots
@@ -137,7 +139,7 @@ class Plots(LazyNamespace):
             **common_kwargs,
         )
 
-        plots = [overall_plot] + predictor_plots
+        plots = [overall_plot, *predictor_plots]
         for plot in plots:
             plot.show()
 
@@ -186,6 +188,7 @@ class Plots(LazyNamespace):
         remaining: bool = True,
         include_numeric_single_bin: bool = False,
     ) -> tuple[go.Figure, list[go.Figure]] | tuple[pl.DataFrame, pl.DataFrame]:
+        """Plot contributions for overall."""
         display_by_enum = _resolve_contribution_type(display_by)
         agg_kwargs = {
             "sort_by": sort_by,
@@ -278,6 +281,7 @@ class Plots(LazyNamespace):
         remaining: bool = True,
         include_numeric_single_bin: bool = False,
     ) -> tuple[go.Figure, go.Figure, list[go.Figure]] | tuple[pl.DataFrame, pl.DataFrame]:
+        """Plot contributions by context."""
         display_by_enum = _resolve_contribution_type(display_by)
         agg_kwargs = {
             "sort_by": sort_by,

--- a/python/pdstools/explanations/Preprocess.py
+++ b/python/pdstools/explanations/Preprocess.py
@@ -6,7 +6,7 @@ import pathlib
 from datetime import timedelta
 from glob import glob
 from importlib.resources import files as resources_files
-from typing import TYPE_CHECKING
+from typing import ClassVar, TYPE_CHECKING
 
 import duckdb
 import polars as pl
@@ -23,7 +23,9 @@ if TYPE_CHECKING:
 
 
 class Preprocess(LazyNamespace):
-    dependencies = ["duckdb", "polars"]
+    """Preprocess."""
+
+    dependencies: ClassVar[list[str]] = ["duckdb", "polars"]
     dependency_group = "explanations"
 
     SEP = ", "
@@ -459,8 +461,7 @@ class Preprocess(LazyNamespace):
         if len(self.selected_files) == 0:
             self._populate_selected_files()
 
-        q = ", ".join([f"'{x}'" for x in self.selected_files])
-        return q
+        return ", ".join([f"'{x}'" for x in self.selected_files])
 
     def _populate_selected_files(self):
         # If data_file is provided, use it directly (supports URLs and local files)
@@ -531,7 +532,7 @@ class Preprocess(LazyNamespace):
             self.selected_files = [str(local_path)]
             logger.info("Downloaded file:= \n %s", self.selected_files)
         except Exception as e:
-            raise ValueError(f"Failed to download file from {file_url}: {e}")
+            raise ValueError(f"Failed to download file from {file_url}: {e}") from e
 
     def _execute_query(self, query: str):
         """Execute a query on the in-memory DuckDB connection."""

--- a/python/pdstools/explanations/Preprocess.py
+++ b/python/pdstools/explanations/Preprocess.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = ["Preprocess"]
 
 import logging

--- a/python/pdstools/explanations/Reports.py
+++ b/python/pdstools/explanations/Reports.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import ClassVar, TYPE_CHECKING
 
 import yaml  # type: ignore[import-untyped]  # types-PyYAML not in project deps
 
@@ -29,7 +29,9 @@ if TYPE_CHECKING:
 
 
 class Reports(LazyNamespace):
-    dependencies = ["yaml"]
+    """Reports."""
+
+    dependencies: ClassVar[list[str]] = ["yaml"]
     dependency_group = "explanations"
 
     def __init__(self, explanations: "Explanations"):

--- a/python/pdstools/explanations/Reports.py
+++ b/python/pdstools/explanations/Reports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = ["Reports"]
 
 import logging

--- a/python/pdstools/explanations/__init__.py
+++ b/python/pdstools/explanations/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .Explanations import Explanations
 
 __all__ = [

--- a/python/pdstools/explanations/resources/__init__.py
+++ b/python/pdstools/explanations/resources/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 # Resources package for explanations module

--- a/python/pdstools/ih/Aggregates.py
+++ b/python/pdstools/ih/Aggregates.py
@@ -1,8 +1,8 @@
 """Aggregation methods for Interaction History analysis."""
 
+from __future__ import annotations
+
 import logging
-from collections.abc import Sequence
-from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -10,11 +10,13 @@ import polars as pl
 from ..utils import cdh_utils
 from ..utils.namespaces import LazyNamespace
 from ..utils.pega_outcomes import get_openrate_labels as _get_openrate_labels
-from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    from datetime import timedelta
+    from collections.abc import Sequence
     from .IH import IH as IH_Class
 
 

--- a/python/pdstools/ih/Aggregates.py
+++ b/python/pdstools/ih/Aggregates.py
@@ -112,10 +112,7 @@ class Aggregates(LazyNamespace):
         >>> ih.aggregates.summarize_by_interaction(by="Channel").collect()
 
         """
-        if every is not None:
-            source = self.ih.data.with_columns(pl.col.OutcomeTime.dt.truncate(every))
-        else:
-            source = self.ih.data
+        source = self.ih.data.with_columns(pl.col.OutcomeTime.dt.truncate(every)) if every is not None else self.ih.data
 
         if by is None:
             by_seq: list[str | pl.Expr] = []
@@ -153,7 +150,7 @@ class Aggregates(LazyNamespace):
             # TODO: reconsider null vs False for non-applicable channel/metric combinations
             pos_or: pl.Expr = pl.lit(False)
             neg_or: pl.Expr = pl.lit(False)
-            for channel_dir, labels in channel_aware.items():
+            for channel_dir, _labels in channel_aware.items():
                 or_labels = _get_openrate_labels(channel_dir)
                 if or_labels is None:
                     continue  # inbound — both stay False → null after agg
@@ -219,20 +216,19 @@ class Aggregates(LazyNamespace):
             if metric not in ("Engagement", "OpenRate")
         ]
 
-        interactions = (
+        return (
             cdh_utils._apply_query(source, query)
             .group_by(
-                (group_by_clause + ["InteractionID"]) if group_by_clause is not None else ["InteractionID"],
+                ([*group_by_clause, "InteractionID"]) if group_by_clause is not None else ["InteractionID"],
             )
             .agg(
-                [engagement_agg, openrate_agg] + other_agg,
+                [engagement_agg, openrate_agg, *other_agg],
                 Propensity=pl.col.Propensity.last(),
                 # for debugging
                 Outcomes=pl.col.Outcome.unique().sort(),
             )
             .drop([] if debug else ["Outcomes"])
         )
-        return interactions
 
     def summary_success_rates(
         self,
@@ -349,7 +345,7 @@ class Aggregates(LazyNamespace):
             .drop([] if debug else ["Outcomes"])
         )
 
-        if group_by_clause is None:
+        if group_by_clause is None:  # noqa: SIM108 — inline comment clarifies the drop
             summary = summary.drop("literal")  # created by empty group_by
         else:
             summary = summary.sort(group_by_clause)
@@ -395,10 +391,7 @@ class Aggregates(LazyNamespace):
         >>> ih.aggregates.summary_outcomes(every="1mo").collect()
 
         """
-        if every is not None:
-            source = self.ih.data.with_columns(pl.col.OutcomeTime.dt.truncate(every))
-        else:
-            source = self.ih.data
+        source = self.ih.data.with_columns(pl.col.OutcomeTime.dt.truncate(every)) if every is not None else self.ih.data
 
         if by is None:
             by_seq: list[str | pl.Expr] = []
@@ -413,6 +406,4 @@ class Aggregates(LazyNamespace):
             by_pl_exprs,
         )
 
-        summary = (cdh_utils._apply_query(source, query).group_by(group_by_clause).agg(Count=pl.len())).sort("Count")
-
-        return summary
+        return (cdh_utils._apply_query(source, query).group_by(group_by_clause).agg(Count=pl.len())).sort("Count")

--- a/python/pdstools/ih/IH.py
+++ b/python/pdstools/ih/IH.py
@@ -1,5 +1,6 @@
 """Interaction History analysis for Pega CDH."""
 
+from typing import ClassVar
 import datetime
 import logging
 import math
@@ -65,14 +66,14 @@ class IH:
     data: pl.LazyFrame
     outcome_labels_used: dict | None
 
-    positive_outcome_labels: dict[str, list[str]] = {
+    positive_outcome_labels: ClassVar[dict[str, list[str]]] = {
         "Engagement": ["Accepted", "Accept", "Clicked", "Click"],
         "Conversion": ["Conversion"],
         "OpenRate": ["Opened", "Open"],
     }
     """Mapping of metric types to positive outcome labels."""
 
-    negative_outcome_labels: dict[str, list[str]] = {
+    negative_outcome_labels: ClassVar[dict[str, list[str]]] = {
         "Engagement": ["Impression", "Impressed", "Pending", "NoResponse"],
         "Conversion": ["Impression", "Pending"],
         "OpenRate": ["Impression", "Pending"],
@@ -136,8 +137,7 @@ class IH:
         missing = set(REQUIRED_IH_COLUMNS).difference(df.collect_schema().names())
         if missing:
             raise ValueError(f"Missing required IH columns: {sorted(missing)}")
-        df = cdh_utils._apply_schema_types(df, Schema.IHInteraction)
-        return df
+        return cdh_utils._apply_schema_types(df, Schema.IHInteraction)
 
     def _scan_outcome_labels(self) -> dict | None:
         """Scan data for channel/outcome combinations and resolve defaults.
@@ -328,9 +328,7 @@ class IH:
             a = responses * propensity
             b = responses * (1 - propensity)
 
-            sampled = rng.betavariate(a, b)
-
-            return sampled
+            return rng.betavariate(a, b)
 
         ih_fake_impressions = pl.DataFrame(
             {
@@ -587,7 +585,7 @@ class IH:
         customer_outcomes = []
 
         # Iterate over customers
-        for user_id, user_df in df.group_by(customerid_column):
+        for _user_id, user_df in df.group_by(customerid_column):
             user_actions = user_df[level].to_list()
             outcome_actions = user_df[outcome_column].to_list()
 

--- a/python/pdstools/ih/IH.py
+++ b/python/pdstools/ih/IH.py
@@ -255,14 +255,14 @@ class IH:
         if boto3_client is None:
             try:
                 import boto3
-            except ImportError:
+            except ImportError as err:
                 from ..utils.namespaces import MissingDependenciesException
 
                 raise MissingDependenciesException(
                     ["boto3"],
                     namespace="IH.from_s3",
                     deps_group="pega_io",
-                )
+                ) from err
             boto3_client = boto3.client("s3", region_name=region)
 
         import tempfile

--- a/python/pdstools/ih/IH.py
+++ b/python/pdstools/ih/IH.py
@@ -6,6 +6,7 @@ from typing import ClassVar, TYPE_CHECKING
 import datetime
 import logging
 import math
+import os
 import random
 from collections import defaultdict
 

--- a/python/pdstools/ih/IH.py
+++ b/python/pdstools/ih/IH.py
@@ -1,10 +1,11 @@
 """Interaction History analysis for Pega CDH."""
 
-from typing import ClassVar
+from __future__ import annotations
+
+from typing import ClassVar, TYPE_CHECKING
 import datetime
 import logging
 import math
-import os
 import random
 from collections import defaultdict
 
@@ -19,11 +20,14 @@ from ..utils.cdh_utils import (
     parse_pega_date_time_formats,
 )
 from ..utils.pega_outcomes import resolve_outcome_labels as _resolve_outcome_labels
-from ..utils.types import QUERY
 from . import Schema
 from .Aggregates import Aggregates
 from .Plots import Plots
 from .Schema import REQUIRED_IH_COLUMNS
+
+if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    import os
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/ih/Plots.py
+++ b/python/pdstools/ih/Plots.py
@@ -153,7 +153,7 @@ class Plots(LazyNamespace):
 
         cols = df[by].unique().shape[0]  # TODO can be None
         # TODO generalize to support pl expression, see ADM plots, eg facet in bubble chart
-        condition_col = cast(str, condition)
+        condition_col = cast("str", condition)
         rows = df[condition_col].unique().shape[0]
 
         fig = make_subplots(

--- a/python/pdstools/ih/Plots.py
+++ b/python/pdstools/ih/Plots.py
@@ -3,19 +3,19 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
-from typing import TYPE_CHECKING, Literal, cast, overload
+from typing import ClassVar, Literal, TYPE_CHECKING, cast, overload
 
 import polars as pl
 
 from ..utils import cdh_utils
 from ..utils.namespaces import LazyNamespace
 from ..utils.plot_utils import Figure, simplify_facet_titles
-from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    from datetime import timedelta
     from .IH import IH as IH_Class
 
 
@@ -49,7 +49,7 @@ class Plots(LazyNamespace):
 
     """
 
-    dependencies = ["plotly"]
+    dependencies: ClassVar[list[str]] = ["plotly"]
     dependency_group = "adm"
 
     def __init__(self, ih: "IH_Class"):
@@ -287,7 +287,7 @@ class Plots(LazyNamespace):
 
         fig = px.treemap(
             plot_data.collect(),
-            path=[px.Constant("ALL")] + ["Outcome"] + by,
+            path=[px.Constant("ALL"), "Outcome", *by],
             values="Count",
             color="Count",
             branchvalues="total",
@@ -394,7 +394,7 @@ class Plots(LazyNamespace):
 
         fig = px.treemap(
             plot_data_collected,
-            path=[px.Constant("ALL")] + by,
+            path=[px.Constant("ALL"), *by],
             values="CTR_DisplayValue",
             color="CTR_DisplayValue",
             color_continuous_scale=px.colors.sequential.RdBu,

--- a/python/pdstools/ih/__init__.py
+++ b/python/pdstools/ih/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .IH import IH
 
 __all__ = ["IH"]

--- a/python/pdstools/impactanalyzer/ImpactAnalyzer.py
+++ b/python/pdstools/impactanalyzer/ImpactAnalyzer.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
+
 import json
 import logging
-import os
-from collections.abc import Callable, Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar, Literal, overload
+from typing import ClassVar, Literal, overload, TYPE_CHECKING
 
 import polars as pl
 import polars.selectors as cs
@@ -18,9 +18,13 @@ from ..utils.cdh_utils import (
     weighted_average_polars,
 )
 from ..utils.pega_outcomes import resolve_outcome_labels as _resolve_outcome_labels
-from ..utils.types import QUERY
 from .Plots import Plots
 from .Schema import REQUIRED_IA_COLUMNS, ImpactAnalyzerData
+
+if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    from collections.abc import Callable, Sequence
+    import os
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/impactanalyzer/ImpactAnalyzer.py
+++ b/python/pdstools/impactanalyzer/ImpactAnalyzer.py
@@ -4,7 +4,7 @@ import os
 from collections.abc import Callable, Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, overload
+from typing import ClassVar, Literal, overload
 
 import polars as pl
 import polars.selectors as cs
@@ -80,7 +80,7 @@ class ImpactAnalyzer:
     ia_data: pl.LazyFrame
     outcome_labels_used: dict | None
 
-    default_ia_experiments = {
+    default_ia_experiments: ClassVar[dict[str, tuple[str, str]]] = {
         "NBA vs Random": ("NBAPrioritization", "NBA"),
         "NBA vs Propensity Only": ("PropensityPriority", "NBA"),
         "NBA vs No Levers": ("LeverPriority", "NBA"),
@@ -92,13 +92,13 @@ class ImpactAnalyzer:
     }
     """Default experiments mapping experiment names to (control, test) group tuples."""
 
-    outcome_labels = {
+    outcome_labels: ClassVar[dict[str, list[str]]] = {
         "Impressions": ["Impression"],
         "Accepts": ["Accept", "Accepted", "Click", "Clicked"],
     }
     """Mapping of metric names to outcome labels used for aggregation."""
 
-    default_ia_controlgroups = {
+    default_ia_controlgroups: ClassVar[dict[str, list[str | None]]] = {
         "MktValue": [
             "NBAHealth_NBAPrioritization",
             "NBAHealth_PropensityPriority",
@@ -828,7 +828,7 @@ class ImpactAnalyzer:
 
         from ..pega_io.File import _read_excel, read_data
 
-        if read_kwargs:
+        if read_kwargs:  # noqa: SIM108 — comment clarifies why we branch
             # Sheet selection isn't part of read_data's contract — call the
             # shared Excel helper so we still get the fastexcel shim.
             df = _read_excel(excel_source, **read_kwargs)
@@ -1006,8 +1006,8 @@ class ImpactAnalyzer:
             )
 
         return (
-            self.ia_data.sort(group_by + ["ControlGroup"])
-            .group_by(group_by + ["ControlGroup"], maintain_order=True)
+            self.ia_data.sort([*group_by, "ControlGroup"])
+            .group_by([*group_by, "ControlGroup"], maintain_order=True)
             .agg(agg_exprs)
             .drop(cs.starts_with("Pega_") if drop_internal_cols else [])
         )
@@ -1113,8 +1113,8 @@ class ImpactAnalyzer:
                     pl.exclude(by_column_names).name.suffix("_Control"),
                 ),
                 how="left",
-                left_on=["Control"] + by_column_names,
-                right_on=["ControlGroup_Control"] + by_column_names,
+                left_on=["Control", *by_column_names],
+                right_on=["ControlGroup_Control", *by_column_names],
             )
             .with_columns(
                 Control_Fraction=pl.col("Impressions_Control")
@@ -1136,5 +1136,5 @@ class ImpactAnalyzer:
             )
 
         return result.drop(cs.starts_with("Pega_")).sort(
-            ["Experiment"] + by_column_names,
+            ["Experiment", *by_column_names],
         )

--- a/python/pdstools/impactanalyzer/Plots.py
+++ b/python/pdstools/impactanalyzer/Plots.py
@@ -3,18 +3,18 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Literal, overload
+from typing import ClassVar, Literal, TYPE_CHECKING, overload
 
 import polars as pl
 
 from ..utils.cdh_utils import _apply_query
 from ..utils.namespaces import LazyNamespace
-from ..utils.plot_utils import Figure
-from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    from ..utils.plot_utils import Figure
     from .ImpactAnalyzer import ImpactAnalyzer as ImpactAnalyzer_Class
 
 
@@ -48,7 +48,7 @@ class Plots(LazyNamespace):
 
     """
 
-    dependencies = ["plotly"]
+    dependencies: ClassVar[list[str]] = ["plotly"]
     dependency_group = "adm"
 
     def __init__(self, ia: "ImpactAnalyzer_Class"):
@@ -73,14 +73,13 @@ class Plots(LazyNamespace):
             Alphabetically ordered list of default experiment names.
 
         """
-        default_experiments = [
+        return [
             "Adaptive Models vs Random Propensity",
             "NBA vs No Levers",
             "NBA vs Only Eligibility Rules",
             "NBA vs Propensity Only",
             "NBA vs Random",
         ]
-        return default_experiments
 
     @staticmethod
     def _get_facet_config(data: pl.DataFrame, facet: str | None) -> dict:

--- a/python/pdstools/impactanalyzer/__init__.py
+++ b/python/pdstools/impactanalyzer/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .ImpactAnalyzer import ImpactAnalyzer
 
 __all__ = ["ImpactAnalyzer"]

--- a/python/pdstools/infinity/__init__.py
+++ b/python/pdstools/infinity/__init__.py
@@ -1,5 +1,7 @@
 """Infinity API client for Pega Decision Management."""
 
+from __future__ import annotations
+
 from importlib.util import find_spec
 from typing import TYPE_CHECKING
 

--- a/python/pdstools/infinity/client.py
+++ b/python/pdstools/infinity/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = ["AsyncInfinity", "Infinity"]
 
 from importlib.util import find_spec

--- a/python/pdstools/infinity/internal/_auth.py
+++ b/python/pdstools/infinity/internal/_auth.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import logging
 import time
-from collections.abc import Generator
 
 import httpx
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/infinity/internal/_base_client.py
+++ b/python/pdstools/infinity/internal/_base_client.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
 import warnings
-from collections.abc import Coroutine
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -20,6 +21,9 @@ from anyio import (
 
 from ._auth import PegaOAuth, _read_client_credential_file
 from ._exceptions import APIConnectionError, APITimeoutError, handle_pega_exception
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
 
 _HttpxClientT = TypeVar("_HttpxClientT", bound=httpx.Client | httpx.AsyncClient)
 logger = logging.getLogger(__name__)

--- a/python/pdstools/infinity/internal/_base_client.py
+++ b/python/pdstools/infinity/internal/_base_client.py
@@ -103,6 +103,7 @@ class BaseClient(Generic[_HttpxClientT]):
             """Could not infer Pega version automatically.
 For full compatibility, please supply the pega_version argument to the Infinity class.
 """,
+            stacklevel=2,
         )
         return None
 
@@ -252,7 +253,7 @@ class SyncAPIClient(BaseClient[httpx.Client]):
         except httpx.TimeoutException as err:
             raise APITimeoutError(request=str(request)) from err
         except httpx.ConnectError as err:
-            raise Exception(str(err))
+            raise Exception(str(err)) from err
         except Exception as err:
             raise APIConnectionError(request=str(request)) from err
         return response
@@ -498,7 +499,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient]):  # pragma: no cover
         except httpx.TimeoutException as err:
             raise APITimeoutError(request=str(request)) from err
         except httpx.ConnectError as err:
-            raise Exception(str(err))
+            raise Exception(str(err)) from err
         except Exception as err:
             raise APIConnectionError(request=str(request)) from err
         return response

--- a/python/pdstools/infinity/internal/_constants.py
+++ b/python/pdstools/infinity/internal/_constants.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Literal
 
 PEGA_VERSIONS: Literal["8.8", "23.1", "24.1", "24.2"]

--- a/python/pdstools/infinity/internal/_exceptions.py
+++ b/python/pdstools/infinity/internal/_exceptions.py
@@ -1,6 +1,10 @@
-from typing import Any
+from __future__ import annotations
 
-from httpx import URL, Response
+from typing import Any, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from httpx import URL, Response
 
 
 class PegaException(Exception):

--- a/python/pdstools/infinity/internal/_exceptions.py
+++ b/python/pdstools/infinity/internal/_exceptions.py
@@ -123,14 +123,14 @@ def handle_pega_exception(
 ) -> PegaException | Exception:
     try:
         content = response.json()
-    except ValueError:
+    except ValueError as err:
         raise InvalidRequest(
             str(base_url),
             endpoint,
             params,
             response,
             "Invalid request.",
-        )
+        ) from err
     details = content.get("errorDetails", None)
 
     if not details:

--- a/python/pdstools/infinity/internal/_pagination.py
+++ b/python/pdstools/infinity/internal/_pagination.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
-from typing import Any, Generic, TypeVar, overload
+from typing import Any, Generic, TypeVar, overload, TYPE_CHECKING
 
 import polars as pl
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
 
 T = TypeVar("T")
 
@@ -176,7 +178,7 @@ class PaginatedList(Generic[T]):
             try:
                 response = response[self._root]
             except KeyError as e:
-                raise ValueError(f"Json format unexpected, {self._root} not found.{e}")
+                raise ValueError(f"Json format unexpected, {self._root} not found.{e}") from e
 
         for element in response:
             if element is not None:
@@ -255,7 +257,7 @@ class AsyncPaginatedList(Generic[T]):
             try:
                 response = response[self._root]
             except KeyError as e:
-                raise ValueError(f"Json format unexpected, {self._root} not found.{e}")
+                raise ValueError(f"Json format unexpected, {self._root} not found.{e}") from e
 
         for element in response:
             if element is not None:

--- a/python/pdstools/infinity/resources/__init__.py
+++ b/python/pdstools/infinity/resources/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from . import prediction_studio
 from .knowledge_buddy import AsyncKnowledgeBuddy, KnowledgeBuddy
 

--- a/python/pdstools/infinity/resources/knowledge_buddy/__init__.py
+++ b/python/pdstools/infinity/resources/knowledge_buddy/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .knowledge_buddy import AsyncKnowledgeBuddy, KnowledgeBuddy
 
 __all__ = ["AsyncKnowledgeBuddy", "KnowledgeBuddy"]

--- a/python/pdstools/infinity/resources/knowledge_buddy/knowledge_buddy.py
+++ b/python/pdstools/infinity/resources/knowledge_buddy/knowledge_buddy.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
-import httpx
 from pydantic import AliasChoices, BaseModel, Field, Json
 
 from ...internal._exceptions import InternalServerError, InvalidInputs, PegaException
 from ...internal._resource import AsyncAPIResource, SyncAPIResource, api_method
 
 if TYPE_CHECKING:
+    import httpx
     from collections.abc import Callable
 
 

--- a/python/pdstools/infinity/resources/knowledge_buddy/knowledge_buddy.py
+++ b/python/pdstools/infinity/resources/knowledge_buddy/knowledge_buddy.py
@@ -1,11 +1,13 @@
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
-from collections.abc import Callable
 
 import httpx
 from pydantic import AliasChoices, BaseModel, Field, Json
 
 from ...internal._exceptions import InternalServerError, InvalidInputs, PegaException
 from ...internal._resource import AsyncAPIResource, SyncAPIResource, api_method
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class TextInput(TypedDict):
@@ -157,7 +159,7 @@ class _KnowledgeBuddyMixin:
             Text of the comment.
 
         """
-        response = await self._a_put(
+        return await self._a_put(
             "/prweb/api/knowledgebuddy/v1/question/feedback",
             data=dict(
                 questionID=question_id,
@@ -165,7 +167,6 @@ class _KnowledgeBuddyMixin:
                 comments=comments,
             ),
         )
-        return response
 
     @staticmethod
     def _custom_exception_hook(

--- a/python/pdstools/infinity/resources/prediction_studio/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/__init__.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import logging
 
 from . import v24_1, v24_2
-from .base import AsyncPredictionStudioBase, PredictionStudioBase
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base import AsyncPredictionStudioBase, PredictionStudioBase
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/infinity/resources/prediction_studio/base.py
+++ b/python/pdstools/infinity/resources/prediction_studio/base.py
@@ -6,13 +6,16 @@ from typing import (
     Any,
     Literal,
     TypedDict,
+    TYPE_CHECKING,
 )
 
-import polars as pl
 from pydantic import BaseModel
 
 from ...internal._exceptions import IncompatiblePegaVersionError
 from ...internal._resource import AsyncAPIResource, SyncAPIResource
+
+if TYPE_CHECKING:
+    import polars as pl
 
 DEPLOYMENT_MODE = Literal["shadow", "champion/challenger"]
 
@@ -115,7 +118,7 @@ class _PredictionMixin(ABC):
     def describe(self): ...
 
 
-class _NotificationMixin(ABC):
+class _NotificationMixin(ABC):  # noqa: B024 — ABC used for cooperative MRO with pydantic resources
     def __init__(
         self,
         client,
@@ -147,7 +150,7 @@ class _NotificationMixin(ABC):
         self.trigger_time = datetime.strptime(triggerTime, "%Y%m%dT%H%M%S.%f %Z")
 
 
-class UploadedModel(ABC): ...
+class UploadedModel(ABC): ...  # noqa: B024 — ABC marker for subclass discovery
 
 
 class ModelValidationError(Exception):
@@ -184,7 +187,7 @@ class _RepositoryMixin(ABC):
         raise IncompatiblePegaVersionError("24.2", "Retrieving the S3 URL directly")
 
 
-class _DataMartExportMixin(ABC):
+class _DataMartExportMixin(ABC):  # noqa: B024 — ABC used for cooperative MRO with pydantic resources
     def __init__(self, client, **kwargs):
         super().__init__(client=client)
         self.referenceId = kwargs.get("referenceId")

--- a/python/pdstools/infinity/resources/prediction_studio/local_model_utils.py
+++ b/python/pdstools/infinity/resources/prediction_studio/local_model_utils.py
@@ -522,7 +522,7 @@ class ONNXModel(LocalModel):
             raise MissingDependenciesException(
                 ["torch"],
                 namespace="ONNXModel.from_pytorch",
-            )
+            ) from None
 
         import io as _io
 
@@ -640,7 +640,7 @@ class ONNXModel(LocalModel):
         except Exception as e:
             raise ONNXModelValidationError(
                 f"Unable to create inference session: {e!s}",
-            )
+            ) from e
         metadata = session.get_modelmeta().custom_metadata_map
 
         if PEGA_METADATA not in metadata:

--- a/python/pdstools/infinity/resources/prediction_studio/model_security.py
+++ b/python/pdstools/infinity/resources/prediction_studio/model_security.py
@@ -21,8 +21,10 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/infinity/resources/prediction_studio/types.py
+++ b/python/pdstools/infinity/resources/prediction_studio/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import Literal, TypeVar
 

--- a/python/pdstools/infinity/resources/prediction_studio/v24_1/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_1/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..base import AsyncPredictionStudioBase, PredictionStudioBase
 from .prediction import AsyncPrediction, Prediction
 from .prediction_studio import AsyncPredictionStudio, PredictionStudio

--- a/python/pdstools/infinity/resources/prediction_studio/v24_1/prediction.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_1/prediction.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING, Any, Literal
-from collections.abc import Callable
 
 import polars as pl
 from pydantic import validate_call
@@ -10,6 +9,9 @@ from ....internal._exceptions import NoMonitoringInfo
 from ....internal._resource import api_method
 from ..base import AsyncPrediction as AsyncPredictionBase
 from ..base import Prediction as PredictionBase
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class _PredictionV24_1Mixin:
@@ -31,7 +33,7 @@ class _PredictionV24_1Mixin:
         endpoint = f"/prweb/api/PredictionStudio/v1/predictions/{self.prediction_id}/metric/{metric}"
         try:
             info = await self._a_get(endpoint, time_frame=timeframe)
-            data = (
+            return (
                 pl.DataFrame(
                     info["monitoringData"],
                     schema={
@@ -50,16 +52,14 @@ class _PredictionV24_1Mixin:
                 )
                 .drop("dataUsage")
             )
-            return data
         except NoMonitoringInfo:
-            data = pl.DataFrame(
+            return pl.DataFrame(
                 schema={
                     "value": pl.Float64,
                     "snapshotTime": pl.Datetime("ns"),
                     "category": pl.Utf8,
                 },
             )
-            return data
 
     @api_method
     async def describe(self):

--- a/python/pdstools/infinity/resources/prediction_studio/v24_1/prediction.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_1/prediction.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Literal
 
 import polars as pl
 from pydantic import validate_call
 
 from .....utils import cdh_utils
-from ....internal._constants import METRIC
+from ....internal._constants import METRIC  # noqa: TC001 — runtime needed by pydantic.validate_call
 from ....internal._exceptions import NoMonitoringInfo
 from ....internal._resource import api_method
 from ..base import AsyncPrediction as AsyncPredictionBase

--- a/python/pdstools/infinity/resources/prediction_studio/v24_1/prediction_studio.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_1/prediction_studio.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ....internal._pagination import AsyncPaginatedList, PaginatedList
 from ....internal._resource import api_method
 from ..base import AsyncPredictionStudioBase, PredictionStudioBase

--- a/python/pdstools/infinity/resources/prediction_studio/v24_1/repository.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_1/repository.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..base import AsyncRepository as AsyncBaseRepository
 from ..base import Repository as BaseRepository
 

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .champion_challenger import AsyncChampionChallenger, ChampionChallenger
 from .datamart_export import AsyncDatamartExport, DatamartExport
 from .model import AsyncModel, Model

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/champion_challenger/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/champion_challenger/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ._async import AsyncChampionChallenger
 from ._mixin import _ChampionChallengerV24_2Mixin
 from ._sync import ChampionChallenger

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/champion_challenger/_async.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/champion_challenger/_async.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-import polars as pl
 
 from .....internal._pagination import AsyncPaginatedList
 from ...base import AsyncChampionChallenger as AsyncChampionChallengerBase
 from ._mixin import _ChampionChallengerV24_2Mixin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
 
 
 class AsyncChampionChallenger(

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/champion_challenger/_mixin.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/champion_challenger/_mixin.py
@@ -4,7 +4,6 @@ import logging
 import random
 import string
 from typing import TYPE_CHECKING, Any
-from collections.abc import Callable
 
 from pydantic import validate_call
 
@@ -12,6 +11,9 @@ from .....internal._exceptions import PegaException, PegaMLopsError
 from .....internal._resource import _maybe_await, api_method
 from ...types import AdmModelType
 from ..model_upload import UploadedModel
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -299,7 +301,7 @@ class _ChampionChallengerV24_2Mixin:
                 "Error when deleting challenger model: " + str(e),
             ) from e
         await self._refresh_champion_challenger()
-        logging.info("Deleted challenger model: %s", response)
+        logger.info("Deleted challenger model: %s", response)
 
     @api_method
     async def promote_challenger_model(self):
@@ -326,7 +328,7 @@ class _ChampionChallengerV24_2Mixin:
             raise PegaMLopsError(
                 "Error when promoting challenger model: " + str(e),
             ) from e
-        logging.info("Promoted challenger model: %s", response)
+        logger.info("Promoted challenger model: %s", response)
 
     @api_method
     async def update_challenger_response_share(
@@ -607,10 +609,10 @@ class _ChampionChallengerV24_2Mixin:
 
         if "Approved" not in response["message"]:
             raise PegaMLopsError("Error when adding model")
-        logging.info("Add model: Refreshing Champion challenger configuration: ")
+        logger.info("Add model: Refreshing Champion challenger configuration: ")
         await self._sleep(1)
         await self._refresh_champion_challenger()
-        logging.info("Add model: %s", response)
+        logger.info("Add model: %s", response)
 
     @api_method
     @validate_call
@@ -690,4 +692,4 @@ class _ChampionChallengerV24_2Mixin:
         if "Approved" not in response["message"]:
             raise PegaMLopsError("Error when adding model")
         await self._refresh_champion_challenger()
-        logging.info("Clone model: %s", response)
+        logger.info("Clone model: %s", response)

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/datamart_export.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/datamart_export.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ....internal._resource import api_method
 from ..base import AsyncDataMartExport as AsyncPreviousDatamartExport
 from ..base import DataMartExport as PreviousDatamartExport

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/model.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/model.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING, Any, Literal, overload
-from collections.abc import Callable
 
 import polars as pl
 
@@ -9,6 +8,9 @@ from ..base import AsyncModel as AsyncPreviousModel
 from ..base import AsyncNotification, ModelAttributes, Notification
 from ..base import Model as PreviousModel
 from ..types import NotificationCategory
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class _ModelV24_2Mixin:

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/model.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import polars as pl
@@ -7,9 +9,9 @@ from ....internal._resource import api_method
 from ..base import AsyncModel as AsyncPreviousModel
 from ..base import AsyncNotification, ModelAttributes, Notification
 from ..base import Model as PreviousModel
-from ..types import NotificationCategory
 
 if TYPE_CHECKING:
+    from ..types import NotificationCategory
     from collections.abc import Callable
 
 

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/model_upload.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/model_upload.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..base import UploadedModel as ModelUploaderPrevious
 
 

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ._async import AsyncPrediction
 from ._mixin import _PredictionV24_2Mixin
 from ._sync import Prediction

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_async.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_async.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-import polars as pl
 
 from .....internal._exceptions import PegaException, PegaMLopsError
 from .....internal._pagination import AsyncPaginatedList
 from ...base import AsyncNotification
-from ...types import NotificationCategory
 from ...v24_1.prediction import AsyncPrediction as AsyncPredictionPrevious
 from ._mixin import _PredictionV24_2Mixin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...types import NotificationCategory
+    import polars as pl
 
 
 class AsyncPrediction(_PredictionV24_2Mixin, AsyncPredictionPrevious):
@@ -90,7 +93,7 @@ class AsyncPrediction(_PredictionV24_2Mixin, AsyncPredictionPrevious):
                     context=model["contextName"],
                     category=model["categoryName"] if model.get("categoryName") is not None else None,
                     model_objective=model["model_type"],
-                    active_model=[
+                    active_model=next(
                         AsyncModel(
                             client=self._client,
                             modelId=mod["id"],
@@ -106,7 +109,7 @@ class AsyncPrediction(_PredictionV24_2Mixin, AsyncPredictionPrevious):
                         if model["activeModel"] is not None
                         and mod["id"] == model["activeModel"]
                         and mod["contextName"] == model["contextName"]
-                    ][0],
+                    ),
                 ),
             )
 

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_mixin.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_mixin.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 from typing import TYPE_CHECKING, Any, Literal
-from collections.abc import Callable
 
 import polars as pl
 from pydantic import validate_call
 
 from ......utils import cdh_utils
-from .....internal._constants import METRIC
+from .....internal._constants import METRIC  # noqa: TC001 — runtime needed by pydantic.validate_call
 from .....internal._exceptions import NoMonitoringInfo, PegaException
 from .....internal._resource import api_method
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class _PredictionV24_2Mixin:
@@ -114,7 +116,7 @@ class _PredictionV24_2Mixin:
                 endDate=end_date_str,
                 frequency=frequency,
             )
-            data = (
+            return (
                 pl.DataFrame(
                     info["monitoringData"],
                     schema={
@@ -133,16 +135,14 @@ class _PredictionV24_2Mixin:
                 )
                 .drop("dataUsage")
             )
-            return data
         except NoMonitoringInfo:
-            data = pl.DataFrame(
+            return pl.DataFrame(
                 schema={
                     "value": pl.Float64,
                     "snapshotTime": pl.Datetime("ns"),
                     "category": pl.Utf8,
                 },
             )
-            return data
 
     @api_method
     async def package_staged_changes(self, message: str | None = None):

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_sync.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Literal, overload, TYPE_CHECKING
 
 import polars as pl
 
 from .....internal._exceptions import PegaException, PegaMLopsError
 from .....internal._pagination import PaginatedList
 from ...base import Notification
-from ...types import NotificationCategory
 from ...v24_1.prediction import Prediction as PredictionPrevious
 from ._mixin import _PredictionV24_2Mixin
+
+if TYPE_CHECKING:
+    from ...types import NotificationCategory
 
 
 class Prediction(_PredictionV24_2Mixin, PredictionPrevious):
@@ -127,7 +129,7 @@ class Prediction(_PredictionV24_2Mixin, PredictionPrevious):
                     context=model["contextName"],
                     category=model["categoryName"] if model.get("categoryName") is not None else None,
                     model_objective=model["model_type"],
-                    active_model=[
+                    active_model=next(
                         Model(
                             client=self._client,
                             modelId=mod["id"],
@@ -143,7 +145,7 @@ class Prediction(_PredictionV24_2Mixin, PredictionPrevious):
                         if model["activeModel"] is not None
                         and mod["id"] == model["activeModel"]
                         and mod["contextName"] == model["contextName"]
-                    ][0],
+                    ),
                 ),
             )
 

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ._async import AsyncPredictionStudio
 from ._mixin import _PredictionStudioV24_2Mixin
 from ._sync import PredictionStudio

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_async.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_async.py
@@ -10,11 +10,12 @@ from ..model import AsyncModel
 from ..prediction import AsyncPrediction
 from ..repository import AsyncRepository
 from ._mixin import _PredictionStudioV24_2Mixin
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from ...types import NotificationCategory
     import polars as pl
+
+    from ...types import NotificationCategory
 
 
 class AsyncPredictionStudio(_PredictionStudioV24_2Mixin, AsyncPredictionStudioPrevious):
@@ -121,8 +122,9 @@ class AsyncPredictionStudio(_PredictionStudioV24_2Mixin, AsyncPredictionStudioPr
             uniques["prediction_id"] = prediction_id
         if label:
             uniques["label"] = label
-        pages = await self.list_predictions()
-        return await pages.get(**uniques)  # type: ignore[union-attr, return-value]  # return_df defaults False so pages is AsyncPaginatedList
+        # return_df defaults to False so list_predictions always returns the paginated list
+        pages = cast("AsyncPaginatedList[AsyncPrediction]", await self.list_predictions())
+        return await pages.get(**uniques)
 
     async def get_model(
         self,
@@ -149,8 +151,9 @@ class AsyncPredictionStudio(_PredictionStudioV24_2Mixin, AsyncPredictionStudioPr
             uniques["model_id"] = model_id.upper()
         if label:
             uniques["label"] = label
-        pages = await self.list_models()
-        return await pages.get(**uniques)  # type: ignore[union-attr, return-value]  # return_df defaults False so pages is AsyncPaginatedList
+        # return_df defaults to False so list_models always returns the paginated list
+        pages = cast("AsyncPaginatedList[AsyncModel]", await self.list_models())
+        return await pages.get(**uniques)
 
     async def trigger_datamart_export(self) -> AsyncDatamartExport:
         """Initiates an export of model data to the Repository.

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_async.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_async.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
-import polars as pl
 
 from .....internal._exceptions import NoMonitoringExportError, PegaException
 from .....internal._pagination import AsyncPaginatedList
 from ...base import AsyncNotification
-from ...types import NotificationCategory
 from ...v24_1 import AsyncPredictionStudio as AsyncPredictionStudioPrevious
 from ..datamart_export import AsyncDatamartExport
 from ..model import AsyncModel
 from ..prediction import AsyncPrediction
 from ..repository import AsyncRepository
 from ._mixin import _PredictionStudioV24_2Mixin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...types import NotificationCategory
+    import polars as pl
 
 
 class AsyncPredictionStudio(_PredictionStudioV24_2Mixin, AsyncPredictionStudioPrevious):

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_mixin.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_mixin.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import base64
 from typing import TYPE_CHECKING, Any
-from collections.abc import Callable
 
 import anyio
 
-from ...base import LocalModel
 from ...local_model_utils import ONNXModel
 from .....internal._resource import api_method
 from ..model_upload import UploadedModel
+
+if TYPE_CHECKING:
+    from ...base import LocalModel
+    from collections.abc import Callable
 
 
 class _PredictionStudioV24_2Mixin:

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_sync.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Literal, overload, TYPE_CHECKING
 
 import polars as pl
 
 from .....internal._exceptions import NoMonitoringExportError, PegaException
 from .....internal._pagination import PaginatedList
 from ...base import Notification
-from ...types import NotificationCategory
 from ...v24_1 import PredictionStudio as PredictionStudioPrevious
 from ..datamart_export import DatamartExport
 from ..model import Model
 from ..prediction import Prediction
 from ..repository import Repository
 from ._mixin import _PredictionStudioV24_2Mixin
+
+if TYPE_CHECKING:
+    from ...types import NotificationCategory
 
 
 class PredictionStudio(_PredictionStudioV24_2Mixin, PredictionStudioPrevious):

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/repository.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/repository.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..v24_1 import Repository as RepositoryPrevious
 from ..v24_1.repository import AsyncRepository as AsyncRepositoryPrevious
 

--- a/python/pdstools/pega_io/API.py
+++ b/python/pdstools/pega_io/API.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from os import PathLike
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 
 def _read_client_credential_file(credential_file: PathLike) -> dict[str, str]:  # pragma: no cover

--- a/python/pdstools/pega_io/Anonymization.py
+++ b/python/pdstools/pega_io/Anonymization.py
@@ -6,10 +6,13 @@ import logging
 import math
 import os
 import tempfile
-from collections.abc import Iterator
 from glob import glob
 
 import polars as pl
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -237,7 +240,7 @@ class Anonymization:
                 ["polars-hash"],
                 namespace="Anonymization",
                 deps_group="pega_io",
-            )
+            ) from None
 
         df: pl.LazyFrame = pl.concat(
             [pl.scan_parquet(f) for f in chunked_files],

--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -154,14 +154,13 @@ def _read_from_bytesio(file: BytesIO, extension: str) -> pl.LazyFrame:
     # Read based on extension
     if extension == ".parquet":
         return pl.read_parquet(file).lazy()
-    elif extension == ".csv":
+    if extension == ".csv":
         return pl.read_csv(file).lazy()
-    elif extension in {".arrow", ".feather", ".ipc"}:
+    if extension in {".arrow", ".feather", ".ipc"}:
         return pl.read_ipc(file).lazy()
-    elif extension in {".json", ".ndjson", ".jsonl"}:
+    if extension in {".json", ".ndjson", ".jsonl"}:
         return pl.read_ndjson(file).lazy()
-    else:
-        raise ValueError(f"Unsupported file type for BytesIO: {extension}")
+    raise ValueError(f"Unsupported file type for BytesIO: {extension}")
 
 
 def read_data(path: str | Path | BytesIO) -> pl.LazyFrame:
@@ -267,7 +266,7 @@ def read_data(path: str | Path | BytesIO) -> pl.LazyFrame:
     if original_path.is_dir():
         # It's a directory, possibly hive-partitioned at arbitrary depth.
         # Find the first supported data file, skipping hidden/OS-artifact entries.
-        for dirpath, dirs, files in os.walk(str(original_path)):
+        for _dirpath, dirs, files in os.walk(str(original_path)):
             dirs[:] = [d for d in dirs if not d.startswith(".") and not _is_artifact(d)]
             for file in sorted(files):
                 if file.startswith(".") or _is_artifact(file):
@@ -569,10 +568,7 @@ def _import_file(
             try_parse_dates=True,
             ignore_errors=ignore_errors,
         )
-        if isinstance(file, BytesIO):
-            df = pl.read_csv(file, **csv_opts).lazy()
-        else:
-            df = pl.scan_csv(file, **csv_opts)
+        df = pl.read_csv(file, **csv_opts).lazy() if isinstance(file, BytesIO) else pl.scan_csv(file, **csv_opts)
         return _fill_context_field_nulls(df)
 
     if extension == ".json":
@@ -604,10 +600,7 @@ def _import_file(
         return _fill_context_field_nulls(df)
 
     if extension.casefold() in {".feather", ".ipc", ".arrow"}:
-        if isinstance(file, BytesIO):
-            df = pl.read_ipc(file).lazy()
-        else:
-            df = pl.scan_ipc(file)
+        df = pl.read_ipc(file).lazy() if isinstance(file, BytesIO) else pl.scan_ipc(file)
         return _fill_context_field_nulls(df)
 
     raise ValueError(

--- a/python/pdstools/pega_io/File.py
+++ b/python/pdstools/pega_io/File.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gzip
 import logging
 import os
@@ -8,17 +10,19 @@ import tarfile
 import tempfile
 import warnings
 import zipfile
-from collections.abc import Iterable
 from datetime import datetime, timezone
 from glob import glob
 from io import BytesIO
 from pathlib import Path
-from typing import Literal, cast, overload
+from typing import Literal, cast, overload, TYPE_CHECKING
 
 import polars as pl
 import polars.selectors as cs
 
 from ..utils.cdh_utils import from_prpc_date_time
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/pega_io/S3.py
+++ b/python/pdstools/pega_io/S3.py
@@ -95,7 +95,7 @@ class S3Data:
                 ["aioboto3"],
                 namespace="S3Data",
                 deps_group="pega_io",
-            )
+            ) from None
 
         def ensure_path(path: str) -> None:
             if not os.path.exists(path):

--- a/python/pdstools/pega_io/__init__.py
+++ b/python/pdstools/pega_io/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .Anonymization import Anonymization
 from .API import _read_client_credential_file as _read_client_credential_file
 from .API import get_token

--- a/python/pdstools/prediction/Plots.py
+++ b/python/pdstools/prediction/Plots.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Literal, overload
+from typing import ClassVar, Literal, TYPE_CHECKING, overload
 
 import polars as pl
 
 from ..utils import cdh_utils
 from ..utils.namespaces import LazyNamespace
-from ..utils.types import QUERY
 
 if TYPE_CHECKING:
+    from ..utils.types import QUERY
     from plotly.graph_objects import Figure
 
     from .Prediction import Prediction
@@ -34,7 +34,7 @@ class PredictionPlots(LazyNamespace):
     lift, CTR, and response counts over time.
     """
 
-    dependencies = ["plotly"]
+    dependencies: ClassVar[list[str]] = ["plotly"]
     dependency_group = "adm"
 
     def __init__(self, prediction: Prediction):
@@ -73,7 +73,7 @@ class PredictionPlots(LazyNamespace):
         """
         import plotly.express as px
 
-        from ..utils import pega_template as pega_template  # noqa: F401  (registers template)
+        from ..utils import pega_template as pega_template
 
         # Calculate date_range FIRST and collect it to avoid Polars lazy query race condition
         # where multiple lazy queries from the same LazyFrame can cause crashes

--- a/python/pdstools/prediction/Prediction.py
+++ b/python/pdstools/prediction/Prediction.py
@@ -533,12 +533,11 @@ class Prediction:
         time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S.%f")[:-3]
 
         if self.predictions is not None:
-            predictions_cache = pega_io.cache_to_file(
+            return pega_io.cache_to_file(
                 self.predictions,
                 abs_path,
                 name=f"cached_prediction_data_{time}",
             )
-            return predictions_cache
 
     @classmethod
     def from_processed_data(cls, df: pl.LazyFrame):
@@ -638,14 +637,10 @@ class Prediction:
                                     _interpolate(160, 200, p, days),
                                     _interpolate(120, 120, p, days),
                                     None,
-                                ]
-                                + [
                                     _interpolate(120, 120, p, days),
                                     _interpolate(250, 300, p, days),
                                     _interpolate(150, 150, p, days),
                                     None,
-                                ]
-                                + [
                                     _interpolate(1400, 1400, p, days),
                                     _interpolate(2800, 4000, p, days),
                                     _interpolate(1520, 1520, p, days),
@@ -830,8 +825,8 @@ class Prediction:
                     .then(pl.lit(False))
                     .otherwise(pl.col("isMultiChannel"))
                     .alias("isMultiChannel"),
-                ]
-                + period_expr,
+                    *period_expr,
+                ],
             )
             .group_by(
                 [

--- a/python/pdstools/prediction/Prediction.py
+++ b/python/pdstools/prediction/Prediction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import itertools
 import logging
@@ -12,8 +14,11 @@ from ..utils.metric_limits import (
     get_predictions_channel_mapping,
     is_standard_NBAD_prediction,
 )
-from ..utils.types import QUERY
 from .Plots import PredictionPlots
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 

--- a/python/pdstools/prediction/Prediction.py
+++ b/python/pdstools/prediction/Prediction.py
@@ -4,7 +4,6 @@ import datetime
 import itertools
 import logging
 import os
-from collections.abc import Iterable
 
 import polars as pl
 
@@ -18,6 +17,8 @@ from .Plots import PredictionPlots
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
@@ -345,14 +346,14 @@ class Prediction:
         if boto3_client is None:
             try:
                 import boto3
-            except ImportError:
+            except ImportError as err:
                 from ..utils.namespaces import MissingDependenciesException
 
                 raise MissingDependenciesException(
                     ["boto3"],
                     namespace="Prediction.from_s3",
                     deps_group="pega_io",
-                )
+                ) from err
             boto3_client = boto3.client("s3", region_name=region)
 
         import tempfile

--- a/python/pdstools/prediction/__init__.py
+++ b/python/pdstools/prediction/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .Plots import PredictionPlots
 from .Prediction import Prediction
 

--- a/python/pdstools/reports/GlobalExplanations/__init__.py
+++ b/python/pdstools/reports/GlobalExplanations/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 # Global Explanations reports module

--- a/python/pdstools/reports/GlobalExplanations/scripts/__init__.py
+++ b/python/pdstools/reports/GlobalExplanations/scripts/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 # Global Explanations scripts module

--- a/python/pdstools/reports/GlobalExplanations/scripts/generate_report.py
+++ b/python/pdstools/reports/GlobalExplanations/scripts/generate_report.py
@@ -255,7 +255,7 @@ class ReportGenerator:
             context_content_template = self._read_template(ALL_CONTEXT_CONTENT_TEMPLATE)
             single_context_template = self._read_template(SINGLE_CONTEXT_TEMPLATE)
 
-            for query_batch_nb, contexts in context_batches.items():
+            for _query_batch_nb, contexts in context_batches.items():
                 for context in contexts:
                     context_str = self._get_context_string(context)
                     context_label = ("plt-" + context_str).lower()

--- a/python/pdstools/reports/GlobalExplanations/scripts/generate_report.py
+++ b/python/pdstools/reports/GlobalExplanations/scripts/generate_report.py
@@ -8,6 +8,8 @@ Templates are located in: assets/templates/
 Generated .qmd files are written to the project root for Quarto to render.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import logging

--- a/python/pdstools/resources/__init__.py
+++ b/python/pdstools/resources/__init__.py
@@ -1,5 +1,7 @@
 """Resources module for pdstools configuration data."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 _RESOURCES_DIR = Path(__file__).parent

--- a/python/pdstools/utils/__init__.py
+++ b/python/pdstools/utils/__init__.py
@@ -7,4 +7,6 @@ fully-qualified path. Nothing is re-exported at the package level — the
 namespaced and don't leak into the public API surface.
 """
 
+from __future__ import annotations
+
 __all__: list[str] = []

--- a/python/pdstools/utils/cdh_utils/__init__.py
+++ b/python/pdstools/utils/cdh_utils/__init__.py
@@ -88,24 +88,10 @@ from ._polars import (
 )
 
 __all__ = [
-    # constants / shared types
-    "F",
     "POLARS_DURATION_PATTERN",
     "QUERY",
-    "logger",
-    # date / time
-    "from_prpc_date_time",
-    "parse_pega_date_time_formats",
-    "to_prpc_date_time",
-    # naming / categorisation
-    "default_predictor_categorization",
-    # polars helpers
-    "is_valid_polars_duration",
-    "lazy_sample",
-    "overlap_lists_polars",
-    "overlap_matrix",
-    "weighted_average_polars",
-    "weighted_performance_polars",
+    # constants / shared types
+    "F",
     # metrics
     "auc_from_bincounts",
     "auc_from_probs",
@@ -113,17 +99,31 @@ __all__ = [
     "aucpr_from_bincounts",
     "aucpr_from_probs",
     "bin_log_odds",
-    "feature_importance",
-    "gains_table",
-    "lift",
-    "log_odds_polars",
-    "safe_range_auc",
-    "z_ratio",
     # I/O / misc
     "create_working_and_temp_dir",
+    # naming / categorisation
+    "default_predictor_categorization",
+    "feature_importance",
+    # date / time
+    "from_prpc_date_time",
+    "gains_table",
     "get_latest_pdstools_version",
+    # polars helpers
+    "is_valid_polars_duration",
+    "lazy_sample",
     "legend_color_order",
+    "lift",
+    "log_odds_polars",
+    "logger",
+    "overlap_lists_polars",
+    "overlap_matrix",
+    "parse_pega_date_time_formats",
     "process_files_to_bytes",
     "safe_flatten_list",
+    "safe_range_auc",
     "setup_logger",
+    "to_prpc_date_time",
+    "weighted_average_polars",
+    "weighted_performance_polars",
+    "z_ratio",
 ]

--- a/python/pdstools/utils/cdh_utils/__init__.py
+++ b/python/pdstools/utils/cdh_utils/__init__.py
@@ -19,6 +19,8 @@ supported import surface. Imports such as
 unchanged.
 """
 
+from __future__ import annotations
+
 # ruff: noqa: F401
 # Re-export the module-level imports that the legacy single-file module
 # exposed via ``dir(cdh_utils)``. Some downstream code relied on these

--- a/python/pdstools/utils/cdh_utils/_common.py
+++ b/python/pdstools/utils/cdh_utils/_common.py
@@ -1,5 +1,7 @@
 """Shared internals used across the cdh_utils submodules."""
 
+from __future__ import annotations
+
 import logging
 from typing import TypeVar
 

--- a/python/pdstools/utils/cdh_utils/_dates.py
+++ b/python/pdstools/utils/cdh_utils/_dates.py
@@ -1,9 +1,14 @@
 """Date and time helpers for Pega-formatted timestamps."""
 
+from __future__ import annotations
+
 import datetime
 
 import polars as pl
-from polars._typing import PolarsTemporalType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from polars._typing import PolarsTemporalType
 
 
 def parse_pega_date_time_formats(

--- a/python/pdstools/utils/cdh_utils/_io.py
+++ b/python/pdstools/utils/cdh_utils/_io.py
@@ -1,17 +1,22 @@
 """I/O, logging, working-directory and version-check helpers."""
 
+from __future__ import annotations
+
 import datetime
 import io
 import logging
 import tempfile
 import zipfile
 from io import StringIO
-from os import PathLike
 from pathlib import Path
 
 import polars as pl
 
 from ._common import logger
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 
 def process_files_to_bytes(

--- a/python/pdstools/utils/cdh_utils/_metrics.py
+++ b/python/pdstools/utils/cdh_utils/_metrics.py
@@ -199,10 +199,7 @@ def aucpr_from_bincounts(
 
     pos_arr = np.asarray(pos)
     neg_arr = np.asarray(neg)
-    if probs is None:
-        o = np.argsort(-(pos_arr / (pos_arr + neg_arr)))
-    else:
-        o = np.argsort(-np.asarray(probs))
+    o = np.argsort(-(pos_arr / (pos_arr + neg_arr))) if probs is None else np.argsort(-np.asarray(probs))
     recall = np.cumsum(pos_arr[o]) / np.sum(pos_arr)
     precision = np.cumsum(pos_arr[o]) / np.cumsum(pos_arr[o] + neg_arr[o])
     prevrecall = np.insert(recall[0 : (len(recall) - 1)], 0, 0)
@@ -530,13 +527,13 @@ def gains_table(df, value: str, index=None, by=None):
         )
     else:
         by_as_list = by if isinstance(by, list) else [by]
-        sort_exprs: list[str | pl.Expr] = by_as_list + [sort_expr]
+        sort_exprs: list[str | pl.Expr] = [*by_as_list, sort_expr]
         gains_df = (
             df.lazy()
             .sort(sort_exprs, descending=True)
             .select(
-                by_as_list
-                + [
+                [
+                    *by_as_list,
                     index_expr.over(by).cast(pl.Float64).alias("cum_x"),
                     (pl.cum_sum(value) / pl.sum(value)).over(by).cast(pl.Float64).alias("cum_y"),
                 ],
@@ -545,6 +542,6 @@ def gains_table(df, value: str, index=None, by=None):
         # Add entry for the (0,0) point
         gains_df = pl.concat(
             [gains_df.group_by(by).agg(cum_x=pl.lit(0.0), cum_y=pl.lit(0.0)), gains_df],
-        ).sort(by_as_list + ["cum_x"])
+        ).sort([*by_as_list, "cum_x"])
 
     return gains_df.collect()

--- a/python/pdstools/utils/cdh_utils/_metrics.py
+++ b/python/pdstools/utils/cdh_utils/_metrics.py
@@ -1,11 +1,16 @@
 """Performance metrics: AUC, lift, log-odds, gains, feature importance."""
 
+from __future__ import annotations
+
 import math
-from collections.abc import Sequence
 
 import polars as pl
 
 from ._polars import weighted_average_polars
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def safe_range_auc(auc: float) -> float:

--- a/python/pdstools/utils/cdh_utils/_misc.py
+++ b/python/pdstools/utils/cdh_utils/_misc.py
@@ -1,5 +1,7 @@
 """Miscellaneous helpers that don't belong to a single concern."""
 
+from __future__ import annotations
+
 from functools import partial
 from operator import is_not
 

--- a/python/pdstools/utils/cdh_utils/_namespacing.py
+++ b/python/pdstools/utils/cdh_utils/_namespacing.py
@@ -1,9 +1,14 @@
 """Pega-style field-name normalisation and predictor categorisation."""
 
+from __future__ import annotations
+
 import re
-from collections.abc import Iterable
 
 import polars as pl
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def _capitalize(

--- a/python/pdstools/utils/cdh_utils/_namespacing.py
+++ b/python/pdstools/utils/cdh_utils/_namespacing.py
@@ -116,8 +116,7 @@ def _capitalize(
     # processing "Configuration" after will correct it back.
     for word in sorted(capitalize_endwords, key=len):
         fields = [re.sub(word, word, field, flags=re.IGNORECASE) for field in fields]
-    fields = [field[:1].upper() + field[1:] for field in fields]
-    return fields
+    return [field[:1].upper() + field[1:] for field in fields]
 
 
 def default_predictor_categorization(

--- a/python/pdstools/utils/cdh_utils/_polars.py
+++ b/python/pdstools/utils/cdh_utils/_polars.py
@@ -1,15 +1,19 @@
 """Polars expression and frame helpers (queries, sampling, schema, overlap)."""
 
+from __future__ import annotations
+
 import re
-from collections.abc import Iterable
-from typing import overload
+from typing import overload, TYPE_CHECKING
 
 import polars as pl
 
-from ..types import QUERY
 from ._common import F, logger
 from ._dates import parse_pega_date_time_formats
 from ._namespacing import _capitalize
+
+if TYPE_CHECKING:
+    from ..types import QUERY
+    from collections.abc import Iterable
 
 
 # Pattern for validating Polars duration strings (e.g., "1d", "2w", "1h30m")

--- a/python/pdstools/utils/cdh_utils/_polars.py
+++ b/python/pdstools/utils/cdh_utils/_polars.py
@@ -115,11 +115,11 @@ def _combine_queries(existing_query: QUERY, new_query: pl.Expr) -> QUERY:
     if isinstance(existing_query, pl.Expr):
         return existing_query & new_query
     if isinstance(existing_query, list):
-        return existing_query + [new_query]
+        return [*existing_query, new_query]
     if isinstance(existing_query, dict):
         # Convert the dictionary to a list of expressions
         existing_exprs = [pl.col(k).is_in(v) for k, v in existing_query.items()]
-        return existing_exprs + [new_query]
+        return [*existing_exprs, new_query]
     raise ValueError("Unsupported query type")
 
 

--- a/python/pdstools/utils/color_mapping.py
+++ b/python/pdstools/utils/color_mapping.py
@@ -5,7 +5,12 @@ categorical dimensions across Streamlit applications. Color consistency is
 critical for user experience when filtering/interacting with visualizations.
 """
 
-import polars as pl
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
 
 
 def create_categorical_color_mappings(

--- a/python/pdstools/utils/datasets.py
+++ b/python/pdstools/utils/datasets.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import warnings
 
 from ..adm.ADMDatamart import ADMDatamart
 from ..adm.trees import ADMTreesModel
-from ..utils.types import QUERY
 from ..valuefinder.ValueFinder import ValueFinder
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..utils.types import QUERY
 
 
 def cdh_sample(query: QUERY | None = None) -> ADMDatamart:

--- a/python/pdstools/utils/datasets.py
+++ b/python/pdstools/utils/datasets.py
@@ -34,10 +34,11 @@ def cdh_sample(query: QUERY | None = None) -> ADMDatamart:
         except Exception as e:
             raise RuntimeError(
                 f"Error importing CDH Sample. Warnings: {[str(i) for i in w] if len(w) > 0 else 'None'}, exceptions: {e}",
-            )
+            ) from e
 
 
 def sample_trees():
+    """Sample trees."""
     with warnings.catch_warnings(record=True) as w:
         try:
             return ADMTreesModel.from_url(
@@ -46,7 +47,7 @@ def sample_trees():
         except Exception as e:
             raise RuntimeError(
                 f"Error importing the Sample Trees dataset. Warnings: {[str(i) for i in w] if len(w) > 0 else 'None'}, exceptions: {e}",
-            )
+            ) from e
 
 
 def sample_value_finder(threshold: float | None = None) -> ValueFinder:
@@ -76,4 +77,4 @@ def sample_value_finder(threshold: float | None = None) -> ValueFinder:
         except Exception as e:
             raise RuntimeError(
                 f"Error importing the Value Finder dataset. Warnings: {[str(i) for i in w] if len(w) > 0 else 'None'}, exceptions: {e}",
-            )
+            ) from e

--- a/python/pdstools/utils/errors.py
+++ b/python/pdstools/utils/errors.py
@@ -1,2 +1,4 @@
 class NotApplicableError(ValueError):
+    """Not applicable error."""
+
     pass

--- a/python/pdstools/utils/errors.py
+++ b/python/pdstools/utils/errors.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class NotApplicableError(ValueError):
     """Not applicable error."""
 

--- a/python/pdstools/utils/metric_limits.py
+++ b/python/pdstools/utils/metric_limits.py
@@ -10,6 +10,8 @@ that turn metric values into "RAG" indicators that can be used to highlight
 values in tables.
 """
 
+from __future__ import annotations
+
 import difflib
 import re
 from typing import Any, ClassVar, Literal

--- a/python/pdstools/utils/metric_limits.py
+++ b/python/pdstools/utils/metric_limits.py
@@ -12,7 +12,7 @@ values in tables.
 
 import difflib
 import re
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 from collections.abc import Callable
 
 import polars as pl
@@ -47,6 +47,7 @@ class MetricLimits:
     _limits_df: pl.DataFrame | None
 
     def __new__(cls) -> "MetricLimits":
+        """New."""
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._limits_df = None
@@ -470,12 +471,14 @@ def exclusive_0_1_range_rag(value: float) -> RAGValue | None:
 
 
 def positive_values(value: float) -> RAGValue | None:
+    """Positive values."""
     if value is None:
         return None
     return "GREEN" if value >= 0 else "RED"
 
 
 def strict_positive_values(value: float) -> RAGValue | None:
+    """Strict positive values."""
     if value is None:
         return None
     return "GREEN" if value > 0 else "RED"
@@ -614,7 +617,7 @@ class MetricFormats:
 
     """
 
-    _FORMATS: dict[str, NumberFormat] = {
+    _FORMATS: ClassVar[dict[str, NumberFormat]] = {
         "ModelPerformance": NumberFormat(decimals=2, scale_by=100),
         "EngagementLift": NumberFormat(decimals=0, scale_by=100, suffix="%"),
         "OmniChannelPercentage": NumberFormat(decimals=1, scale_by=100, suffix="%"),

--- a/python/pdstools/utils/namespaces.py
+++ b/python/pdstools/utils/namespaces.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import logging
 import sys

--- a/python/pdstools/utils/namespaces.py
+++ b/python/pdstools/utils/namespaces.py
@@ -23,6 +23,8 @@ def _to_install_name(dep: str) -> str:
 
 
 def require_dependencies(func):
+    """Decorator that triggers dependency checking before invoking ``func``."""
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         self.check_dependencies()
@@ -32,7 +34,10 @@ def require_dependencies(func):
 
 
 class LazyNamespaceMeta(type):
+    """Lazy namespace meta."""
+
     def __new__(cls, name, bases, dct):
+        """New."""
         for attr_name, attr_value in dct.items():
             if isinstance(attr_value, types.FunctionType) and attr_name not in [
                 "__init__",
@@ -44,6 +49,8 @@ class LazyNamespaceMeta(type):
 
 
 class LazyNamespace(metaclass=LazyNamespaceMeta):
+    """Lazy namespace."""
+
     dependencies: list[str] | None
     dependency_group: str | None
 
@@ -51,6 +58,7 @@ class LazyNamespace(metaclass=LazyNamespaceMeta):
         self._dependencies_checked = False
 
     def check_dependencies(self):
+        """Check dependencies."""
         if not self._dependencies_checked:
             self._check_dependencies()
             self._dependencies_checked = True
@@ -77,6 +85,8 @@ class LazyNamespace(metaclass=LazyNamespaceMeta):
 
 
 class MissingDependenciesException(Exception):
+    """Missing dependencies exception."""
+
     def __init__(
         self,
         deps: list[str],

--- a/python/pdstools/utils/number_format.py
+++ b/python/pdstools/utils/number_format.py
@@ -8,14 +8,16 @@ Polars expressions).
 See: https://posit-dev.github.io/great-tables/reference/vals.fmt_number.html
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from math import isnan
 from typing import TYPE_CHECKING
-from collections.abc import Callable
 
 import polars as pl
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from great_tables import GT
 
 __all__ = ["NumberFormat"]

--- a/python/pdstools/utils/pega_template.py
+++ b/python/pdstools/utils/pega_template.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import plotly.graph_objects as go
 import plotly.io as pio
 

--- a/python/pdstools/utils/plot_utils.py
+++ b/python/pdstools/utils/plot_utils.py
@@ -6,6 +6,8 @@ installed, an optional-dependency import shim, label abbreviation,
 facet-title cleanup, dynamic facet sizing, and report-layout adjustments.
 """
 
+from __future__ import annotations
+
 import logging
 import math
 from typing import TYPE_CHECKING, Any, TypeAlias

--- a/python/pdstools/utils/polars_ext.py
+++ b/python/pdstools/utils/polars_ext.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import polars as pl
 
 

--- a/python/pdstools/utils/polars_ext.py
+++ b/python/pdstools/utils/polars_ext.py
@@ -3,10 +3,13 @@ import polars as pl
 
 @pl.api.register_lazyframe_namespace("pdstools")
 class Sample:
+    """Sample."""
+
     def __init__(self, ldf: pl.LazyFrame) -> None:
         self._ldf = ldf
 
     def sample(self, n):
+        """Sample."""
         from functools import partial
 
         def sample_it(s: pl.Series, n) -> pl.Series:
@@ -30,11 +33,14 @@ class Sample:
         )
 
     def height(self):
+        """Height."""
         return self._ldf.select(pl.first().len()).collect().item()
 
     def shape(self):
+        """Shape."""
         return (self.height(), len(self._ldf.collect_schema().names()))
 
     def item(self):
+        """Item."""
         if self.shape() == (1, 1):
             return self._ldf.collect().item()

--- a/python/pdstools/utils/progress_utils.py
+++ b/python/pdstools/utils/progress_utils.py
@@ -78,19 +78,17 @@ def format_time_estimate(min_sec: float, max_sec: float) -> str:
         # Fallback if humanize not available
         if max_sec < 60:
             return f"{int(max_sec)} seconds"
-        else:
-            return f"{int(max_sec / 60)} minutes"
+        return f"{int(max_sec / 60)} minutes"
 
     if max_sec < 10:
         return "a few seconds"
-    elif max_sec < 60:
+    if max_sec < 60:
         return f"{int(max_sec)} seconds"
-    else:
-        min_str = humanize.naturaldelta(min_sec)
-        max_str = humanize.naturaldelta(max_sec)
-        if min_str == max_str:
-            return min_str
-        return f"{min_str} to {max_str}"
+    min_str = humanize.naturaldelta(min_sec)
+    max_str = humanize.naturaldelta(max_sec)
+    if min_str == max_str:
+        return min_str
+    return f"{min_str} to {max_str}"
 
 
 def estimate_sampling_time(total_rows: int, sample_size: int) -> tuple[float, float]:

--- a/python/pdstools/utils/progress_utils.py
+++ b/python/pdstools/utils/progress_utils.py
@@ -11,6 +11,8 @@ The estimates are based on calibrated speeds and provide ranges to account
 for system variability.
 """
 
+from __future__ import annotations
+
 
 def estimate_extraction_time(file_size_bytes: int) -> tuple[float, float]:
     """Estimate extraction time for a zip file based on size.

--- a/python/pdstools/utils/report_utils/__init__.py
+++ b/python/pdstools/utils/report_utils/__init__.py
@@ -104,25 +104,36 @@ from ._tables import create_metric_gttable, create_metric_itable
 __all__ = [
     # shared types / state
     "QUERY",
-    "logger",
     # re-exports from sibling modules
     "MetricFormats",
     "MetricLimits",
     "NumberFormat",
-    "exclusive_0_1_range_rag",
-    "positive_values",
-    "standard_NBAD_channels_rag",
-    "standard_NBAD_configurations_rag",
-    "standard_NBAD_directions_rag",
-    "standard_NBAD_predictions_rag",
-    "strict_positive_values",
+    # polars helpers / aggregations
+    "avg_by_hierarchy",
+    # html post-processing
+    "bundle_quarto_resources",
+    "check_report_for_errors",
     # filenames / resource copying
     "copy_quarto_file",
     "copy_report_resources",
+    # rag-coloured metric tables
+    "create_metric_gttable",
+    "create_metric_itable",
+    # query serialisation
+    "deserialize_query",
+    "exclusive_0_1_range_rag",
+    "gains_table",
+    "generate_zipped_report",
     "get_output_filename",
     # quarto execution / callouts / credits
     "get_pandoc_with_version",
     "get_quarto_with_version",
+    "logger",
+    "max_by_hierarchy",
+    "n_unique_values",
+    "polars_col_exists",
+    "polars_subset_to_existing_cols",
+    "positive_values",
     "quarto_callout_important",
     "quarto_callout_info",
     "quarto_callout_no_prediction_data_warning",
@@ -130,23 +141,12 @@ __all__ = [
     "quarto_plot_exception",
     "quarto_print",
     "run_quarto",
-    "show_credits",
-    # html post-processing
-    "bundle_quarto_resources",
-    "check_report_for_errors",
-    "generate_zipped_report",
-    # rag-coloured metric tables
-    "create_metric_gttable",
-    "create_metric_itable",
-    # polars helpers / aggregations
-    "avg_by_hierarchy",
-    "gains_table",
-    "max_by_hierarchy",
-    "n_unique_values",
-    "polars_col_exists",
-    "polars_subset_to_existing_cols",
     "sample_values",
-    # query serialisation
-    "deserialize_query",
     "serialize_query",
+    "show_credits",
+    "standard_NBAD_channels_rag",
+    "standard_NBAD_configurations_rag",
+    "standard_NBAD_directions_rag",
+    "standard_NBAD_predictions_rag",
+    "strict_positive_values",
 ]

--- a/python/pdstools/utils/report_utils/__init__.py
+++ b/python/pdstools/utils/report_utils/__init__.py
@@ -22,6 +22,8 @@ supported import surface. Imports such as
 to resolve unchanged.
 """
 
+from __future__ import annotations
+
 # ruff: noqa: F401
 # Re-export the module-level imports that the legacy single-file module
 # exposed via ``dir(report_utils)``. Some downstream code (and Quarto

--- a/python/pdstools/utils/report_utils/_common.py
+++ b/python/pdstools/utils/report_utils/_common.py
@@ -1,5 +1,7 @@
 """Shared module-level state for the ``report_utils`` submodules."""
 
+from __future__ import annotations
+
 import logging
 
 logger = logging.getLogger("pdstools.utils.report_utils")

--- a/python/pdstools/utils/report_utils/_filenames.py
+++ b/python/pdstools/utils/report_utils/_filenames.py
@@ -1,8 +1,13 @@
 """Filename generation and resource copying for report rendering."""
 
+from __future__ import annotations
+
 import os
 import shutil
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def get_output_filename(

--- a/python/pdstools/utils/report_utils/_html.py
+++ b/python/pdstools/utils/report_utils/_html.py
@@ -1,5 +1,7 @@
 """HTML post-processing: CSS inlining, zip bundling, error scanning."""
 
+from __future__ import annotations
+
 import os
 import re
 import shutil

--- a/python/pdstools/utils/report_utils/_html.py
+++ b/python/pdstools/utils/report_utils/_html.py
@@ -199,12 +199,12 @@ def check_report_for_errors(html_path: str | Path) -> list[str]:
             with zipfile.ZipFile(html_path) as zf:
                 html_members = [n for n in zf.namelist() if n.endswith(".html")]
                 if not html_members:
-                    raise IOError(f"No HTML file found inside zip: {html_path}")
+                    raise OSError(f"No HTML file found inside zip: {html_path}")
                 content = zf.read(html_members[0]).decode("utf-8")
         else:
             content = html_path.read_text(encoding="utf-8")
     except Exception as e:
-        raise IOError(f"Failed to read HTML file: {e}")
+        raise OSError(f"Failed to read HTML file: {e}") from e
 
     errors = []
 

--- a/python/pdstools/utils/report_utils/_polars_helpers.py
+++ b/python/pdstools/utils/report_utils/_polars_helpers.py
@@ -1,5 +1,7 @@
 """Small Polars helpers and aggregations used by Quarto reports."""
 
+from __future__ import annotations
+
 import polars as pl
 
 

--- a/python/pdstools/utils/report_utils/_polars_helpers.py
+++ b/python/pdstools/utils/report_utils/_polars_helpers.py
@@ -122,10 +122,7 @@ def gains_table(
     sort_expr = pl.col(value) if index is None else pl.col(value) / pl.col(index)
 
     # Determine index expression for cumulative x-axis
-    if index is None:
-        index_expr = pl.int_range(1, pl.len() + 1) / pl.len()
-    else:
-        index_expr = pl.cum_sum(index) / pl.sum(index)
+    index_expr = pl.int_range(1, pl.len() + 1) / pl.len() if index is None else pl.cum_sum(index) / pl.sum(index)
 
     if by is None:
         # Single gains curve
@@ -143,13 +140,13 @@ def gains_table(
     else:
         # Multiple gains curves grouped by column(s)
         by_as_list = by if isinstance(by, list) else [by]
-        sort_expr_with_by = by_as_list + [sort_expr]
+        sort_expr_with_by = [*by_as_list, sort_expr]
         gains_df = (
             df.lazy()
             .sort(sort_expr_with_by, descending=True)
             .select(
-                by_as_list
-                + [
+                [
+                    *by_as_list,
                     index_expr.over(by).cast(pl.Float64).alias("cum_x"),
                     (pl.cum_sum(value) / pl.sum(value)).over(by).cast(pl.Float64).alias("cum_y"),
                 ]
@@ -157,7 +154,7 @@ def gains_table(
         )
         # Add entry for the (0,0) point for each group
         gains_df = pl.concat([gains_df.group_by(by).agg(cum_x=pl.lit(0.0), cum_y=pl.lit(0.0)), gains_df]).sort(
-            by_as_list + ["cum_x"]
+            [*by_as_list, "cum_x"]
         )
 
     return gains_df.collect()

--- a/python/pdstools/utils/report_utils/_quarto.py
+++ b/python/pdstools/utils/report_utils/_quarto.py
@@ -15,7 +15,7 @@ from ._html import _inline_css
 def _write_params_files(
     temp_dir: Path,
     params: dict | None = None,
-    project: dict = {"type": "default"},
+    project: dict | None = None,
     analysis: dict | None = None,
     full_embed: bool = False,
 ) -> None:
@@ -46,6 +46,8 @@ def _write_params_files(
 
     params = params or {}
     analysis = analysis or {}
+    if project is None:
+        project = {"type": "default"}
 
     # Parameters to python code
     with open(temp_dir / "params.yml", "w") as f:
@@ -84,9 +86,9 @@ def run_quarto(
     output_filename: str | None = None,
     output_type: str | None = "html",
     params: dict | None = None,
-    project: dict = {"type": "default"},
+    project: dict | None = None,
     analysis: dict | None = None,
-    temp_dir: Path = Path(),
+    temp_dir: Path | None = None,
     *,
     full_embed: bool = False,
 ) -> int:
@@ -129,6 +131,8 @@ def run_quarto(
         If required files are not found
 
     """
+    if temp_dir is None:
+        temp_dir = Path()
 
     def get_command() -> list[str]:
         quarto_exec, _ = get_quarto_with_version()
@@ -273,7 +277,7 @@ def _get_cmd_output(args: list[str]) -> list[str]:
         logger.error(f"Failed to run command {' '.join(args)}: {e}")
         raise FileNotFoundError(
             f"Command failed. Make sure {args[0]} is installed and in the system PATH.",
-        )
+        ) from e
 
 
 def _get_version_only(versionstr: str) -> str:
@@ -401,4 +405,4 @@ def show_credits(quarto_source: str | None = None):
         ]
     )
 
-    quarto_print("\n\n    ".join([""] + lines) + "\n\n    ")
+    quarto_print("\n\n    ".join(["", *lines]) + "\n\n    ")

--- a/python/pdstools/utils/report_utils/_quarto.py
+++ b/python/pdstools/utils/report_utils/_quarto.py
@@ -1,5 +1,7 @@
 """Quarto execution helpers: run, version detection, callouts, credits."""
 
+from __future__ import annotations
+
 import datetime
 import os
 import re

--- a/python/pdstools/utils/report_utils/_query.py
+++ b/python/pdstools/utils/report_utils/_query.py
@@ -1,11 +1,16 @@
 """Serialise/deserialise pdstools ``QUERY`` objects for embedding in reports."""
 
+from __future__ import annotations
+
 import io
 import json
 
 import polars as pl
 
-from ..types import QUERY
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..types import QUERY
 
 
 def serialize_query(query: QUERY | None) -> dict | None:

--- a/python/pdstools/utils/report_utils/_tables.py
+++ b/python/pdstools/utils/report_utils/_tables.py
@@ -1,5 +1,7 @@
 """RAG-coloured metric table builders (itables and great_tables)."""
 
+from __future__ import annotations
+
 import html
 from typing import Any
 

--- a/python/pdstools/utils/show_versions.py
+++ b/python/pdstools/utils/show_versions.py
@@ -136,6 +136,8 @@ def _external_tool_status(tool: str) -> str:
 
 
 def expand_nested_deps(extras: dict[str, set[str]]) -> dict[str, set[str]]:
+    """Expand nested deps."""
+
     def expand_dep(dep: str, processed: set[str]) -> set[str]:
         if not dep.startswith(f"{package_name}["):
             return {dep}
@@ -165,6 +167,7 @@ def expand_nested_deps(extras: dict[str, set[str]]) -> dict[str, set[str]]:
 
 
 def grouped_dependencies() -> dict[str, set[str]]:
+    """Grouped dependencies."""
     extras: dict[str, set[str]] = {"required": set()}
     requires = importlib.metadata.distribution(package_name).requires
     if not requires:  # pragma: no cover
@@ -194,7 +197,7 @@ def _get_dependency_version(dep_name: str) -> str:
         logger.debug(f"Failed to import module {dep_name}: {e}")
         return "<not installed>"
 
-    if hasattr(module, "__version__"):
+    if hasattr(module, "__version__"):  # noqa: SIM108 — comment clarifies the fallback
         module_version = module.__version__
     else:
         # importlib.metadata was introduced in Python 3.8
@@ -213,15 +216,15 @@ def _dependency_table(public_only: bool = False):
             _ = dependencies.pop(private_dep_group)
     deps = [{"group": k, "deps": list(v.union(required))} for k, v in dependencies.items()]
     pivot = pl.DataFrame(deps).explode("deps").pivot(values="deps", index="group", on="deps")
-    pivotted = pivot.with_columns(
+    return pivot.with_columns(
         pl.when(pl.col(col).is_not_null()).then(pl.lit("√")).otherwise(pl.lit("X")).alias(col)
         for col in pivot.columns
         if col != "group"
     )
-    return pivotted
 
 
 def dependency_great_table(public_only: bool = True):
+    """Dependency great table."""
     import great_tables
 
     dependency_table = _dependency_table(public_only=public_only)
@@ -229,7 +232,7 @@ def dependency_great_table(public_only: bool = True):
     optional_deps = list(set(dependency_table.collect_schema().names()))
     optional_deps = [n for n in optional_deps if n not in [*required_deps, "required"]]
     dependency_table = dependency_table.select(*required_deps, *optional_deps)
-    tab = (
+    return (
         great_tables.GT(dependency_table)
         .tab_header("Optional dependencies")
         .tab_options(column_labels_hidden=False)
@@ -237,4 +240,3 @@ def dependency_great_table(public_only: bool = True):
         .tab_spanner(label="Required", columns=list(required_deps))
         .tab_spanner(label="Optional", columns=list(set(optional_deps)))
     )
-    return tab

--- a/python/pdstools/utils/streamlit_utils.py
+++ b/python/pdstools/utils/streamlit_utils.py
@@ -299,10 +299,7 @@ def parse_sample_spec(value: str) -> dict[str, int | float]:
     elif value.lower().endswith("m"):
         multiplier = 1000000
 
-    if multiplier:
-        count = int(float(value[:-1]) * multiplier)
-    else:
-        count = int(value)
+    count = int(float(value[:-1]) * multiplier) if multiplier else int(value)
 
     if count <= 0:
         raise ValueError(f"Sample count must be positive, got {count}")
@@ -320,6 +317,7 @@ def get_current_index(options, key, default=0):
 
 @st.cache_resource
 def cached_sample():
+    """Cached sample."""
     return datasets.cdh_sample()
 
 
@@ -347,6 +345,7 @@ def cached_datamart(**kwargs):
 
 @st.cache_resource
 def cached_sample_prediction():
+    """Cached sample prediction."""
     return Prediction.from_mock_data(days=60)
 
 
@@ -432,6 +431,7 @@ def import_datamart(
 
 
 def from_uploaded_file(extract_pyname_keys, codespaces, infer_schema_length=10000):
+    """From uploaded file."""
     model_file = st.file_uploader(
         "Upload Model Snapshot",
         type=["json", "zip", "parquet", "csv", "arrow"],
@@ -495,6 +495,7 @@ def from_uploaded_file(extract_pyname_keys, codespaces, infer_schema_length=1000
 
 
 def from_file_path(extract_pyname_keys, codespaces, infer_schema_length=10000):
+    """From file path."""
     st.write(
         """If you've followed the instructions on how to get the ADMDatamart data,
     you can import the data simply by pointing the app to the directory
@@ -589,8 +590,9 @@ def from_file_path(extract_pyname_keys, codespaces, infer_schema_length=10000):
 
 
 def model_selection_df(df: pl.LazyFrame, context_keys: list):
+    """Model selection df."""
     return (
-        df.select(["ModelID", "Configuration"] + context_keys)
+        df.select(["ModelID", "Configuration", *context_keys])
         .unique()
         .sort("Name")
         .select(pl.lit(False).alias("Generate Report"), pl.all())
@@ -601,7 +603,7 @@ def model_selection_df(df: pl.LazyFrame, context_keys: list):
 def filter_dataframe(
     df: pl.LazyFrame,
     schema: dict | None = None,
-    queries=[],
+    queries: list | None = None,
 ) -> pl.LazyFrame:
     """Adds a UI on top of a dataframe to let viewers filter columns
 
@@ -616,6 +618,8 @@ def filter_dataframe(
         The filtered LazyFrame
 
     """
+    if queries is None:
+        queries = []
     to_filter_columns = st.multiselect(
         "Filter dataframe on",
         df.collect_schema().names(),
@@ -722,6 +726,7 @@ def model_and_row_counts(df: ANY_FRAME):
 
 
 def configure_predictor_categorization():
+    """Configure predictor categorization."""
     df = st.session_state["dm"].combinedData
     if len(st.session_state["filters"]) > 0:
         for filter in st.session_state["filters"]:
@@ -755,11 +760,13 @@ def configure_predictor_categorization():
 
 @st.cache_data
 def convert_df(df):
+    """Convert df."""
     return df.write_csv().encode("utf-8")
 
 
 @st.cache_data
 def st_get_latest_pdstools_version():
+    """St get latest pdstools version."""
     return cdh_utils.get_latest_pdstools_version()
 
 

--- a/python/pdstools/utils/streamlit_utils.py
+++ b/python/pdstools/utils/streamlit_utils.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
-from typing import Literal
+from typing import Literal, TYPE_CHECKING
 
 from packaging.version import Version, InvalidVersion
 import plotly.express as px
@@ -13,8 +15,10 @@ from .. import pega_io
 from ..adm.ADMDatamart import ADMDatamart
 from ..prediction.Prediction import Prediction
 from ..utils import datasets
-from ..utils.types import ANY_FRAME
 from . import cdh_utils
+
+if TYPE_CHECKING:
+    from ..utils.types import ANY_FRAME
 
 # ---------------------------------------------------------------------------
 # Shared Streamlit helpers — used by all pdstools apps

--- a/python/pdstools/utils/table_definitions.py
+++ b/python/pdstools/utils/table_definitions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import polars as pl
 
 

--- a/python/pdstools/utils/table_definitions.py
+++ b/python/pdstools/utils/table_definitions.py
@@ -2,6 +2,8 @@ import polars as pl
 
 
 class PegaDefaultTables:
+    """Pega default tables."""
+
     class ADMModelSnapshot:
         pxApplication = pl.Categorical
         pyAppliesToClass = pl.Categorical

--- a/python/pdstools/utils/types.py
+++ b/python/pdstools/utils/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 
 import polars as pl

--- a/python/pdstools/valuefinder/Aggregates.py
+++ b/python/pdstools/valuefinder/Aggregates.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
 
 
 class Aggregates:
+    """Aggregates."""
+
     def __init__(self, vf: "ValueFinder"):
         self.vf = vf
         self._quantile_from_threshold: dict[float, float] = {}
@@ -44,6 +46,7 @@ class Aggregates:
         )
 
     def get_counts_per_stage(self, *, threshold: float | None = None):
+        """Get counts per stage."""
         threshold = threshold or self.vf.threshold
         customer_summary = self.get_customer_summary(threshold=threshold)
         return (
@@ -58,10 +61,12 @@ class Aggregates:
 
     @cached_property
     def max_propensity_per_customer(self) -> pl.DataFrame:
+        """Max propensity per customer."""
         return self.vf.df.group_by(["CustomerID", "Stage"]).agg(pl.max("ModelPropensity")).collect()
 
-    @cache
+    @cache  # noqa: B019 — VF instances are short-lived analysis objects, not long-running services
     def get_threshold_from_quantile(self, quantile: float) -> float:
+        """Get threshold from quantile."""
         threshold = (
             self.vf.df.filter(pl.col("Stage") == "Eligibility")
             .select(pl.col("ModelPropensity").quantile(quantile))
@@ -75,8 +80,9 @@ class Aggregates:
         self._quantile_from_threshold[threshold] = quantile
         return threshold
 
-    @cache
+    @cache  # noqa: B019 — VF instances are short-lived analysis objects, not long-running services
     def get_counts_for_threshold(self, threshold: float) -> pl.DataFrame:
+        """Get counts for threshold."""
         return (
             self.max_propensity_per_customer.with_columns(
                 RelevantActions=pl.col("ModelPropensity") >= pl.lit(threshold),

--- a/python/pdstools/valuefinder/Aggregates.py
+++ b/python/pdstools/valuefinder/Aggregates.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import cache, cached_property
 from typing import TYPE_CHECKING
 

--- a/python/pdstools/valuefinder/Plots.py
+++ b/python/pdstools/valuefinder/Plots.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
 from typing import (
     TYPE_CHECKING,
+    ClassVar,
     Literal,
     TypeVar,
     cast,
@@ -15,12 +15,13 @@ from typing_extensions import ParamSpec
 
 from ..utils.cdh_utils import _apply_query, lazy_sample
 from ..utils.namespaces import LazyNamespace
-from ..utils.plot_utils import Figure
-from ..utils.types import QUERY
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    from ..utils.plot_utils import Figure
+    from collections.abc import Iterable
     from .ValueFinder import ValueFinder
 
 COLORSCALE_TYPES = list[tuple[float, str]] | list[str]
@@ -30,7 +31,9 @@ P = ParamSpec("P")
 
 
 class Plots(LazyNamespace):
-    dependencies = ["plotly"]
+    """Plots."""
+
+    dependencies: ClassVar[list[str]] = ["plotly"]
     dependency_group = "adm"
 
     def __init__(self, vf: "ValueFinder"):
@@ -59,6 +62,7 @@ class Plots(LazyNamespace):
         query: QUERY | None = None,
         return_df: bool = False,
     ):
+        """Funnel chart."""
         df = _apply_query(self.vf.df, query)
         df = (
             df.group_by("Stage")
@@ -87,6 +91,7 @@ class Plots(LazyNamespace):
         return fig
 
     def propensity_distribution(self, sample_size: int = 10_000) -> Figure:
+        """Propensity distribution."""
         import plotly.figure_factory as ff
         import plotly.graph_objects as go
         from plotly.subplots import make_subplots
@@ -143,6 +148,7 @@ class Plots(LazyNamespace):
         sample_size: int = 10_000,
         stage="Eligibility",
     ) -> Figure:
+        """Propensity threshold."""
         import plotly.figure_factory as ff
         import plotly.graph_objects as go
         from plotly.subplots import make_subplots
@@ -241,6 +247,7 @@ class Plots(LazyNamespace):
         quantiles: Iterable[float] | None = None,
         rounding: int = 3,
     ):
+        """Pie charts."""
         import plotly.graph_objects as go
         from plotly.subplots import make_subplots
 
@@ -342,9 +349,10 @@ class Plots(LazyNamespace):
         quantiles: Iterable[float] | None = None,
         rounding: int = 3,
     ):
+        """Distribution per threshold."""
         import plotly.express as px
 
-        from ..utils import pega_template as pega_template  # noqa: F401
+        from ..utils import pega_template as pega_template
 
         thresholds = self._get_thresholds(
             thresholds,
@@ -365,7 +373,7 @@ class Plots(LazyNamespace):
             "NoActions": "Without actions",
         }
         plot_df = pl.concat(df).rename(col_name_map)
-        fig = (
+        return (
             px.area(
                 plot_df,
                 x="Threshold",
@@ -386,4 +394,3 @@ class Plots(LazyNamespace):
             .update_layout(legend_title_text="Status")
             .update_xaxes(tickformat=",.1%")
         )
-        return fig

--- a/python/pdstools/valuefinder/Schema.py
+++ b/python/pdstools/valuefinder/Schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import polars as pl
 
 

--- a/python/pdstools/valuefinder/Schema.py
+++ b/python/pdstools/valuefinder/Schema.py
@@ -2,6 +2,8 @@ import polars as pl
 
 
 class pyValueFinder:
+    """Py value finder."""
+
     pyDirection = pl.Categorical
     pySubjectType = pl.Categorical
     ModelPositives = pl.UInt32

--- a/python/pdstools/valuefinder/ValueFinder.py
+++ b/python/pdstools/valuefinder/ValueFinder.py
@@ -54,6 +54,7 @@ class ValueFinder:
         n_customers: int | None = None,
         threshold: float | None = None,
     ):
+        """From ds export."""
         df = read_ds_export(filename or "value_finder", base_path)
         if df is None:
             raise ValueError(f"Could not find {filename} in {base_path}")
@@ -71,6 +72,7 @@ class ValueFinder:
         cache_file_prefix: str = "",
         cache_directory: os.PathLike | str = "cache",
     ):
+        """From dataflow export."""
         df = read_dataflow_output(
             files,
             cache_file_prefix + "value_finder",
@@ -85,6 +87,7 @@ class ValueFinder:
         )  # pragma: no cover
 
     def set_threshold(self, new_threshold: float | None = None):
+        """Set threshold."""
         if new_threshold:
             self._th = pl.LazyFrame({"th": new_threshold})
         else:
@@ -94,6 +97,7 @@ class ValueFinder:
 
     @cached_property
     def threshold(self):
+        """Threshold."""
         return self._th.collect().item()
 
     def save_data(self, path: os.PathLike | str = ".") -> Path | None:
@@ -111,10 +115,9 @@ class ValueFinder:
 
         """
         time = datetime.now().strftime("%Y%m%dT%H%M%S.%f")[:-3]
-        cache_file = cache_to_file(
+        return cache_to_file(
             self.df,
             path,
             name=f"cached_value_finder_data_{time}",
             cache_type="parquet",
         )
-        return cache_file

--- a/python/pdstools/valuefinder/ValueFinder.py
+++ b/python/pdstools/valuefinder/ValueFinder.py
@@ -1,18 +1,23 @@
-import os
-from collections.abc import Iterable
+from __future__ import annotations
+
 from datetime import datetime
 from functools import cached_property
-from pathlib import Path
 
 import polars as pl
 
 from ..pega_io import read_dataflow_output, read_ds_export
 from ..pega_io.File import cache_to_file
 from ..utils import cdh_utils
-from ..utils.types import QUERY
 from . import Schema
 from .Aggregates import Aggregates
 from .Plots import Plots
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..utils.types import QUERY
+    from pathlib import Path
+    from collections.abc import Iterable
+    import os
 
 
 class ValueFinder:

--- a/python/pdstools/valuefinder/__init__.py
+++ b/python/pdstools/valuefinder/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .ValueFinder import ValueFinder
 
 __all__ = ["ValueFinder"]

--- a/python/tests/adm/test_ADMTrees.py
+++ b/python/tests/adm/test_ADMTrees.py
@@ -32,9 +32,9 @@ def sample_x(trees):
         if len(values) == 1:
             if "true" in values or "false" in values:
                 values = {"true", "false"}
-            if isinstance(list(values)[0], str):
+            if isinstance(next(iter(values)), str):
                 try:
-                    float(list(values)[0])
+                    float(next(iter(values)))
                 except Exception:
                     print("FAILED ON ", values)
                     values = values.union({"Other"})

--- a/python/tests/adm/test_BinAggregator_accumulate.py
+++ b/python/tests/adm/test_BinAggregator_accumulate.py
@@ -21,7 +21,10 @@ import pytest
 from polars.testing import assert_frame_equal
 
 from pdstools import datasets
-from pdstools.adm.BinAggregator import BinAggregator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pdstools.adm.BinAggregator import BinAggregator
 
 
 @pytest.fixture(scope="module")
@@ -173,10 +176,7 @@ def _make_synthetic_case(seed: int, n_models: int, n_bins: int, *, disjoint: boo
                 prev = x
 
         nb = len(edges) - 1
-        if immature and m % 2 == 0:
-            responses = [0.0] * nb
-        else:
-            responses = [rng.uniform(0, 5000) for _ in range(nb)]
+        responses = [0.0] * nb if immature and m % 2 == 0 else [rng.uniform(0, 5000) for _ in range(nb)]
         lifts = [rng.uniform(-1.5, 2.0) for _ in range(nb)]
         mid = f"model_{seed}_{m}"
         sources.append(_make_source(mid, edges, lifts, responses))

--- a/python/tests/adm/test_Prediction.py
+++ b/python/tests/adm/test_Prediction.py
@@ -581,7 +581,7 @@ def test_performance_range_in_summary_methods(preds_singleday):
     )
 
     # Secondary invariant: a non-degenerate AUC must sit in [0.5, 1.0].
-    for perf in performance_values + [overall_perf] + list(mock_rows.values()):
+    for perf in [*performance_values, overall_perf, *list(mock_rows.values())]:
         assert 0.5 <= perf <= 1.0
 
 

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -1802,7 +1802,7 @@ class TestOfferQualityAnalysis:
         # For stages without propensity, should use atleast_one_action instead of relevant/irrelevant
         stages_without_prop = set(da_v2.AvailableNBADStages) - set(da_v2.stages_with_propensity)
         if stages_without_prop:
-            stage = list(stages_without_prop)[0]
+            stage = next(iter(stages_without_prop))
             stage_df = df.filter(pl.col(da_v2.level) == stage)
             if stage_df.height > 0:
                 # Should have atleast_one_action counts, not relevant/irrelevant

--- a/python/tests/decision_analyzer/test_data_read_utils.py
+++ b/python/tests/decision_analyzer/test_data_read_utils.py
@@ -251,7 +251,7 @@ class TestValidateColumns:
     def test_display_name_columns_accepted(self):
         """validate_columns should accept display names as well as raw names."""
         cols = {}
-        for raw_col, config in DecisionAnalyzer.items():
+        for _raw_col, config in DecisionAnalyzer.items():
             if config["default"]:
                 display_name = config["display_name"]
                 dtype = config["type"]

--- a/python/tests/infinity/test_resource.py
+++ b/python/tests/infinity/test_resource.py
@@ -26,8 +26,7 @@ class _GreetMixin:
 
     @api_method
     async def greet(self, name: str) -> str:
-        result = await self._a_get(f"/hello/{name}")
-        return result
+        return await self._a_get(f"/hello/{name}")
 
     async def _internal_helper(self) -> str:
         """Plain async helper — should NOT be wrapped by __init_subclass__."""

--- a/python/tests/prediction_studio/test_onnx_universal.py
+++ b/python/tests/prediction_studio/test_onnx_universal.py
@@ -8,9 +8,12 @@ Run with:
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _pytorch_available() -> bool:

--- a/python/tests/reports/test_global_explanations_generation.py
+++ b/python/tests/reports/test_global_explanations_generation.py
@@ -77,7 +77,7 @@ def params_file(temp_report_dir):
 @pytest.fixture
 def mock_templates():
     """Mock template content for testing."""
-    templates = {
+    return {
         "getting-started.qmd": """---
 title: "Getting Started"
 ---
@@ -130,7 +130,6 @@ Top N: {TOP_N}
 Sort by text: {SORT_BY_TEXT}
 """,
     }
-    return templates
 
 
 class TestReportGeneration:

--- a/python/tests/streamlit_apps/decision_analyzer/test_channel_filter.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_channel_filter.py
@@ -16,13 +16,16 @@ both session-state keys reflect the new selection.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import polars as pl
 
 from streamlit.testing.v1 import AppTest
 
-from pdstools.decision_analyzer.DecisionAnalyzer import DecisionAnalyzer
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pdstools.decision_analyzer.DecisionAnalyzer import DecisionAnalyzer
+    from pathlib import Path
 
 
 def _find_selectbox(at: AppTest, key: str):

--- a/python/tests/streamlit_apps/decision_analyzer/test_da_autoload_missing_sample.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_da_autoload_missing_sample.py
@@ -10,10 +10,13 @@ branch falls through with no data.
 
 from __future__ import annotations
 
-from pathlib import Path
 
-import pytest
 from streamlit.testing.v1 import AppTest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+    from pathlib import Path
 
 
 def test_da_home_renders_when_sample_missing(

--- a/python/tests/streamlit_apps/decision_analyzer/test_da_home.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_da_home.py
@@ -8,9 +8,12 @@ seeded via the ``seeded_decision_analyzer`` fixture.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from streamlit.testing.v1 import AppTest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_home_renders_without_data(da_app_dir: Path):

--- a/python/tests/streamlit_apps/decision_analyzer/test_da_home_rerun.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_da_home_rerun.py
@@ -10,9 +10,12 @@ the transition from "no data" to "have data".
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from streamlit.testing.v1 import AppTest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_sample_auto_load_triggers_rerun_then_unlocks_nav(da_app_dir: Path):

--- a/python/tests/streamlit_apps/decision_analyzer/test_da_pages.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_da_pages.py
@@ -26,12 +26,15 @@ edits.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 from streamlit.testing.v1 import AppTest
 
-from pdstools.decision_analyzer.DecisionAnalyzer import DecisionAnalyzer
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pdstools.decision_analyzer.DecisionAnalyzer import DecisionAnalyzer
+    from pathlib import Path
 
 # Page 12 (About) is intentionally excluded — it uses the shared
 # `show_about_page()` helper, which is exercised by the HC/IA About

--- a/python/tests/streamlit_apps/decision_analyzer/test_da_wrong_format_upload.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_da_wrong_format_upload.py
@@ -9,10 +9,13 @@ error rather than crashing with a Python stack trace.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 from streamlit.testing.v1 import AppTest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_da_garbage_parquet_upload_handled_gracefully(da_app_dir: Path) -> None:

--- a/python/tests/streamlit_apps/decision_analyzer/test_stage_level_radio.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_stage_level_radio.py
@@ -15,11 +15,14 @@ state-transition: change the radio value, verify the analyzer's
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from streamlit.testing.v1 import AppTest
 
-from pdstools.decision_analyzer.DecisionAnalyzer import DecisionAnalyzer
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pdstools.decision_analyzer.DecisionAnalyzer import DecisionAnalyzer
+    from pathlib import Path
 
 
 def _find_radio(at: AppTest, key: str):

--- a/python/tests/streamlit_apps/decision_analyzer/test_upload_replaces_autoload.py
+++ b/python/tests/streamlit_apps/decision_analyzer/test_upload_replaces_autoload.py
@@ -17,11 +17,14 @@ not the sample's.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import polars as pl
 import pytest
 from streamlit.testing.v1 import AppTest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 # Distinctive row count — must not collide with the bundled sample's

--- a/python/tests/streamlit_apps/health_check/test_direct_upload_renders.py
+++ b/python/tests/streamlit_apps/health_check/test_direct_upload_renders.py
@@ -11,9 +11,12 @@ value.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from streamlit.testing.v1 import AppTest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_direct_file_upload_renders_uploaders(hc_app_dir: Path):

--- a/python/tests/streamlit_apps/health_check/test_hc_autoload_missing_sample.py
+++ b/python/tests/streamlit_apps/health_check/test_hc_autoload_missing_sample.py
@@ -12,10 +12,13 @@ exception branch.
 
 from __future__ import annotations
 
-from pathlib import Path
 
-import pytest
 from streamlit.testing.v1 import AppTest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+    from pathlib import Path
 
 
 def _boom() -> object:

--- a/python/tests/streamlit_apps/health_check/test_hc_pages.py
+++ b/python/tests/streamlit_apps/health_check/test_hc_pages.py
@@ -8,12 +8,15 @@ instead of passing silently.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 from streamlit.testing.v1 import AppTest
 
-from pdstools.adm.ADMDatamart import ADMDatamart
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pdstools.adm.ADMDatamart import ADMDatamart
+    from pathlib import Path
 
 
 def test_home_renders_without_data(hc_app_dir: Path):

--- a/python/tests/streamlit_apps/health_check/test_hc_wrong_format_upload.py
+++ b/python/tests/streamlit_apps/health_check/test_hc_wrong_format_upload.py
@@ -10,9 +10,12 @@ user can retry.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from streamlit.testing.v1 import AppTest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_hc_garbage_zip_upload_handled_gracefully(hc_app_dir: Path) -> None:

--- a/python/tests/streamlit_apps/impact_analyzer/test_ia_pages.py
+++ b/python/tests/streamlit_apps/impact_analyzer/test_ia_pages.py
@@ -9,13 +9,16 @@ instead of passing silently.
 from __future__ import annotations
 
 import copy
-from pathlib import Path
 
 import polars as pl
 import pytest
 from streamlit.testing.v1 import AppTest
 
-from pdstools.impactanalyzer.ImpactAnalyzer import ImpactAnalyzer
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pdstools.impactanalyzer.ImpactAnalyzer import ImpactAnalyzer
+    from pathlib import Path
 
 
 def test_home_pre_load_text_is_product_neutral(ia_app_dir: Path):

--- a/python/tests/streamlit_apps/launcher/test_cross_app_state_isolation.py
+++ b/python/tests/streamlit_apps/launcher/test_cross_app_state_isolation.py
@@ -24,10 +24,13 @@ should be upgraded to drive the real ``switch_page`` flow.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 from streamlit.testing.v1 import AppTest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_da_autoload_independent_of_hc_dm(da_app_dir: Path, hc_app_dir: Path) -> None:

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -21,7 +21,7 @@ class TestAppsDict:
     def test_launcher_is_first_entry(self):
         # Order matters — launcher is the default selection in the
         # interactive picker, so it must be the first key.
-        assert list(APPS.keys())[0] == "launcher"
+        assert next(iter(APPS.keys())) == "launcher"
 
     def test_launcher_path_points_at_launcher_module(self):
         assert APPS["launcher"]["path"] == "pdstools.app.launcher"
@@ -32,12 +32,12 @@ class TestAppsDict:
             assert "path" in value, f"{key} missing 'path'"
 
     def test_display_names_are_strings(self):
-        for key, value in APPS.items():
+        for _key, value in APPS.items():
             assert isinstance(value["display_name"], str)
             assert len(value["display_name"]) > 0
 
     def test_paths_are_dotted_module_paths(self):
-        for key, value in APPS.items():
+        for _key, value in APPS.items():
             path = value["path"]
             assert isinstance(path, str)
             assert path.startswith("pdstools.app.")
@@ -415,7 +415,7 @@ class TestRunInteractivePrompt:
     def test_select_by_number(self):
         args = self._run_with_input(["1"])
         # First entry in APPS is the cross-app launcher
-        assert args.app == list(APPS.keys())[0]
+        assert args.app == next(iter(APPS.keys()))
         assert args.app == "launcher"
 
     def test_launcher_alias_resolves(self, monkeypatch):
@@ -481,7 +481,7 @@ class TestRunQuestionaryPicker:
                 with patch.object(sys, "exit"):
                     args = _make_args(app=None)
                     run(args, [])
-        assert args.app == list(APPS.keys())[0]
+        assert args.app == next(iter(APPS.keys()))
 
     def test_questionary_choice_sets_app(self, monkeypatch):
         """When questionary returns a choice, run() launches that app."""
@@ -551,7 +551,7 @@ class TestRunQuestionaryPicker:
                 with patch.object(sys, "exit"):
                     args = _make_args(app=None)
                     run(args, [])
-        assert args.app == list(APPS.keys())[0]
+        assert args.app == next(iter(APPS.keys()))
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_doc_scenarios.py
+++ b/python/tests/test_doc_scenarios.py
@@ -36,10 +36,7 @@ basePath = pathlib.Path(__file__).parent.parent.parent
 def test_notebook(relative_filepath):
     file = str(basePath / relative_filepath)
 
-    if platform.system() == "Windows":  # pragma: no cover
-        pythonPath = "python"
-    else:
-        pythonPath = str(basePath / "python")
+    pythonPath = "python" if platform.system() == "Windows" else str(basePath / "python")
 
     with testbook(file) as tb:
         tb.inject(

--- a/python/tests/utils/test_cdh_utils.py
+++ b/python/tests/utils/test_cdh_utils.py
@@ -497,8 +497,8 @@ def test_feature_importance_scaled_multiple_predictors():
             # High importance: very strong differentiation between bins
             "PredictorName": ["High"] * 3 + ["Medium"] * 3 + ["Low"] * 3,
             "ModelID": ["m1"] * 9,
-            "BinPositives": [95, 5, 50] + [70, 40, 50] + [52, 50, 48],  # High varies a lot, Low is uniform
-            "BinNegatives": [5, 95, 50] + [30, 60, 50] + [48, 50, 52],
+            "BinPositives": [95, 5, 50, 70, 40, 50, 52, 50, 48],  # High varies a lot, Low is uniform
+            "BinNegatives": [5, 95, 50, 30, 60, 50, 48, 50, 52],
             "BinResponseCount": [100, 100, 100] * 3,
         }
     )
@@ -777,7 +777,7 @@ def test_gains_table():
             1,
         ]
     ]
-    assert gains.get_column("cum_y").round(5).to_list() == [0] + expected_gains
+    assert gains.get_column("cum_y").round(5).to_list() == [0, *expected_gains]
 
     # with responses, the order should be the same as in the classifier data
     gains = cdh_utils.gains_table(df, "Positives", index="Responses")

--- a/python/tests/utils/test_report_utils.py
+++ b/python/tests/utils/test_report_utils.py
@@ -176,16 +176,16 @@ def test_create_metric_itable_column_descriptions(monkeypatch):
 
     assert captured_df is not None
     # Check that Model column was renamed to include tooltip
-    model_col = [c for c in captured_df.columns if "Model" in c][0]
+    model_col = next(c for c in captured_df.columns if "Model" in c)
     assert 'title="The predictive model name"' in model_col
     assert "<span" in model_col
 
     # Check that Performance column was renamed to include tooltip
-    perf_col = [c for c in captured_df.columns if "Performance" in c][0]
+    perf_col = next(c for c in captured_df.columns if "Performance" in c)
     assert 'title="Model AUC score (0.5-1.0)"' in perf_col
 
     # Channel was not in column_descriptions, so should not have tooltip
-    channel_col = [c for c in captured_df.columns if "Channel" in c][0]
+    channel_col = next(c for c in captured_df.columns if "Channel" in c)
     assert channel_col == "Channel"  # unchanged
 
 


### PR DESCRIPTION
This is the v5.0.0 lint + typing tightening pass agreed in the audit
reviews. Three commits, scoped to keep each diff reviewable.

## Commit 1 — chore(ruff): tighten lint config for v5

Adds 28 new ruff rule codes to `extend-select`. Headline changes:

- `RUF005/012/015/022/100`: collection literals, ClassVar on mutable
  class defaults, sorted `__all__`, unused-noqa enforcement.
- `RUF001/002/003`: ambiguous unicode flagged, but with a curated
  `allowed-confusables = ["×", "ℹ", "–", "‑"]` so intentional
  typography (`5 × 10 grid`, en-dashes in numeric ranges,
  non-breaking hyphens, info icons in Streamlit headers) is kept
  as-authored.
- `B904`: 21 sites converted to `raise ... from err` / `from None`.
- `B006/007/008/019/024/028`: mutable-default and abuse-of-cache
  patterns flagged. Polars expressions (`pl.col`, `pl.lit`, …) and
  `pathlib.Path` whitelisted via `extend-immutable-calls`.
- `RET504/505/506` + `SIM108`: return / ternary cleanups.
- `TC001/002/003`: 77 imports moved into TYPE_CHECKING blocks. Two
  must remain at runtime (`METRIC` consumed by
  `pydantic.validate_call`) and carry `# noqa: TC001` with an
  explanation.
- `LOG015`: 5 `logging.info(...)` calls switched to module-level
  `logger.info(...)`.
- `D101/D102/D103` with numpy convention: 77 minimal numpy-style
  docstrings added in core modules. `app/`, `ih/`, `infinity/`,
  `tests/`, `docs/`, `examples/`, and `scripts/` get per-file
  ignores (UI / SDK / fixture code where docstrings aren't
  load-bearing).
- `UP012/UP024`: trivial modernisations.

## Commit 2 — chore: add `from __future__ import annotations` project-wide

121 modules updated. Mechanical change, tests confirm no behaviour
diff. The new annotation deferral exposed 46 additional TC violations
which were also auto-fixed in this commit.

## Commit 3 — typing: remove `# type: ignore` that hide real bugs (3 sites)

- `infinity/.../v24_2/prediction_studio/_async.py` (×2):
  `pages.get(**uniques)` had `# type: ignore[union-attr,
  return-value]` because `list_predictions()`/`list_models()` return
  `AsyncPaginatedList[X] | pl.DataFrame`. Narrow with `cast(...)`
  since `return_df=False` (the default) always yields the paginated
  list — the call site is now honest about the type.
- `cli.py`: optional `questionary` fallback used
  `questionary = None  # type: ignore[assignment]`. Replaced with an
  explicit `questionary: ModuleType | None` annotation; the existing
  `if questionary is not None` guard narrows correctly.

## Validation

- `uv run ruff check .` → all checks pass
- `uv run pre-commit run --all-files` → all hooks pass
- Targeted pytest runs across utils / infinity / prediction_studio /
  test_cli pass cleanly
- Full suite matches `master`: same 12 streamlit_apps state-isolation
  flakes and the same `test_Prediction.py::test_plots` shape-assertion
  failure exist on `master` and are unrelated to this PR.

## Out of scope (deferred to v5.1)

- `ANN`, `TID252`, and `N` rules (per the user's plan)
- Promoting the auto-generated one-line docstrings on the highest-traffic
  functions to full numpy-style sections
- A docstring sweep for `infinity/` (currently per-file-ignored)