### PR TITLE
Drop boto3 as a direct dep; let aioboto3 bring it in transitively

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ adm = [
     'pydot>=4.0,<5',
     'requests',
 ]
-pega_io = ['aioboto3>=15.5,<16', 'boto3>=1.40,<2', 'polars_hash>=0.5,<1']
+pega_io = ['aioboto3>=15.5,<16', 'polars_hash>=0.5,<1']
 api = ['httpx>=0.27,<1', 'pydantic>=2.10,<3', 'anyio>=4.0,<5']
 healthcheck = ['pdstools[adm]', 'great_tables>=0.13,<1', 'quarto', 'papermill>=2.6,<3', 'xlsxwriter>=3.0,<4', 'pydot>=4.0,<5', 'ipykernel>=6,<8']
 explanations = ['duckdb>=1.1,<2', "plotly[express]>=6.0,<7", "pyarrow>=18,<25", "pyyaml>=6,<7", "ipywidgets"]

--- a/uv.lock
+++ b/uv.lock
@@ -2873,7 +2873,6 @@ adm = [
 all = [
     { name = "aioboto3" },
     { name = "anyio" },
-    { name = "boto3" },
     { name = "duckdb" },
     { name = "fastexcel" },
     { name = "great-tables" },
@@ -2977,13 +2976,11 @@ onnx = [
 ]
 pega-io = [
     { name = "aioboto3" },
-    { name = "boto3" },
     { name = "polars-hash" },
 ]
 tests = [
     { name = "aioboto3" },
     { name = "anyio" },
-    { name = "boto3" },
     { name = "coverage" },
     { name = "duckdb" },
     { name = "fastexcel" },
@@ -3030,7 +3027,6 @@ requires-dist = [
     { name = "aioboto3", marker = "extra == 'pega-io'", specifier = ">=15.5,<16" },
     { name = "anyio", marker = "extra == 'api'", specifier = ">=4.0,<5" },
     { name = "anyio", marker = "extra == 'docs'" },
-    { name = "boto3", marker = "extra == 'pega-io'", specifier = ">=1.40,<2" },
     { name = "coverage", marker = "extra == 'tests'", specifier = ">=7" },
     { name = "duckdb", marker = "extra == 'docs'" },
     { name = "duckdb", marker = "extra == 'explanations'", specifier = ">=1.1,<2" },


### PR DESCRIPTION
boto3 and aioboto3 cannot move independently — aioboto3 ships 'aiobotocore[boto3]==<exact>' which pins botocore to a tight range that boto3 itself must match. aioboto3's release cadence lags boto3's by weeks-to-months, so any dependabot bump that pushes boto3 ahead of aioboto3 produces a resolver conflict.

#788 + #809 already hit this twice for the floor; the third dependabot run hit it on the *upper* side (boto3 1.43.16 vs aioboto3 15.5.0's aiobotocore pinning botocore <1.40.62).

Fix: stop declaring boto3 as a direct dep. aioboto3>=15.5 already pulls in boto3 (via aiobotocore[boto3]==2.25.1), so the pega_io extra still installs boto3 — verified by 'pip list' showing boto3==1.40.61 after 'pip install -e .[pega_io]' and 'import boto3' succeeding. The boto3 API surface we use (boto3.client("s3", ...)) has been stable across all 1.x; we never needed a 1.40 floor in the first place.

Effect: aioboto3 becomes the single source of truth that dependabot manages; boto3 follows transitively via the lockfile. No more boto3/aioboto3 floor-conflict whack-a-mole.