### PR TITLE
Fix dependabot resolution errors from #788

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires-python = ">=3.10,<3.15"
 # Bounds are added to deps that ship breaking majors regularly. Stable single-
 # major deps (requests, pyyaml, ipywidgets, etc.) can stay loose.
 dependencies = [
-    "polars>=1.37,!=1.35.1,<=1.39.3",
+    "polars>=1.37,!=1.35.1,<2",
     'typing_extensions',
 ]
 
@@ -53,14 +53,14 @@ adm = [
     'pydot>=4.0,<5',
     'requests',
 ]
-pega_io = ['aioboto3>=15.0,<16', 'boto3>=1.40,<2', 'polars_hash>=0.5,<1']
+pega_io = ['aioboto3>=15.5,<16', 'boto3>=1.40,<2', 'polars_hash>=0.5,<1']
 api = ['httpx>=0.27,<1', 'pydantic>=2.10,<3', 'anyio>=4.0,<5']
 healthcheck = ['pdstools[adm]', 'great_tables>=0.13,<1', 'quarto', 'papermill>=2.6,<3', 'xlsxwriter>=3.0,<4', 'pydot>=4.0,<5', 'ipykernel>=6,<8']
 explanations = ['duckdb>=1.1,<2', "plotly[express]>=6.0,<7", "pyarrow>=18,<25", "pyyaml>=6,<7", "ipywidgets"]
 app = [
     'pdstools[healthcheck]',
     'streamlit>=1.45,<2',
-    "polars[rt64]>=1.37,!=1.35.1,<=1.39.3",
+    "polars[rt64]>=1.37,!=1.35.1,<2",
     'humanize>=4.0.0,<5',
     'fastexcel>=0.19,<1',
     'questionary>=2.0,<3',
@@ -70,8 +70,7 @@ onnx = [
     'skl2onnx>=1.19.1', # Updated to be compatible with onnx 1.19.0+
     'onnx>=1.18,<1.22', # Using ONNX 1.18.x specifically
     'pdstools[api]',
-    "onnxruntime>=1.22,<1.24; python_version < '3.11'",
-    "onnxruntime>=1.22,<1.25; python_version >= '3.11'",
+    "onnxruntime>=1.22,<1.25",
     "scipy>=1.15.3",
 ]
 all = ['pdstools[app, pega_io, onnx, explanations]']

--- a/uv.lock
+++ b/uv.lock
@@ -3027,7 +3027,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioboto3", marker = "extra == 'pega-io'", specifier = ">=15.0,<16" },
+    { name = "aioboto3", marker = "extra == 'pega-io'", specifier = ">=15.5,<16" },
     { name = "anyio", marker = "extra == 'api'", specifier = ">=4.0,<5" },
     { name = "anyio", marker = "extra == 'docs'" },
     { name = "boto3", marker = "extra == 'pega-io'", specifier = ">=1.40,<2" },
@@ -3047,8 +3047,7 @@ requires-dist = [
     { name = "myst-parser", marker = "extra == 'docs'" },
     { name = "nbsphinx", marker = "extra == 'docs'" },
     { name = "onnx", marker = "extra == 'onnx'", specifier = ">=1.18,<1.22" },
-    { name = "onnxruntime", marker = "python_full_version >= '3.11' and extra == 'onnx'", specifier = ">=1.22,<1.25" },
-    { name = "onnxruntime", marker = "python_full_version < '3.11' and extra == 'onnx'", specifier = ">=1.22,<1.24" },
+    { name = "onnxruntime", marker = "extra == 'onnx'", specifier = ">=1.22,<1.25" },
     { name = "openpyxl", marker = "extra == 'tests'", specifier = ">=3" },
     { name = "papermill", marker = "extra == 'healthcheck'", specifier = ">=2.6,<3" },
     { name = "pdstools", extras = ["adm"], marker = "extra == 'healthcheck'" },
@@ -3058,8 +3057,8 @@ requires-dist = [
     { name = "pdstools", extras = ["healthcheck"], marker = "extra == 'app'" },
     { name = "plotly", extras = ["express"], marker = "extra == 'adm'", specifier = ">=6.0,<7" },
     { name = "plotly", extras = ["express"], marker = "extra == 'explanations'", specifier = ">=6.0,<7" },
-    { name = "polars", specifier = "!=1.35.1,>=1.37,<=1.39.3" },
-    { name = "polars", extras = ["rt64"], marker = "extra == 'app'", specifier = "!=1.35.1,>=1.37,<=1.39.3" },
+    { name = "polars", specifier = "!=1.35.1,>=1.37,<2" },
+    { name = "polars", extras = ["rt64"], marker = "extra == 'app'", specifier = "!=1.35.1,>=1.37,<2" },
     { name = "polars-hash", marker = "extra == 'pega-io'", specifier = ">=0.5,<1" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pyarrow", marker = "extra == 'explanations'", specifier = ">=18,<25" },


### PR DESCRIPTION
Stacks on top of #788. Three floor/cap conflicts surfaced on the first dependabot run after #788 introduced bounded direct dependencies.

Fixes

┌────────────────┬────────────────────────────┬──────────────────────┬─────────────────────────────────────────────────────────────────────────────────────┐
│ Dep            │ Was                        │ Now                  │ Why                                                                                 │
├────────────────┼────────────────────────────┼──────────────────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ polars         │ >=1.37,!=1.35.1,<=1.39.3   │ >=1.37,!=1.35.1,<2   │ Stale point-pin pre-dating the bounded strategy; blocked every polars patch/minor   │
│                │                            │                      │ dependabot tried.                                                                   │
├────────────────┼────────────────────────────┼──────────────────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ polars[rt64]   │ same                       │ same                 │ Mirror change.                                                                      │
│ (app extra)    │                            │                      │                                                                                     │
├────────────────┼────────────────────────────┼──────────────────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ aioboto3       │ >=15.0,<16                 │ >=15.5,<16           │ aioboto3 15.0 → aiobotocore 2.23 → botocore <1.38.28, incompatible with boto3>=1.40 │
│ (pega_io)      │                            │                      │ (needs botocore 1.40.x). 15.5 is the first 15.x tracking botocore 1.40.             │
├────────────────┼────────────────────────────┼──────────────────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ onnxruntime    │ split: <1.24; py<3.11 /    │ >=1.22,<1.25         │ onnxruntime 1.24 dropped cp310 wheels, so uv naturally resolves py3.10 to 1.23.x    │
│ (onnx)         │ <1.25; py>=3.11            │ (uniform)            │ without the marker. Split was over-engineering and dependabot's resolver kept       │
│                │                            │                      │ trying to bump the <3.11 entry to 1.24.3.                                           │
└────────────────┴────────────────────────────┴──────────────────────┴─────────────────────────────────────────────────────────────────────────────────────┘

Verification

uv pip install -e .[tests] --resolution=lowest-direct on Python 3.10 resolves cleanly to: aioboto3==15.5.0 · boto3==1.40.46 · botocore==1.40.61 · onnxruntime==1.22.0 · polars==1.37.0.

Note on strategy

This is the bracket strategy working as intended — the floor+cap combination caught a real cross-dep incompatibility that would otherwise have surfaced as a user resolver error after release. The fix is to tighten the floors, not abandon the approach.