### PR TITLE
Feature/prediction studio refactor

### DIFF
--- a/examples/prediction_studio/PredictionStudio.ipynb
+++ b/examples/prediction_studio/PredictionStudio.ipynb
@@ -1050,8 +1050,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/prediction_studio/PredictionStudio.ipynb
+++ b/examples/prediction_studio/PredictionStudio.ipynb
@@ -109,8 +109,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions = client.prediction_studio.list_predictions(return_df=True)\n",
-    "predictions"
+    "predictions = client.prediction_studio.list_predictions()\n",
+    "predictions.as_df()\n"
    ]
   },
   {
@@ -128,8 +128,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prediction = client.prediction_studio.get_prediction(label=\"TestPrediction\")\n",
-    "prediction.describe()"
+    "prediction = predictions[\"TestPrediction\"]\n",
+    "prediction.describe()\n"
    ]
   },
   {
@@ -148,10 +148,10 @@
    "outputs": [],
    "source": [
     "from datetime import date\n",
-    "prediction = client.prediction_studio.get_prediction(label=\"TestPred\")\n",
+    "prediction = predictions[\"TestPred\"]\n",
     "prediction.get_metric(start_date=date(2026,4,2), end_date=date(2026,4,11),\n",
     "                        metric=\"Lift\",\n",
-    "                        frequency=\"Daily\")"
+    "                        frequency=\"Daily\")\n"
    ]
   },
   {
@@ -171,9 +171,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Predict_action_propensity = client.prediction_studio.get_prediction(label=\"ContinuousPMCharts\")\n",
-    "notification = Predict_action_propensity.get_notifications(return_df=True)\n",
-    "notification"
+    "predict_action_propensity = predictions[\"ContinuousPMCharts\"]\n",
+    "notification = predict_action_propensity.get_notifications(return_df=True)\n",
+    "notification\n"
    ]
   },
   {
@@ -189,8 +189,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "models = client.prediction_studio.list_models(return_df=True)\n",
-    "models"
+    "models = client.prediction_studio.list_models()\n",
+    "models.as_df()\n"
    ]
   },
   {
@@ -206,8 +206,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = client.prediction_studio.get_model(model_id=\"Data-Customer!Adm_16531579691\")\n",
-    "model.describe()"
+    "model = models[\"Data-Customer!Adm_16531579691\"]\n",
+    "model.describe()\n"
    ]
   },
   {
@@ -311,8 +311,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prediction = client.prediction_studio.get_prediction(label=\"SamplePred\")\n",
-    "prediction.get_champion_challengers()"
+    "prediction = predictions[\"SamplePred\"]\n",
+    "prediction.get_champion_challengers()\n"
    ]
   },
   {
@@ -321,8 +321,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "testmodel_falcons = client.prediction_studio.get_model(label=\"SamplePred_05071_Candidate\")\n",
-    "testmodel_falcons.describe()"
+    "testmodel_falcons = models[\"SamplePred_05071_Candidate\"]\n",
+    "testmodel_falcons.describe()\n"
    ]
   },
   {
@@ -398,8 +398,8 @@
    "outputs": [],
    "source": [
     "from pdstools.infinity.resources.prediction_studio.types import AdmModelType\n",
-    "prediction=client.prediction_studio.get_prediction(label=\"SamplePred\")\n",
-    "cc=prediction.get_champion_challengers()[0]\n",
+    "prediction = predictions[\"SamplePred\"]\n",
+    "cc = prediction.get_champion_challengers()[testmodel_falcons.label]\n",
     "cc.clone_model(challenger_response_share=0.8, adm_model_type=AdmModelType.GRADIENT_BOOSTING, model_label=\"SamplePred_Candidate\")\n"
    ]
   },
@@ -461,8 +461,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "NoContext_CC = prediction.get_champion_challengers()\n",
-    "NoContext_CC"
+    "ccs = prediction.get_champion_challengers()\n",
+    "NoContext_CC = ccs[Retention_CC.active_model.label]\n",
+    "NoContext_CC\n"
    ]
   },
   {
@@ -487,7 +488,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_model = client.prediction_studio.get_model(label=\"Test_model_1\")"
+    "test_model = models[\"Test_model_1\"]\n"
    ]
   },
   {
@@ -970,8 +971,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prediction = client.prediction_studio.get_prediction(label=\"PredTest\")\n",
-    "prediction.get_champion_challengers()"
+    "prediction = predictions[\"PredTest\"]\n",
+    "prediction.get_champion_challengers()\n"
    ]
   },
   {

--- a/python/pdstools/infinity/__init__.py
+++ b/python/pdstools/infinity/__init__.py
@@ -9,6 +9,12 @@ from ..utils.namespaces import MissingDependenciesException
 
 if TYPE_CHECKING:
     from .client import AsyncInfinity, Infinity
+    from .resources.prediction_studio.schemas import (
+        ModelData,
+        ModelInstanceData,
+        NotificationData,
+        PredictionData,
+    )
 
 
 class DependencyNotFound:
@@ -38,8 +44,16 @@ def _check_dependencies() -> list[str]:
     return missing
 
 
+_DATA_MODELS = (
+    "ModelData",
+    "ModelInstanceData",
+    "NotificationData",
+    "PredictionData",
+)
+
+
 def __getattr__(name: str):
-    """Lazy import to avoid loading httpx until needed."""
+    """Lazy import to avoid loading httpx / pydantic until needed."""
     if name in ("Infinity", "AsyncInfinity"):
         missing_dependencies = _check_dependencies()
 
@@ -52,7 +66,32 @@ def __getattr__(name: str):
             return Infinity
         return AsyncInfinity
 
+    if name in _DATA_MODELS:
+        if not find_spec("pydantic"):
+            return DependencyNotFound(["pydantic"])
+
+        from .resources.prediction_studio.schemas import (
+            ModelData,
+            ModelInstanceData,
+            NotificationData,
+            PredictionData,
+        )
+
+        return {
+            "ModelData": ModelData,
+            "ModelInstanceData": ModelInstanceData,
+            "NotificationData": NotificationData,
+            "PredictionData": PredictionData,
+        }[name]
+
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
-__all__ = ["AsyncInfinity", "Infinity"]
+__all__ = [
+    "AsyncInfinity",
+    "Infinity",
+    "ModelData",
+    "ModelInstanceData",
+    "NotificationData",
+    "PredictionData",
+]

--- a/python/pdstools/infinity/client.py
+++ b/python/pdstools/infinity/client.py
@@ -36,7 +36,6 @@ class Infinity(SyncAPIClient):
         *,
         base_url: "str | httpx.URL",
         auth: "httpx.Auth | PegaOAuth",
-        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -51,7 +50,6 @@ class Infinity(SyncAPIClient):
         super().__init__(
             base_url=base_url,
             auth=auth,
-            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
             timeout=timeout,
@@ -126,7 +124,6 @@ class AsyncInfinity(AsyncAPIClient):
         *,
         base_url: "str | httpx.URL",
         auth: "httpx.Auth | PegaOAuth",
-        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -141,7 +138,6 @@ class AsyncInfinity(AsyncAPIClient):
         super().__init__(
             base_url=base_url,
             auth=auth,
-            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
             timeout=timeout,

--- a/python/pdstools/infinity/client.py
+++ b/python/pdstools/infinity/client.py
@@ -36,6 +36,7 @@ class Infinity(SyncAPIClient):
         *,
         base_url: "str | httpx.URL",
         auth: "httpx.Auth | PegaOAuth",
+        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -50,6 +51,7 @@ class Infinity(SyncAPIClient):
         super().__init__(
             base_url=base_url,
             auth=auth,
+            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
             timeout=timeout,
@@ -124,6 +126,7 @@ class AsyncInfinity(AsyncAPIClient):
         *,
         base_url: "str | httpx.URL",
         auth: "httpx.Auth | PegaOAuth",
+        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -138,6 +141,7 @@ class AsyncInfinity(AsyncAPIClient):
         super().__init__(
             base_url=base_url,
             auth=auth,
+            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
             timeout=timeout,

--- a/python/pdstools/infinity/internal/_base_client.py
+++ b/python/pdstools/infinity/internal/_base_client.py
@@ -65,12 +65,14 @@ class BaseClient(Generic[_HttpxClientT]):
         *,
         base_url: str | httpx.URL,
         auth: httpx.Auth | PegaOAuth,
+        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
     ):
         self._base_url = self._enforce_trailing_slash(httpx.URL(base_url))
         self.auth = auth
+        self.application_name = application_name
         self.verify = verify
         self.pega_version = pega_version
         self.timeout = timeout
@@ -122,6 +124,7 @@ For full compatibility, please supply the pega_version argument to the Infinity 
         base_url: str,
         client_id: str,
         client_secret: str,
+        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -134,6 +137,7 @@ For full compatibility, please supply the pega_version argument to the Infinity 
                 client_secret=client_secret,
                 verify=verify,
             ),
+            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
             timeout=timeout,
@@ -144,6 +148,7 @@ For full compatibility, please supply the pega_version argument to the Infinity 
         cls,
         file_path: str,
         verify: bool = False,
+        application_name: str | None = None,
         pega_version: str | None = None,
         timeout: float = 90,
     ):
@@ -154,6 +159,7 @@ For full compatibility, please supply the pega_version argument to the Infinity 
             base_url=base_url,
             client_id=creds["Client ID"],
             client_secret=creds["Client Secret"],
+            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
             timeout=timeout,
@@ -167,6 +173,7 @@ For full compatibility, please supply the pega_version argument to the Infinity 
         password: str | None = None,
         *,
         verify: bool = True,
+        application_name: str | None = None,
         pega_version: str | None = None,
         timeout: int = 90,
     ):
@@ -187,6 +194,7 @@ For full compatibility, please supply the pega_version argument to the Infinity 
         return cls(
             base_url=base_url,
             auth=auth,
+            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
             timeout=timeout,
@@ -200,6 +208,7 @@ class SyncAPIClient(BaseClient[httpx.Client]):
         self,
         base_url: str | httpx.URL,
         auth: httpx.Auth | PegaOAuth,
+        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -207,6 +216,7 @@ class SyncAPIClient(BaseClient[httpx.Client]):
         super().__init__(
             base_url=base_url,
             auth=auth,
+            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
         )
@@ -477,6 +487,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient]):  # pragma: no cover
         self,
         base_url: str | httpx.URL,
         auth: httpx.Auth | PegaOAuth,
+        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -484,6 +495,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient]):  # pragma: no cover
         super().__init__(
             base_url=base_url,
             auth=auth,
+            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
         )

--- a/python/pdstools/infinity/internal/_base_client.py
+++ b/python/pdstools/infinity/internal/_base_client.py
@@ -65,14 +65,12 @@ class BaseClient(Generic[_HttpxClientT]):
         *,
         base_url: str | httpx.URL,
         auth: httpx.Auth | PegaOAuth,
-        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
     ):
         self._base_url = self._enforce_trailing_slash(httpx.URL(base_url))
         self.auth = auth
-        self.application_name = application_name
         self.verify = verify
         self.pega_version = pega_version
         self.timeout = timeout
@@ -102,9 +100,13 @@ class BaseClient(Generic[_HttpxClientT]):
         )
 
     def _get_version(self, repo):
-        if len(repo) == 1 and "repository_name" in repo:
+        # Real systems return camelCase keys (repositoryName/repositoryType);
+        # some older/mocked responses use snake_case. Accept both.
+        has_name = "repository_name" in repo or "repositoryName" in repo
+        has_type = "repository_type" in repo or "repositoryType" in repo
+        if len(repo) == 1 and has_name:
             return "24.1"
-        if "repository_type" in repo:
+        if has_type:
             return "24.2"
         warnings.warn(
             """Could not infer Pega version automatically.
@@ -120,7 +122,6 @@ For full compatibility, please supply the pega_version argument to the Infinity 
         base_url: str,
         client_id: str,
         client_secret: str,
-        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -134,7 +135,6 @@ For full compatibility, please supply the pega_version argument to the Infinity 
                 verify=verify,
             ),
             verify=verify,
-            application_name=application_name,
             pega_version=pega_version,
             timeout=timeout,
         )
@@ -144,7 +144,6 @@ For full compatibility, please supply the pega_version argument to the Infinity 
         cls,
         file_path: str,
         verify: bool = False,
-        application_name: str | None = None,
         pega_version: str | None = None,
         timeout: float = 90,
     ):
@@ -155,7 +154,6 @@ For full compatibility, please supply the pega_version argument to the Infinity 
             base_url=base_url,
             client_id=creds["Client ID"],
             client_secret=creds["Client Secret"],
-            application_name=application_name,
             verify=verify,
             pega_version=pega_version,
             timeout=timeout,
@@ -169,7 +167,6 @@ For full compatibility, please supply the pega_version argument to the Infinity 
         password: str | None = None,
         *,
         verify: bool = True,
-        application_name: str | None = None,
         pega_version: str | None = None,
         timeout: int = 90,
     ):
@@ -191,7 +188,6 @@ For full compatibility, please supply the pega_version argument to the Infinity 
             base_url=base_url,
             auth=auth,
             verify=verify,
-            application_name=application_name,
             pega_version=pega_version,
             timeout=timeout,
         )
@@ -204,7 +200,6 @@ class SyncAPIClient(BaseClient[httpx.Client]):
         self,
         base_url: str | httpx.URL,
         auth: httpx.Auth | PegaOAuth,
-        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -221,7 +216,6 @@ class SyncAPIClient(BaseClient[httpx.Client]):
             verify=verify,
             timeout=timeout,
         )
-        self.application_name = application_name
 
     def _infer_version(self, on_error: Literal["error", "warn", "ignore"] = "error"):
         # Probe 25-specific endpoint first; it does not exist on older systems.
@@ -254,7 +248,14 @@ class SyncAPIClient(BaseClient[httpx.Client]):
                         "The Infinity system may be unavailable."
                     ),
                 )
-            # 404 or other non-200: endpoint absent on older systems, fall through.
+            if probe.status_code != 404:
+                # The endpoint resolved but returned a client error other than
+                # 404 (e.g. 400 when the model-category data dictionary is
+                # absent). The v3 predictions API only exists on 25+/26
+                # systems — a pre-25 system returns 404 because the path
+                # itself is unknown — so its presence implies 26.1.
+                return "26.1"
+            # 404: endpoint absent on older systems, fall through.
         except PegaException:
             raise
         except Exception as e:
@@ -476,7 +477,6 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient]):  # pragma: no cover
         self,
         base_url: str | httpx.URL,
         auth: httpx.Auth | PegaOAuth,
-        application_name: str | None = None,
         verify: bool = False,
         pega_version: str | None = None,
         timeout: float = 90,
@@ -493,7 +493,6 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient]):  # pragma: no cover
             verify=verify,
             timeout=timeout,
         )
-        self.application_name = application_name
 
     def _collect_awaitable_blocking(
         self,
@@ -544,7 +543,14 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient]):  # pragma: no cover
                         "The Infinity system may be unavailable."
                     ),
                 )
-            # 404 or other non-200: endpoint absent on older systems, fall through.
+            if probe.status_code != 404:
+                # The endpoint resolved but returned a client error other than
+                # 404 (e.g. 400 when the model-category data dictionary is
+                # absent). The v3 predictions API only exists on 25+/26
+                # systems — a pre-25 system returns 404 because the path
+                # itself is unknown — so its presence implies 26.1.
+                return "26.1"
+            # 404: endpoint absent on older systems, fall through.
         except PegaException:
             raise
         except Exception as e:

--- a/python/pdstools/infinity/internal/_pagination.py
+++ b/python/pdstools/infinity/internal/_pagination.py
@@ -10,6 +10,20 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+def _frame_from_resources(content_class: Any, items: Any) -> pl.DataFrame:
+    """Build a DataFrame from resource items with a locked schema when available.
+
+    Resources backed by the Pydantic data layer expose ``_public_schema()``,
+    which yields a stable column set and dtypes so that empty results,
+    all-null optionals, and forward-compatible extra fields don't change the
+    output schema. Resources that have not yet migrated fall back to Polars'
+    value inference (``schema=None``).
+    """
+    schema_fn = getattr(content_class, "_public_schema", None)
+    schema = schema_fn() if callable(schema_fn) else None
+    return pl.DataFrame((getattr(item, "_public_dict", {}) for item in items), schema=schema)
+
+
 class _Slice(Generic[T]):
     """A lazy slice view over a :class:`PaginatedList`."""
 
@@ -46,7 +60,7 @@ class _Slice(Generic[T]):
         return self._stop is not None and index >= self._stop
 
     def as_df(self) -> pl.DataFrame:
-        return pl.DataFrame(getattr(prediction, "_public_dict", {}) for prediction in self)
+        return _frame_from_resources(self._list._content_class, self)
 
 
 class PaginatedList(Generic[T]):
@@ -162,6 +176,10 @@ class PaginatedList(Generic[T]):
 
     def __repr__(self) -> str:
         return f"<PaginatedList of type {self._content_class.__name__}>"
+
+    def as_df(self) -> pl.DataFrame:
+        """Collect all pages into a polars DataFrame."""
+        return _frame_from_resources(self._content_class, self)
 
     def _get_next_page(self) -> list[T]:
         response = self._client.request(
@@ -315,4 +333,4 @@ class AsyncPaginatedList(Generic[T]):
     async def as_df(self) -> pl.DataFrame:
         """Collect all pages into a polars DataFrame."""
         items = await self.collect()
-        return pl.DataFrame(getattr(item, "_public_dict", {}) for item in items)
+        return _frame_from_resources(self._content_class, items)

--- a/python/pdstools/infinity/internal/_pagination.py
+++ b/python/pdstools/infinity/internal/_pagination.py
@@ -214,10 +214,18 @@ class PaginatedList(Generic[T]):
 
         content: list[T] = []
         if self._root:
-            try:
+            if self._root in response:
                 response = response[self._root]
-            except KeyError as e:
-                raise ValueError(f"Json format unexpected, {self._root} not found.{e}") from e
+            elif not response:
+                # An empty body (e.g. ``{}`` when there are no items) is an
+                # empty page, not a malformed payload — yield zero elements.
+                # A *populated* dict missing the root key is still a genuine
+                # format error and falls through to the raise below.
+                response = []
+            else:
+                raise ValueError(
+                    f"Json format unexpected, {self._root} not found.",
+                )
 
         for element in response:
             if element is not None:
@@ -293,10 +301,18 @@ class AsyncPaginatedList(Generic[T]):
 
         content: list[T] = []
         if self._root:
-            try:
+            if self._root in response:
                 response = response[self._root]
-            except KeyError as e:
-                raise ValueError(f"Json format unexpected, {self._root} not found.{e}") from e
+            elif not response:
+                # An empty body (e.g. ``{}`` when there are no items) is an
+                # empty page, not a malformed payload — yield zero elements.
+                # A *populated* dict missing the root key is still a genuine
+                # format error and falls through to the raise below.
+                response = []
+            else:
+                raise ValueError(
+                    f"Json format unexpected, {self._root} not found.",
+                )
 
         for element in response:
             if element is not None:

--- a/python/pdstools/infinity/internal/_pagination.py
+++ b/python/pdstools/infinity/internal/_pagination.py
@@ -10,6 +10,15 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+def _resolve_id_field(content_class: Any) -> str:
+    """Return the attribute name used for string/``in`` lookups.
+
+    Resources backed by the Pydantic data layer declare ``_id_field`` (e.g.
+    ``"prediction_id"``). Anything else falls back to ``"id"``.
+    """
+    return getattr(content_class, "_id_field", "id")
+
+
 def _frame_from_resources(content_class: Any, items: Any) -> pl.DataFrame:
     """Build a DataFrame from resource items with a locked schema when available.
 
@@ -110,14 +119,26 @@ class PaginatedList(Generic[T]):
             return self._elements[index]
         if isinstance(index, slice):
             return _Slice(self, index)
-        assert "id" in self._content_class, (
-            "To pass a string as index for a paginated list, the content class needs an 'id' field."
-        )
+        id_field = _resolve_id_field(self._content_class)
         for element in self.__iter__():
-            if getattr(element, "id", None) == index:
+            if getattr(element, id_field, None) == index:
                 return element
 
         raise IndexError(index)
+
+    def __contains__(self, key: object) -> bool:
+        """Mapping-style membership test by id field.
+
+        ``"PREDICT_X" in client.prediction_studio.list_predictions()`` walks the
+        list (fetching pages as needed) and compares each element's id field.
+        """
+        id_field = _resolve_id_field(self._content_class)
+        return any(getattr(element, id_field, None) == key for element in self)
+
+    def keys(self) -> list[Any]:
+        """Return the id-field value of every element (mapping-style keys)."""
+        id_field = _resolve_id_field(self._content_class)
+        return [getattr(element, id_field, None) for element in self]
 
     @overload
     def get(self, __key: int | str, __default: str | None = None) -> T: ...
@@ -136,8 +157,8 @@ class PaginatedList(Generic[T]):
     ) -> T | _Slice[T] | Any:
         """Returns the specified key or default.
 
-        If string type provided as key, the content_class needs to be a Pydantic class,
-        with an attribute called 'id'.
+        If a string is provided as key, the content class needs an id field
+        (``_id_field``, defaulting to ``"id"``) to look up against.
 
         Parameters
         ----------
@@ -323,12 +344,19 @@ class AsyncPaginatedList(Generic[T]):
                 if isinstance(__key, int):
                     return items[__key]
                 if isinstance(__key, str):
+                    id_field = _resolve_id_field(self._content_class)
                     for el in items:
-                        if getattr(el, "id", None) == __key:
+                        if getattr(el, id_field, None) == __key:
                             return el
             except (IndexError, KeyError, ValueError, AttributeError, TypeError):
                 pass
         return __default
+
+    async def keys(self) -> list[Any]:
+        """Return the id-field value of every element (mapping-style keys)."""
+        id_field = _resolve_id_field(self._content_class)
+        items = await self.collect()
+        return [getattr(element, id_field, None) for element in items]
 
     async def as_df(self) -> pl.DataFrame:
         """Collect all pages into a polars DataFrame."""

--- a/python/pdstools/infinity/internal/_pagination.py
+++ b/python/pdstools/infinity/internal/_pagination.py
@@ -10,6 +10,14 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+class _MissingLookupKeyError(KeyError):
+    """Internal KeyError used for missing string-key lookups."""
+
+
+class _AmbiguousLabelKeyError(KeyError):
+    """Internal KeyError used for ambiguous label-based lookups."""
+
+
 def _resolve_id_field(content_class: Any) -> str:
     """Return the attribute name used for string/``in`` lookups.
 
@@ -17,6 +25,85 @@ def _resolve_id_field(content_class: Any) -> str:
     ``"prediction_id"``). Anything else falls back to ``"id"``.
     """
     return getattr(content_class, "_id_field", "id")
+
+
+def _preferred_keys(items: list[Any], id_field: str) -> list[Any]:
+    """Return user-facing mapping keys for a resource collection.
+
+    Parameters
+    ----------
+    items : list[Any]
+        Collected resource items.
+    id_field : str
+        Attribute name used for id-based lookup.
+
+    Returns
+    -------
+    list[Any]
+        Labels when the collection exposes them, otherwise ids.
+
+    """
+    labels = [getattr(item, "label", None) for item in items if getattr(item, "label", None) is not None]
+    if labels:
+        return labels
+    return [getattr(item, id_field, None) for item in items]
+
+
+def _resolve_string_lookup(items: Any, key: str, id_field: str) -> Any:
+    """Resolve a string key by id first, then by label.
+
+    Parameters
+    ----------
+    items : iterable
+        Resource items to scan.
+    key : str
+        String key to resolve.
+    id_field : str
+        Attribute name used for id-based lookup.
+
+    Returns
+    -------
+    Any
+        The matching resource.
+
+    Raises
+    ------
+    _AmbiguousLabelKeyError
+        If multiple resources share the requested label.
+    _MissingLookupKeyError
+        If neither an id nor a label match is found.
+
+    """
+    label_matches: list[Any] = []
+    available_keys: list[Any] = []
+    has_labels = False
+
+    for element in items:
+        id_value = getattr(element, id_field, None)
+        if id_value == key:
+            return element
+
+        label_value = getattr(element, "label", None)
+        if label_value is not None:
+            has_labels = True
+            available_keys.append(label_value)
+            if label_value == key:
+                label_matches.append(element)
+        else:
+            available_keys.append(id_value)
+
+    if len(label_matches) == 1:
+        return label_matches[0]
+    if len(label_matches) > 1:
+        raise _AmbiguousLabelKeyError(
+            f"Label {key!r} is ambiguous; matched {len(label_matches)} resources. Use the id instead.",
+        )
+
+    visible_keys = available_keys[:5]
+    key_type = "labels" if has_labels else "ids"
+    raise _MissingLookupKeyError(
+        f"{key!r} was not found. Available {key_type}: {visible_keys}.",
+    )
 
 
 def _frame_from_resources(content_class: Any, items: Any) -> pl.DataFrame:
@@ -122,25 +209,32 @@ class PaginatedList(Generic[T]):
         if isinstance(index, slice):
             return _Slice(self, index)
         id_field = _resolve_id_field(self._content_class)
-        for element in self.__iter__():
-            if getattr(element, id_field, None) == index:
-                return element
-
-        raise IndexError(index)
+        return _resolve_string_lookup(self.__iter__(), index, id_field)
 
     def __contains__(self, key: object) -> bool:
-        """Mapping-style membership test by id field.
+        """Perform mapping-style membership tests by id, then label.
 
         ``"PREDICT_X" in client.prediction_studio.list_predictions()`` walks the
-        list (fetching pages as needed) and compares each element's id field.
+        list (fetching pages as needed), first comparing each element's id field
+        and then falling back to ``label`` when the resource exposes one.
         """
+        if not isinstance(key, str):
+            return False
         id_field = _resolve_id_field(self._content_class)
-        return any(getattr(element, id_field, None) == key for element in self)
+        try:
+            _resolve_string_lookup(iter(self), key, id_field)
+        except _MissingLookupKeyError:
+            return False
+        return True
 
     def keys(self) -> list[Any]:
-        """Return the id-field value of every element (mapping-style keys)."""
+        """Return mapping-style keys for every element.
+
+        String lookups try ids first and then labels, so this returns labels
+        when available and otherwise falls back to ids.
+        """
         id_field = _resolve_id_field(self._content_class)
-        return [getattr(element, id_field, None) for element in self]
+        return _preferred_keys(list(self), id_field)
 
     @overload
     def get(self, __key: int | str, __default: str | None = None) -> T: ...
@@ -159,13 +253,14 @@ class PaginatedList(Generic[T]):
     ) -> T | _Slice[T] | Any:
         """Returns the specified key or default.
 
-        If a string is provided as key, the content class needs an id field
-        (``_id_field``, defaulting to ``"id"``) to look up against.
+        If a string is provided as key, lookup first uses the content class id
+        field (``_id_field``, defaulting to ``"id"``) and then falls back to
+        ``label`` when available.
 
         Parameters
         ----------
         __key : int | slice | str
-            Can be a int (index), slice (start:end), or string (id attribute)
+            Can be an int (index), slice (start:end), or string (id/label)
         __default : str | None, optional
             The value to return if none found, by default None
 
@@ -351,7 +446,11 @@ class AsyncPaginatedList(Generic[T]):
         __default: T | None = None,
         **kwargs: Any,
     ) -> T | None:
-        """Async version of PaginatedList.get()."""
+        """Async version of :meth:`PaginatedList.get`.
+
+        String lookup first uses the content class id field and then falls back
+        to ``label`` when available.
+        """
         if kwargs:
             async for element in self:
                 if all(getattr(element, name) == value for name, value in kwargs.items()):
@@ -363,18 +462,20 @@ class AsyncPaginatedList(Generic[T]):
                     return items[__key]
                 if isinstance(__key, str):
                     id_field = _resolve_id_field(self._content_class)
-                    for el in items:
-                        if getattr(el, id_field, None) == __key:
-                            return el
+                    return _resolve_string_lookup(items, __key, id_field)
             except (IndexError, KeyError, ValueError, AttributeError, TypeError):
                 pass
         return __default
 
     async def keys(self) -> list[Any]:
-        """Return the id-field value of every element (mapping-style keys)."""
+        """Return mapping-style keys for every element.
+
+        String lookups try ids first and then labels, so this returns labels
+        when available and otherwise falls back to ids.
+        """
         id_field = _resolve_id_field(self._content_class)
         items = await self.collect()
-        return [getattr(element, id_field, None) for element in items]
+        return _preferred_keys(items, id_field)
 
     async def as_df(self) -> pl.DataFrame:
         """Collect all pages into a polars DataFrame."""

--- a/python/pdstools/infinity/internal/_pagination.py
+++ b/python/pdstools/infinity/internal/_pagination.py
@@ -57,13 +57,15 @@ class _Slice(Generic[T]):
             else:
                 return
 
-    def __getitem__(self, index: int) -> T | None:
+    def __getitem__(self, index: int) -> T:
+        if index < 0:
+            raise IndexError("Cannot negative index a PaginatedList slice")
         i: int = 0
         for e in self:
             if i == index:
                 return e
             i += 1
-        return None
+        raise IndexError(index)
 
     def _finished(self, index: int) -> bool:
         return self._stop is not None and index >= self._stop

--- a/python/pdstools/infinity/internal/_resource.py
+++ b/python/pdstools/infinity/internal/_resource.py
@@ -132,7 +132,7 @@ class SyncAPIResource(ABC):
         classname = self.__class__.__name__
 
         def format_field(field):
-            value = self.__getattribute__(field)
+            value = getattr(self, field)
             if isinstance(value, (int, float)):
                 return str(value)
             if isinstance(value, bool):
@@ -195,7 +195,7 @@ class AsyncAPIResource(ABC):
         classname = self.__class__.__name__
 
         def format_field(field):
-            value = self.__getattribute__(field)
+            value = getattr(self, field)
             if isinstance(value, (int, float)):
                 return str(value)
             if isinstance(value, bool):

--- a/python/pdstools/infinity/resources/prediction_studio/base.py
+++ b/python/pdstools/infinity/resources/prediction_studio/base.py
@@ -285,3 +285,43 @@ class ChampionChallenger(_ChampionChallengerMixin, SyncAPIResource):
 
 class AsyncChampionChallenger(_ChampionChallengerMixin, AsyncAPIResource):
     pass
+
+
+class _ModelInstanceMixin(ABC):  # noqa: B024 — ABC used for cooperative MRO with pydantic resources
+    def __init__(
+        self,
+        client,
+        *,
+        instanceID: str,
+        name: str,
+        type: str,
+        status: str,
+        active: bool,
+        lastUpdateTime: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO
+        if kwargs:
+            logger.debug(
+                "_ModelInstanceMixin received unexpected fields from API response: %s",
+                list(kwargs.keys()),
+            )
+        self.instance_id = instanceID
+        self.name = name
+        self.type = type
+        self.status = status
+        self.active = active
+        self.last_update_time = (
+            datetime.strptime(lastUpdateTime, "%Y%m%dT%H%M%S.%f %Z") if lastUpdateTime is not None else None
+        )
+
+
+class ModelInstance(_ModelInstanceMixin, SyncAPIResource):
+    pass
+
+
+class AsyncModelInstance(_ModelInstanceMixin, AsyncAPIResource):
+    pass
+
+
+__all__ = ["AsyncModelInstance", "ModelInstance"]

--- a/python/pdstools/infinity/resources/prediction_studio/base.py
+++ b/python/pdstools/infinity/resources/prediction_studio/base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from datetime import datetime
 from typing import (
     Any,
     Literal,
@@ -14,7 +13,7 @@ from pydantic import BaseModel
 
 from ...internal._exceptions import IncompatiblePegaVersionError
 from ...internal._resource import AsyncAPIResource, SyncAPIResource
-from .schemas import ModelData, ModelInstanceData, PredictionData
+from .schemas import ModelData, ModelInstanceData, NotificationData, PredictionData
 
 logger = logging.getLogger(__name__)
 
@@ -155,36 +154,45 @@ class _PredictionMixin(ABC):
     def describe(self): ...
 
 
-class _NotificationMixin(ABC):  # noqa: B024 — ABC used for cooperative MRO with pydantic resources
-    def __init__(
-        self,
-        client,
-        *,
-        description: str,
-        modelType: str,
-        notificationID: str,
-        notificationType: str,
-        notificationMnemonic: str,
-        context: str,
-        impact: str,
-        triggerTime: str,
-        modelID: str | None = None,
-        predictionID: str | None = None,
-    ):
+class _NotificationMixin(ABC):
+    """Behaviour wrapper around a :class:`NotificationData` payload.
+
+    The raw API payload is validated into ``self._data`` (a Pydantic model).
+    Attribute reads fall through to ``_data`` via ``__getattr__``, so
+    ``notification.notification_id`` etc. keep working, while ``_public_dict`` /
+    ``_public_fields`` are sourced from ``_data`` so the ``return_df=True``
+    code paths (``get_notifications``) produce a stable, fully-populated schema.
+    """
+
+    _data: NotificationData
+    _data_cls: type[NotificationData] = NotificationData
+
+    def __init__(self, client, **payload):
         super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO
-        if modelID:
-            self.model_id = modelID
-        if predictionID:
-            self.prediction_id = predictionID
-        if context:
-            self.context = context
-        self.notification_type = notificationType
-        self.notification_id = notificationID
-        self.notification_mnemonic = notificationMnemonic
-        self.description = description
-        self.model_type = modelType
-        self.impact = impact
-        self.trigger_time = datetime.strptime(triggerTime, "%Y%m%dT%H%M%S.%f %Z")
+        self._data = self._data_cls.model_validate(payload)
+
+    def __getattr__(self, name: str):
+        try:
+            data = object.__getattribute__(self, "_data")
+        except AttributeError:
+            raise AttributeError(name) from None
+        try:
+            return getattr(data, name)
+        except AttributeError:
+            raise AttributeError(name) from None
+
+    @property
+    def _public_dict(self) -> dict:
+        return self._data.public_dict
+
+    @property
+    def _public_fields(self) -> list[str]:
+        return list(type(self._data).model_fields)
+
+    @classmethod
+    def _public_schema(cls) -> dict:
+        """Polars schema for ``return_df=True`` results (locked column set)."""
+        return cls._data_cls.polars_schema()
 
 
 class UploadedModel(ABC): ...  # noqa: B024 — ABC marker for subclass discovery

--- a/python/pdstools/infinity/resources/prediction_studio/base.py
+++ b/python/pdstools/infinity/resources/prediction_studio/base.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 from ...internal._exceptions import IncompatiblePegaVersionError
 from ...internal._resource import AsyncAPIResource, SyncAPIResource
-from .schemas import ModelData
+from .schemas import ModelData, ModelInstanceData
 
 logger = logging.getLogger(__name__)
 
@@ -301,33 +301,45 @@ class AsyncChampionChallenger(_ChampionChallengerMixin, AsyncAPIResource):
     pass
 
 
-class _ModelInstanceMixin(ABC):  # noqa: B024 — ABC used for cooperative MRO with pydantic resources
-    def __init__(
-        self,
-        client,
-        *,
-        instanceID: str,
-        name: str,
-        type: str,
-        status: str,
-        active: bool,
-        lastUpdateTime: str | None = None,
-        **kwargs,
-    ):
-        super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO
-        if kwargs:
-            logger.debug(
-                "_ModelInstanceMixin received unexpected fields from API response: %s",
-                list(kwargs.keys()),
-            )
-        self.instance_id = instanceID
-        self.name = name
-        self.type = type
-        self.status = status
-        self.active = active
-        self.last_update_time = (
-            datetime.strptime(lastUpdateTime, "%Y%m%dT%H%M%S.%f %Z") if lastUpdateTime is not None else None
-        )
+class _ModelInstanceMixin(ABC):
+    """Behaviour wrapper around a :class:`ModelInstanceData` payload.
+
+    The raw API payload is validated into ``self._data`` (a Pydantic model).
+    Attribute reads fall through to ``_data`` via ``__getattr__``, so
+    ``instance.instance_id`` etc. keep working, while ``_public_dict`` /
+    ``_public_fields`` are sourced from ``_data`` so the ``return_df=True``
+    code paths (``list_instances``) produce a stable, fully-populated schema.
+    """
+
+    _data: ModelInstanceData
+    _data_cls: type[ModelInstanceData] = ModelInstanceData
+
+    def __init__(self, client, **payload):
+        super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO: combined with SyncAPIResource/AsyncAPIResource
+        self._data = self._data_cls.model_validate(payload)
+
+    def __getattr__(self, name: str):
+        try:
+            data = object.__getattribute__(self, "_data")
+        except AttributeError:
+            raise AttributeError(name) from None
+        try:
+            return getattr(data, name)
+        except AttributeError:
+            raise AttributeError(name) from None
+
+    @property
+    def _public_dict(self) -> dict:
+        return self._data.public_dict
+
+    @property
+    def _public_fields(self) -> list[str]:
+        return list(type(self._data).model_fields)
+
+    @classmethod
+    def _public_schema(cls) -> dict:
+        """Polars schema for ``return_df=True`` results (locked column set)."""
+        return cls._data_cls.polars_schema()
 
 
 class ModelInstance(_ModelInstanceMixin, SyncAPIResource):

--- a/python/pdstools/infinity/resources/prediction_studio/base.py
+++ b/python/pdstools/infinity/resources/prediction_studio/base.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 from ...internal._exceptions import IncompatiblePegaVersionError
 from ...internal._resource import AsyncAPIResource, SyncAPIResource
+from .schemas import ModelData
 
 logger = logging.getLogger(__name__)
 
@@ -55,35 +56,48 @@ class ModelAttributes(TypedDict):
 
 
 class _ModelMixin(ABC):
-    def __init__(
-        self,
-        client,
-        *,
-        modelId: str,
-        label: str,
-        modelType: str,
-        status: str,
-        componentName: str | None = None,
-        source: str | None = None,
-        lastUpdateTime: str | None = None,
-        modelingTechnique: str | None = None,
-        updatedBy: str | None = None,
-    ):
+    """Behaviour wrapper around a :class:`ModelData` payload.
+
+    The raw API payload is validated into ``self._data`` (a Pydantic model).
+    Attribute reads fall through to ``_data`` via ``__getattr__``, so
+    ``model.model_id`` etc. keep working, while ``_public_dict`` /
+    ``_public_fields`` are sourced from ``_data`` so the ``return_df=True``
+    code paths (``list_models``) produce a stable, fully-populated schema.
+    """
+
+    _data: ModelData
+    _data_cls: type[ModelData] = ModelData
+
+    def __init__(self, client, **payload):
         super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO: combined with SyncAPIResource/AsyncAPIResource
-        self.model_id = modelId
-        self.label = label
-        self.model_type = modelType
-        self.modeling_technique = modelingTechnique
-        self.source = source
-        self.status = status
-        if componentName:
-            self.component_name = componentName
-        if lastUpdateTime:
-            self.last_update_time = datetime.strptime(
-                lastUpdateTime,
-                "%Y%m%dT%H%M%S.%f %Z",
-            )
-        self.updated_by = updatedBy
+        self._data = self._data_cls.model_validate(payload)
+
+    def __getattr__(self, name: str):
+        # __getattr__ only fires when normal attribute lookup fails, so real
+        # methods and instance attributes still win.  Use object.__getattribute__
+        # to fetch _data without re-entering __getattr__ (which would recurse
+        # before _data is assigned during __init__).
+        try:
+            data = object.__getattribute__(self, "_data")
+        except AttributeError:
+            raise AttributeError(name) from None
+        try:
+            return getattr(data, name)
+        except AttributeError:
+            raise AttributeError(name) from None
+
+    @property
+    def _public_dict(self) -> dict:
+        return self._data.public_dict
+
+    @property
+    def _public_fields(self) -> list[str]:
+        return list(type(self._data).model_fields)
+
+    @classmethod
+    def _public_schema(cls) -> dict:
+        """Polars schema for ``return_df=True`` results (locked column set)."""
+        return cls._data_cls.polars_schema()
 
     @abstractmethod
     def describe(self) -> ModelAttributes: ...

--- a/python/pdstools/infinity/resources/prediction_studio/base.py
+++ b/python/pdstools/infinity/resources/prediction_studio/base.py
@@ -4,6 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import (
     Any,
+    ClassVar,
     Literal,
     TypedDict,
     TYPE_CHECKING,
@@ -66,6 +67,7 @@ class _ModelMixin(ABC):
 
     _data: ModelData
     _data_cls: type[ModelData] = ModelData
+    _id_field: ClassVar[str] = "model_id"
 
     def __init__(self, client, **payload):
         super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO: combined with SyncAPIResource/AsyncAPIResource
@@ -114,6 +116,7 @@ class _PredictionMixin(ABC):
 
     _data: PredictionData
     _data_cls: type[PredictionData] = PredictionData
+    _id_field: ClassVar[str] = "prediction_id"
 
     def __init__(self, client, **payload):
         super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO
@@ -166,6 +169,7 @@ class _NotificationMixin(ABC):
 
     _data: NotificationData
     _data_cls: type[NotificationData] = NotificationData
+    _id_field: ClassVar[str] = "notification_id"
 
     def __init__(self, client, **payload):
         super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO
@@ -335,6 +339,7 @@ class _ModelInstanceMixin(ABC):
 
     _data: ModelInstanceData
     _data_cls: type[ModelInstanceData] = ModelInstanceData
+    _id_field: ClassVar[str] = "instance_id"
 
     def __init__(self, client, **payload):
         super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO: combined with SyncAPIResource/AsyncAPIResource

--- a/python/pdstools/infinity/resources/prediction_studio/base.py
+++ b/python/pdstools/infinity/resources/prediction_studio/base.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 from ...internal._exceptions import IncompatiblePegaVersionError
 from ...internal._resource import AsyncAPIResource, SyncAPIResource
-from .schemas import ModelData
+from .schemas import ModelData, PredictionData
 
 logger = logging.getLogger(__name__)
 
@@ -104,30 +104,44 @@ class _ModelMixin(ABC):
 
 
 class _PredictionMixin(ABC):
-    def __init__(
-        self,
-        client,
-        *,
-        predictionId: str,
-        label: str,
-        status: str | None = None,
-        lastUpdateTime: str | None = None,
-        objective: str | None = None,
-        subject: str | None = None,
-        **kwargs,
-    ):
+    """Behaviour wrapper around a :class:`PredictionData` payload.
+
+    The raw API payload is validated into ``self._data`` (a Pydantic model).
+    Attribute reads fall through to ``_data`` via ``__getattr__``, so
+    ``prediction.prediction_id`` etc. keep working, while ``_public_dict`` /
+    ``_public_fields`` are sourced from ``_data`` so the ``return_df=True``
+    code paths (``list_predictions``) produce a stable, fully-populated schema.
+    """
+
+    _data: PredictionData
+    _data_cls: type[PredictionData] = PredictionData
+
+    def __init__(self, client, **payload):
         super().__init__(client=client)  # type: ignore[call-arg]  # cooperative MRO
-        if kwargs:
-            logger.debug(
-                "_PredictionMixin received unexpected fields from API response: %s",
-                list(kwargs.keys()),
-            )
-        self.prediction_id = predictionId
-        self.label = label
-        self.objective = objective
-        self.subject = subject
-        self.status = status
-        self.last_update_time = datetime.strptime(lastUpdateTime, "%Y%m%dT%H%M%S.%f %Z") if lastUpdateTime else None
+        self._data = self._data_cls.model_validate(payload)
+
+    def __getattr__(self, name: str):
+        try:
+            data = object.__getattribute__(self, "_data")
+        except AttributeError:
+            raise AttributeError(name) from None
+        try:
+            return getattr(data, name)
+        except AttributeError:
+            raise AttributeError(name) from None
+
+    @property
+    def _public_dict(self) -> dict:
+        return self._data.public_dict
+
+    @property
+    def _public_fields(self) -> list[str]:
+        return list(type(self._data).model_fields)
+
+    @classmethod
+    def _public_schema(cls) -> dict:
+        """Polars schema for ``return_df=True`` results (locked column set)."""
+        return cls._data_cls.polars_schema()
 
     @abstractmethod
     def get_metric(

--- a/python/pdstools/infinity/resources/prediction_studio/base.py
+++ b/python/pdstools/infinity/resources/prediction_studio/base.py
@@ -327,6 +327,81 @@ class AsyncChampionChallenger(_ChampionChallengerMixin, AsyncAPIResource):
     pass
 
 
+class ChampionChallengerList(list):
+    """List-like container with label-based lookup for champion/challengers.
+
+    Notes
+    -----
+    Integer indexing, iteration, and list semantics are preserved. String
+    lookup first tries ``challenger_model.label`` and then falls back to
+    ``active_model.label``.
+    """
+
+    def __getitem__(self, index):
+        if isinstance(index, str):
+            return self._resolve_string_key(index)
+
+        return super().__getitem__(index)
+
+    def __contains__(self, item):
+        if isinstance(item, str):
+            try:
+                self._resolve_string_key(item)
+            except KeyError:
+                return False
+            return True
+        return super().__contains__(item)
+
+    def keys(self) -> list[str]:
+        """Return challenger labels, falling back to active labels when needed."""
+        labels: list[str] = []
+        for item in self:
+            challenger_model = getattr(item, "challenger_model", None)
+            challenger_label = getattr(challenger_model, "label", None)
+            if challenger_label is not None:
+                labels.append(challenger_label)
+                continue
+
+            active_model = getattr(item, "active_model", None)
+            active_label = getattr(active_model, "label", None)
+            if active_label is not None:
+                labels.append(active_label)
+        return labels
+
+    def _resolve_string_key(self, key: str):
+        challenger_matches = []
+        active_matches = []
+
+        for item in self:
+            challenger_model = getattr(item, "challenger_model", None)
+            challenger_label = getattr(challenger_model, "label", None)
+            if challenger_label == key:
+                challenger_matches.append(item)
+
+            active_model = getattr(item, "active_model", None)
+            active_label = getattr(active_model, "label", None)
+            if active_label == key:
+                active_matches.append(item)
+
+        if len(challenger_matches) == 1:
+            return challenger_matches[0]
+        if len(challenger_matches) > 1:
+            raise KeyError(
+                f"Label {key!r} is ambiguous; matched {len(challenger_matches)} challenger models. "
+                "Use the model id instead.",
+            )
+        if len(active_matches) == 1:
+            return active_matches[0]
+        if len(active_matches) > 1:
+            raise KeyError(
+                f"Label {key!r} is ambiguous; matched {len(active_matches)} active models. Use the model id instead.",
+            )
+
+        raise KeyError(
+            f"{key!r} was not found. Available challenger labels: {self.keys()[:5]}.",
+        )
+
+
 class _ModelInstanceMixin(ABC):
     """Behaviour wrapper around a :class:`ModelInstanceData` payload.
 

--- a/python/pdstools/infinity/resources/prediction_studio/schemas/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/schemas/__init__.py
@@ -1,4 +1,11 @@
 from ._base import ResourceData, parse_pega_datetime
 from .model import ModelData, ModelDataV26_1
+from .model_instance import ModelInstanceData
 
-__all__ = ["ModelData", "ModelDataV26_1", "ResourceData", "parse_pega_datetime"]
+__all__ = [
+    "ModelData",
+    "ModelDataV26_1",
+    "ModelInstanceData",
+    "ResourceData",
+    "parse_pega_datetime",
+]

--- a/python/pdstools/infinity/resources/prediction_studio/schemas/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/schemas/__init__.py
@@ -1,12 +1,14 @@
 from ._base import ResourceData, parse_pega_datetime
 from .model import ModelData, ModelDataV26_1
 from .model_instance import ModelInstanceData
+from .notification import NotificationData
 from .prediction import PredictionData
 
 __all__ = [
     "ModelData",
     "ModelDataV26_1",
     "ModelInstanceData",
+    "NotificationData",
     "PredictionData",
     "ResourceData",
     "parse_pega_datetime",

--- a/python/pdstools/infinity/resources/prediction_studio/schemas/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/schemas/__init__.py
@@ -1,0 +1,4 @@
+from ._base import ResourceData, parse_pega_datetime
+from .model import ModelData, ModelDataV26_1
+
+__all__ = ["ModelData", "ModelDataV26_1", "ResourceData", "parse_pega_datetime"]

--- a/python/pdstools/infinity/resources/prediction_studio/schemas/__init__.py
+++ b/python/pdstools/infinity/resources/prediction_studio/schemas/__init__.py
@@ -1,4 +1,11 @@
 from ._base import ResourceData, parse_pega_datetime
 from .model import ModelData, ModelDataV26_1
+from .prediction import PredictionData
 
-__all__ = ["ModelData", "ModelDataV26_1", "ResourceData", "parse_pega_datetime"]
+__all__ = [
+    "ModelData",
+    "ModelDataV26_1",
+    "PredictionData",
+    "ResourceData",
+    "parse_pega_datetime",
+]

--- a/python/pdstools/infinity/resources/prediction_studio/schemas/_base.py
+++ b/python/pdstools/infinity/resources/prediction_studio/schemas/_base.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import get_args
+
+import polars as pl
+from pydantic import BaseModel, ConfigDict
+
+# Pega serialises timestamps as e.g. "20240718T120552.671 GMT".  Pydantic's
+# default datetime parser does not understand this, so every *Data model
+# parses it explicitly via :func:`parse_pega_datetime` in a ``mode="before"``
+# field validator.
+_PEGA_DATETIME_FORMAT = "%Y%m%dT%H%M%S.%f %Z"
+
+# Maps the Python annotation of a declared field to the Polars dtype used when
+# materialising ``return_df=True`` results.  Anything unrecognised falls back
+# to ``pl.String`` (Pega payloads are overwhelmingly string-typed).
+_PY_TO_POLARS: dict[type, pl.DataType] = {
+    str: pl.String(),
+    bool: pl.Boolean(),
+    int: pl.Int64(),
+    float: pl.Float64(),
+    datetime: pl.Datetime(),
+    date: pl.Date(),
+}
+
+
+def parse_pega_datetime(value: object) -> datetime | None:
+    """Parse a Pega timestamp string into a naive ``datetime``.
+
+    Parameters
+    ----------
+    value : object
+        The raw value from the API payload.  May already be a ``datetime``
+        (passed through unchanged), ``None`` (returns ``None``), or a Pega
+        timestamp string such as ``"20240718T120552.671 GMT"``.
+
+    Returns
+    -------
+    datetime or None
+        The parsed naive datetime, or ``None`` when the input is empty.
+
+    Raises
+    ------
+    ValueError
+        When ``value`` is a string that does not match the Pega format.
+
+    """
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        if not value:
+            return None
+        return datetime.strptime(value, _PEGA_DATETIME_FORMAT)
+    raise ValueError(f"Cannot parse Pega datetime from {type(value).__name__}: {value!r}")
+
+
+class ResourceData(BaseModel):
+    """Base for all Prediction Studio payload models.
+
+    Centralises the Pydantic configuration shared by every ``*Data`` model:
+
+    * ``populate_by_name`` — accept both the API alias (``modelId``) and the
+      Pythonic field name (``model_id``).
+    * ``extra="allow"`` — retain forward-compatible fields a future Pega
+      release may add, instead of silently dropping them.
+    * ``protected_namespaces=()`` — Pega payloads legitimately use
+      ``model_*`` field names; disable Pydantic's protected-namespace
+      warning rather than mangle the public field names.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="allow",
+        protected_namespaces=(),
+    )
+
+    @classmethod
+    def polars_schema(cls) -> dict[str, pl.DataType]:
+        """Return a stable Polars schema for the declared fields.
+
+        Only declared model fields are included (forward-compatible
+        ``extra="allow"`` fields are intentionally excluded), so the
+        ``return_df=True`` code paths produce a column set and dtypes that do
+        not depend on which optional fields a given API response happened to
+        populate.
+
+        Returns
+        -------
+        dict[str, polars.DataType]
+            Field name to Polars dtype, in field-declaration order.
+        """
+        schema: dict[str, pl.DataType] = {}
+        for name, field in cls.model_fields.items():
+            non_none = [arg for arg in get_args(field.annotation) if arg is not type(None)]
+            base_type = non_none[0] if non_none else field.annotation
+            schema[name] = _PY_TO_POLARS.get(base_type, pl.String())
+        return schema
+
+    @property
+    def public_dict(self) -> dict[str, object]:
+        """Declared-field payload for DataFrame export (extras excluded)."""
+        dump = self.model_dump()
+        return {name: dump[name] for name in type(self).model_fields}

--- a/python/pdstools/infinity/resources/prediction_studio/schemas/model.py
+++ b/python/pdstools/infinity/resources/prediction_studio/schemas/model.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003  # Pydantic resolves this annotation at runtime
+
+from pydantic import Field, field_validator
+
+from ._base import ResourceData, parse_pega_datetime
+
+
+class ModelData(ResourceData):
+    """Typed payload for a Prediction Studio model.
+
+    Fields use Pythonic snake_case names with Pega camelCase aliases. Unknown
+    fields from newer Pega releases are retained (``extra="allow"``) and surface
+    on ``model_dump()`` / attribute access.
+
+    Parameters
+    ----------
+    model_id : str
+        Unique model identifier (alias ``modelId``).
+    label : str
+        Human-readable model name.
+    model_type : str or None
+        The model type, e.g. ``"Adaptive model"`` (alias ``modelType``).
+    modeling_technique : str or None
+        Underlying technique (alias ``modelingTechnique``).
+    source : str or None
+        Origin of the model, e.g. ``"Pega"``.
+    status : str or None
+        Lifecycle status, e.g. ``"Completed"``.
+    component_name : str or None
+        Component the model belongs to (alias ``componentName``).
+    last_update_time : datetime or None
+        Last modification time (alias ``lastUpdateTime``), parsed from the
+        Pega timestamp format.
+    updated_by : str or None
+        Operator who last updated the model (alias ``updatedBy``).
+    """
+
+    model_id: str = Field(alias="modelId")
+    label: str
+    model_type: str | None = Field(default=None, alias="modelType")
+    modeling_technique: str | None = Field(default=None, alias="modelingTechnique")
+    source: str | None = None
+    status: str | None = None
+    component_name: str | None = Field(default=None, alias="componentName")
+    last_update_time: datetime | None = Field(default=None, alias="lastUpdateTime")
+    updated_by: str | None = Field(default=None, alias="updatedBy")
+
+    @field_validator("last_update_time", mode="before")
+    @classmethod
+    def _parse_last_update_time(cls, value: object) -> datetime | None:
+        return parse_pega_datetime(value)
+
+
+class ModelDataV26_1(ModelData):
+    """Typed payload for a Prediction Studio model in API v26.1+.
+
+    Extends :class:`ModelData` with the performance metrics surfaced by the
+    v26.1 models endpoint.
+
+    Parameters
+    ----------
+    performance : float or None
+        Model performance metric (e.g. AUC).
+    performance_measure : str or None
+        The performance metric name (alias ``performanceMeasure``).
+    """
+
+    performance: float | None = None
+    performance_measure: str | None = Field(default=None, alias="performanceMeasure")

--- a/python/pdstools/infinity/resources/prediction_studio/schemas/model_instance.py
+++ b/python/pdstools/infinity/resources/prediction_studio/schemas/model_instance.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003  # Pydantic resolves this annotation at runtime
+
+from pydantic import Field, field_validator
+
+from ._base import ResourceData, parse_pega_datetime
+
+
+class ModelInstanceData(ResourceData):
+    """Typed payload for a Prediction Studio model instance.
+
+    Fields use Pythonic snake_case names with Pega camelCase aliases. Unknown
+    fields from newer Pega releases are retained (``extra="allow"``) and surface
+    on ``model_dump()`` / attribute access.
+
+    Parameters
+    ----------
+    instance_id : str
+        Unique model instance identifier (alias ``instanceID``).
+    name : str or None, default None
+        Human-readable instance name.
+    type : str or None, default None
+        The instance type.
+    status : str or None, default None
+        Lifecycle status.
+    active : bool or None, default None
+        Whether the instance is active.
+    last_update_time : datetime or None, default None
+        Last modification time (alias ``lastUpdateTime``), parsed from the
+        Pega timestamp format.
+    """
+
+    instance_id: str = Field(alias="instanceID")
+    name: str | None = None
+    type: str | None = None
+    status: str | None = None
+    active: bool | None = None
+    last_update_time: datetime | None = Field(default=None, alias="lastUpdateTime")
+
+    @field_validator("last_update_time", mode="before")
+    @classmethod
+    def _parse_last_update_time(cls, value: object) -> datetime | None:
+        return parse_pega_datetime(value)

--- a/python/pdstools/infinity/resources/prediction_studio/schemas/notification.py
+++ b/python/pdstools/infinity/resources/prediction_studio/schemas/notification.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003  # Pydantic resolves this annotation at runtime
+
+from pydantic import Field, field_validator
+
+from ._base import ResourceData, parse_pega_datetime
+
+
+class NotificationData(ResourceData):
+    """Typed payload for a Prediction Studio notification.
+
+    Fields use Pythonic snake_case names with Pega camelCase aliases. Unknown
+    fields from newer Pega releases are retained (``extra="allow"``) and surface
+    on ``model_dump()`` / attribute access.
+
+    ``model_id`` and ``prediction_id`` are optional because a notification is
+    scoped to either a model or a prediction (never both). They are declared
+    so that ``return_df=True`` results always expose both columns, regardless
+    of which endpoint produced the notification.
+
+    Parameters
+    ----------
+    model_id : str or None, default None
+        Owning model identifier (alias ``modelID``).
+    prediction_id : str or None, default None
+        Owning prediction identifier (alias ``predictionID``).
+    context : str or None, default None
+        Context the notification applies to.
+    notification_type : str
+        Type of the notification (alias ``notificationType``).
+    notification_id : str
+        Unique notification identifier (alias ``notificationID``).
+    notification_mnemonic : str
+        Machine-readable notification code (alias ``notificationMnemonic``).
+    description : str
+        Human-readable description.
+    model_type : str
+        Type of the owning model (alias ``modelType``).
+    impact : str
+        Impact level of the notification.
+    trigger_time : datetime
+        Time the notification was raised (alias ``triggerTime``), parsed from
+        the Pega timestamp format.
+    """
+
+    model_id: str | None = Field(default=None, alias="modelID")
+    prediction_id: str | None = Field(default=None, alias="predictionID")
+    context: str | None = None
+    notification_type: str = Field(alias="notificationType")
+    notification_id: str = Field(alias="notificationID")
+    notification_mnemonic: str = Field(alias="notificationMnemonic")
+    description: str
+    model_type: str = Field(alias="modelType")
+    impact: str
+    trigger_time: datetime = Field(alias="triggerTime")
+
+    @field_validator("trigger_time", mode="before")
+    @classmethod
+    def _parse_trigger_time(cls, value: object) -> datetime | None:
+        return parse_pega_datetime(value)

--- a/python/pdstools/infinity/resources/prediction_studio/schemas/prediction.py
+++ b/python/pdstools/infinity/resources/prediction_studio/schemas/prediction.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003  # Pydantic resolves this annotation at runtime
+
+from pydantic import Field, field_validator
+
+from ._base import ResourceData, parse_pega_datetime
+
+
+class PredictionData(ResourceData):
+    """Typed payload for a Prediction Studio prediction.
+
+    Fields use Pythonic snake_case names with Pega camelCase aliases. Unknown
+    fields from newer Pega releases are retained (``extra="allow"``) and surface
+    on ``model_dump()`` / attribute access.
+
+    Parameters
+    ----------
+    prediction_id : str
+        Unique prediction identifier (alias ``predictionId``).
+    label : str
+        Human-readable prediction name.
+    objective : str or None
+        Objective of the prediction.
+    subject : str or None
+        Subject of the prediction.
+    status : str or None
+        Lifecycle status, e.g. ``"Completed"``.
+    last_update_time : datetime or None
+        Last modification time (alias ``lastUpdateTime``), parsed from the
+        Pega timestamp format.
+    """
+
+    prediction_id: str = Field(alias="predictionId")
+    label: str
+    objective: str | None = None
+    subject: str | None = None
+    status: str | None = None
+    last_update_time: datetime | None = Field(default=None, alias="lastUpdateTime")
+
+    @field_validator("last_update_time", mode="before")
+    @classmethod
+    def _parse_last_update_time(cls, value: object) -> datetime | None:
+        return parse_pega_datetime(value)

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/champion_challenger/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/champion_challenger/_sync.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-import polars as pl
 
 from .....internal._pagination import PaginatedList
 from ...base import ChampionChallenger as ChampionChallengerBase
 from ._mixin import _ChampionChallengerV24_2Mixin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
 
 
 class ChampionChallenger(_ChampionChallengerV24_2Mixin, ChampionChallengerBase):
@@ -37,4 +40,4 @@ class ChampionChallenger(_ChampionChallengerV24_2Mixin, ChampionChallengerBase):
         pages: PaginatedList[Model] = PaginatedList(Model, self._client, "get", endpoint, _root="models")
         if not return_df:
             return pages
-        return pl.DataFrame([mod._public_dict for mod in pages])
+        return pages.as_df()

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/model.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/model.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, overload
 
-import polars as pl
 
 from ....internal._pagination import AsyncPaginatedList, PaginatedList
 from ....internal._resource import api_method
@@ -11,6 +10,7 @@ from ..base import AsyncNotification, ModelAttributes, Notification
 from ..base import Model as PreviousModel
 
 if TYPE_CHECKING:
+    import polars as pl
     from ..types import NotificationCategory
     from collections.abc import Callable
 
@@ -88,9 +88,7 @@ class Model(_ModelV24_2Mixin, PreviousModel):
             _root="notifications",
         )
         if return_df:
-            return pl.DataFrame(
-                [getattr(notification, "_public_dict", {}) for notification in notifications],
-            )
+            return notifications.as_df()
         return notifications
 
 

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_async.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_async.py
@@ -62,6 +62,7 @@ class AsyncPrediction(_PredictionV24_2Mixin, AsyncPredictionPrevious):
             Champion-challenger pairs from a prediction.
 
         """
+        from ...base import ChampionChallengerList
         from ..champion_challenger import AsyncChampionChallenger
         from ..model import AsyncModel
 
@@ -135,7 +136,7 @@ class AsyncPrediction(_PredictionV24_2Mixin, AsyncPredictionPrevious):
                 ),
             )
 
-        return ccs
+        return ChampionChallengerList(ccs)
 
     async def add_conditional_model(
         self,

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_sync.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from urllib.parse import quote as _quote
 from typing import Literal, overload, TYPE_CHECKING
 
-import polars as pl
 
 from .....internal._exceptions import PegaException, PegaMLopsError
 from .....internal._pagination import PaginatedList
@@ -12,6 +11,7 @@ from ...v24_1.prediction import Prediction as PredictionPrevious
 from ._mixin import _PredictionV24_2Mixin
 
 if TYPE_CHECKING:
+    import polars as pl
     from ...types import NotificationCategory
 
 
@@ -76,9 +76,7 @@ class Prediction(_PredictionV24_2Mixin, PredictionPrevious):
             category=category,
         )
         if return_df:
-            return pl.DataFrame(
-                [notification._public_dict for notification in notifications],
-            )
+            return notifications.as_df()
         return notifications
 
     def get_champion_challengers(self):

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction/_sync.py
@@ -93,6 +93,7 @@ class Prediction(_PredictionV24_2Mixin, PredictionPrevious):
             challenger across various segments of the prediction.
 
         """
+        from ...base import ChampionChallengerList
         from ..champion_challenger import ChampionChallenger
         from ..model import Model
 
@@ -169,7 +170,7 @@ class Prediction(_PredictionV24_2Mixin, PredictionPrevious):
                 ),
             )
 
-        return ccs
+        return ChampionChallengerList(ccs)
 
     def add_conditional_model(
         self,

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_sync.py
@@ -111,7 +111,7 @@ class PredictionStudio(_PredictionStudioV24_2Mixin, PredictionStudioPrevious):
 
         if not return_df:
             return pages
-        return pl.DataFrame([pred._public_dict for pred in pages])
+        return pages.as_df()
 
     def get_prediction(
         self,

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_sync.py
@@ -72,7 +72,7 @@ class PredictionStudio(_PredictionStudioV24_2Mixin, PredictionStudioPrevious):
         if not return_df:
             return pages
 
-        return pl.DataFrame([mod._public_dict for mod in pages])
+        return pages.as_df()
 
     @overload  # type: ignore[override]  # intentionally widens parent signature with return_df
     def list_predictions(

--- a/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v24_2/prediction_studio/_sync.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Literal, overload, TYPE_CHECKING
 
-import polars as pl
 
 from .....internal._exceptions import NoMonitoringExportError, PegaException
 from .....internal._pagination import PaginatedList
@@ -15,6 +14,7 @@ from ..repository import Repository
 from ._mixin import _PredictionStudioV24_2Mixin
 
 if TYPE_CHECKING:
+    import polars as pl
     from ...types import NotificationCategory
 
 
@@ -255,7 +255,5 @@ class PredictionStudio(_PredictionStudioV24_2Mixin, PredictionStudioPrevious):
             _root="notifications",
         )
         if return_df:
-            return pl.DataFrame(
-                [notification._public_dict for notification in notifications],
-            )
+            return notifications.as_df()
         return notifications

--- a/python/pdstools/infinity/resources/prediction_studio/v25_1/model.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v25_1/model.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, overload
 
-import polars as pl
 
 from ....internal._pagination import AsyncPaginatedList, PaginatedList
 from ....internal._resource import api_method
@@ -11,6 +10,7 @@ from ..base import AsyncNotification, ModelAttributes, Notification
 from ..base import Model as PreviousModel
 
 if TYPE_CHECKING:
+    import polars as pl
     from ..types import NotificationCategory
     from collections.abc import Callable
 
@@ -92,9 +92,7 @@ class Model(_Modelv25_1Mixin, PreviousModel):
             _root="notifications",
         )
         if return_df:
-            return pl.DataFrame(
-                [getattr(notification, "_public_dict", {}) for notification in notifications],
-            )
+            return notifications.as_df()
         return notifications
 
 

--- a/python/pdstools/infinity/resources/prediction_studio/v25_1/prediction_studio.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v25_1/prediction_studio.py
@@ -74,7 +74,7 @@ class PredictionStudio(_PredictionStudiov26_1):
         )
         if not return_df:
             return pages
-        return pl.DataFrame([pred._public_dict for pred in pages])
+        return pages.as_df()
 
 
 class AsyncPredictionStudio(_AsyncPredictionStudiov26_1):

--- a/python/pdstools/infinity/resources/prediction_studio/v25_1/prediction_studio.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v25_1/prediction_studio.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, cast, overload
 
-import polars as pl
 
 from ....internal._pagination import AsyncPaginatedList, PaginatedList
 from ..v26_1.prediction_studio._async import AsyncPredictionStudio as _AsyncPredictionStudiov26_1
@@ -11,6 +10,8 @@ from .model import AsyncModel, Model
 from .prediction import AsyncPrediction, Prediction
 
 if TYPE_CHECKING:
+    import polars as pl
+
     pass
 
 
@@ -47,7 +48,7 @@ class PredictionStudio(_PredictionStudiov26_1):
         pages: PaginatedList[Model] = PaginatedList(Model, self._client, "get", endpoint, _root="models", pageSize=100)
         if not return_df:
             return pages
-        return pl.DataFrame([mod._public_dict for mod in pages])
+        return pages.as_df()
 
     @overload  # type: ignore[override]
     def list_predictions(self, return_df: Literal[False] = False) -> PaginatedList[Prediction]: ...

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/champion_challenger/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/champion_challenger/_sync.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-import polars as pl
 
 from .....internal._pagination import PaginatedList
 from ...base import ChampionChallenger as ChampionChallengerBase
 from ._mixin import _ChampionChallengerv26_1Mixin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
 
 
 class ChampionChallenger(_ChampionChallengerv26_1Mixin, ChampionChallengerBase):
@@ -39,4 +42,4 @@ class ChampionChallenger(_ChampionChallengerv26_1Mixin, ChampionChallengerBase):
         pages: PaginatedList[Model] = PaginatedList(Model, self._client, "get", endpoint, _root="models")
         if not return_df:
             return pages
-        return pl.DataFrame([mod._public_dict for mod in pages])
+        return pages.as_df()

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/model.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/model.py
@@ -142,9 +142,7 @@ class Model(_Modelv26_1Mixin, PreviousModel):
             _root="instances",
         )
         if return_df:
-            return pl.DataFrame(
-                [instance._public_dict for instance in instances],
-            )
+            return instances.as_df()
         return instances
 
 

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/model.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/model.py
@@ -15,6 +15,7 @@ from ..base import (
     Notification,
 )
 from ..base import Model as PreviousModel
+from ..schemas import ModelDataV26_1
 
 if TYPE_CHECKING:
     from ..types import NotificationCategory
@@ -29,37 +30,10 @@ class _Modelv26_1Mixin:
         model_id: str
         _a_get: Callable[..., Any]
 
-    def __init__(
-        self,
-        client,
-        *,
-        modelId: str,
-        label: str,
-        modelType: str,
-        status: str,
-        componentName: str | None = None,
-        source: str | None = None,
-        lastUpdateTime: str | None = None,
-        modelingTechnique: str | None = None,
-        updatedBy: str | None = None,
-        performance: float | None = None,
-        performanceMeasure: str | None = None,
-        **kwargs,
-    ):
-        super().__init__(  # type: ignore[call-arg]
-            client=client,
-            modelId=modelId,
-            label=label,
-            modelType=modelType,
-            status=status,
-            componentName=componentName,
-            source=source,
-            lastUpdateTime=lastUpdateTime,
-            modelingTechnique=modelingTechnique,
-            updatedBy=updatedBy,
-        )
-        self.performance = performance
-        self.performance_measure = performanceMeasure
+    # Construction is handled by base ``_ModelMixin`` (payload -> _data_cls).
+    # v26.1 payloads additionally carry ``performance`` / ``performanceMeasure``,
+    # captured by the version-specific ``ModelDataV26_1`` schema.
+    _data_cls = ModelDataV26_1
 
     @api_method
     async def describe(self) -> ModelAttributes:

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/model.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/model.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, overload
 
-import polars as pl
 
 from ....internal._pagination import AsyncPaginatedList, PaginatedList
 from ....internal._resource import api_method
@@ -18,6 +17,7 @@ from ..base import Model as PreviousModel
 from ..schemas import ModelDataV26_1
 
 if TYPE_CHECKING:
+    import polars as pl
     from ..types import NotificationCategory
     from collections.abc import Callable
 
@@ -99,9 +99,7 @@ class Model(_Modelv26_1Mixin, PreviousModel):
             _root="notifications",
         )
         if return_df:
-            return pl.DataFrame(
-                [getattr(notification, "_public_dict", {}) for notification in notifications],
-            )
+            return notifications.as_df()
         return notifications
 
     @overload

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/model.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/model.py
@@ -7,7 +7,13 @@ import polars as pl
 from ....internal._pagination import AsyncPaginatedList, PaginatedList
 from ....internal._resource import api_method
 from ..base import AsyncModel as AsyncPreviousModel
-from ..base import AsyncNotification, ModelAttributes, Notification
+from ..base import (
+    AsyncModelInstance,
+    AsyncNotification,
+    ModelAttributes,
+    ModelInstance,
+    Notification,
+)
 from ..base import Model as PreviousModel
 
 if TYPE_CHECKING:
@@ -124,6 +130,49 @@ class Model(_Modelv26_1Mixin, PreviousModel):
             )
         return notifications
 
+    @overload
+    def list_instances(
+        self,
+        return_df: Literal[False] = False,
+    ) -> PaginatedList[ModelInstance]: ...
+
+    @overload
+    def list_instances(
+        self,
+        return_df: Literal[True] = True,
+    ) -> pl.DataFrame: ...
+
+    def list_instances(
+        self,
+        return_df: bool = False,
+    ) -> PaginatedList[ModelInstance] | pl.DataFrame:
+        """Fetches a list of model instances for a specific model.
+
+        Parameters
+        ----------
+        return_df : bool, default False
+            If True, returns the model instances as a DataFrame.
+
+        Returns
+        -------
+        PaginatedList[ModelInstance] or polars.DataFrame
+            A list of model instances or a DataFrame.
+
+        """
+        endpoint = f"/prweb/api/PredictionStudio/v1/models/{self.model_id}/instances"
+        instances: PaginatedList[ModelInstance] = PaginatedList(
+            ModelInstance,
+            self._client,
+            "get",
+            endpoint,
+            _root="instances",
+        )
+        if return_df:
+            return pl.DataFrame(
+                [instance._public_dict for instance in instances],
+            )
+        return instances
+
 
 class AsyncModel(_Modelv26_1Mixin, AsyncPreviousModel):
     """v26 async Model — inherits all v24.2 functionality."""
@@ -163,3 +212,44 @@ class AsyncModel(_Modelv26_1Mixin, AsyncPreviousModel):
         if return_df:
             return await notifications.as_df()
         return notifications
+
+    @overload
+    def list_instances(
+        self,
+        return_df: Literal[False] = False,
+    ) -> AsyncPaginatedList[AsyncModelInstance]: ...
+
+    @overload
+    def list_instances(
+        self,
+        return_df: Literal[True] = True,
+    ) -> pl.DataFrame: ...
+
+    async def list_instances(
+        self,
+        return_df: bool = False,
+    ) -> AsyncPaginatedList[AsyncModelInstance] | pl.DataFrame:
+        """Fetches a list of model instances for a specific model.
+
+        Parameters
+        ----------
+        return_df : bool, default False
+            If True, returns the model instances as a DataFrame.
+
+        Returns
+        -------
+        AsyncPaginatedList[AsyncModelInstance] or polars.DataFrame
+            A list of model instances or a DataFrame.
+
+        """
+        endpoint = f"/prweb/api/PredictionStudio/v1/models/{self.model_id}/instances"
+        instances: AsyncPaginatedList[AsyncModelInstance] = AsyncPaginatedList(
+            AsyncModelInstance,
+            self._client,
+            "get",
+            endpoint,
+            _root="instances",
+        )
+        if return_df:
+            return await instances.as_df()
+        return instances

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction/_async.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction/_async.py
@@ -62,6 +62,7 @@ class AsyncPrediction(_Predictionv26_1Mixin, AsyncPredictionPrevious):
             Champion-challenger pairs from a prediction.
 
         """
+        from ...base import ChampionChallengerList
         from ..champion_challenger import AsyncChampionChallenger
         from ..model import AsyncModel
 
@@ -138,7 +139,7 @@ class AsyncPrediction(_Predictionv26_1Mixin, AsyncPredictionPrevious):
                 ),
             )
 
-        return ccs
+        return ChampionChallengerList(ccs)
 
     async def add_conditional_model(
         self,

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction/_sync.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from urllib.parse import quote as _quote
 from typing import Literal, overload, TYPE_CHECKING
 
-import polars as pl
 
 from .....internal._exceptions import PegaException, PegaMLopsError
 from .....internal._pagination import PaginatedList
@@ -12,6 +11,7 @@ from ...v24_1.prediction import Prediction as PredictionPrevious
 from ._mixin import _Predictionv26_1Mixin
 
 if TYPE_CHECKING:
+    import polars as pl
     from ...types import NotificationCategory
 
 
@@ -65,9 +65,7 @@ class Prediction(_Predictionv26_1Mixin, PredictionPrevious):
             _root="notifications",
         )
         if return_df:
-            return pl.DataFrame(
-                [notification._public_dict for notification in notifications],
-            )
+            return notifications.as_df()
         return notifications
 
     def get_champion_challengers(self):

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction/_sync.py
@@ -78,6 +78,7 @@ class Prediction(_Predictionv26_1Mixin, PredictionPrevious):
             challenger across various segments of the prediction.
 
         """
+        from ...base import ChampionChallengerList
         from ..champion_challenger import ChampionChallenger
         from ..model import Model
 
@@ -153,7 +154,7 @@ class Prediction(_Predictionv26_1Mixin, PredictionPrevious):
                 ),
             )
 
-        return ccs
+        return ChampionChallengerList(ccs)
 
     def add_conditional_model(
         self,

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction_studio/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction_studio/_sync.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Literal, overload, TYPE_CHECKING
 
-import polars as pl
 
 from .....internal._exceptions import NoMonitoringExportError, PegaException
 from .....internal._pagination import PaginatedList
@@ -15,6 +14,7 @@ from ..repository import Repository
 from ._mixin import _PredictionStudiov26_1Mixin
 
 if TYPE_CHECKING:
+    import polars as pl
     from ...types import NotificationCategory
 
 
@@ -253,7 +253,5 @@ class PredictionStudio(_PredictionStudiov26_1Mixin, PredictionStudioPrevious):
             pageSize=100,
         )
         if return_df:
-            return pl.DataFrame(
-                [notification._public_dict for notification in notifications],
-            )
+            return notifications.as_df()
         return notifications

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction_studio/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction_studio/_sync.py
@@ -112,7 +112,7 @@ class PredictionStudio(_PredictionStudiov26_1Mixin, PredictionStudioPrevious):
 
         if not return_df:
             return pages
-        return pl.DataFrame([pred._public_dict for pred in pages])
+        return pages.as_df()
 
     def get_prediction(
         self,

--- a/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction_studio/_sync.py
+++ b/python/pdstools/infinity/resources/prediction_studio/v26_1/prediction_studio/_sync.py
@@ -72,7 +72,7 @@ class PredictionStudio(_PredictionStudiov26_1Mixin, PredictionStudioPrevious):
         if not return_df:
             return pages
 
-        return pl.DataFrame([mod._public_dict for mod in pages])
+        return pages.as_df()
 
     @overload  # type: ignore[override]  # intentionally widens parent signature with return_df
     def list_predictions(

--- a/python/tests/infinity/test_async_resources.py
+++ b/python/tests/infinity/test_async_resources.py
@@ -288,7 +288,7 @@ class TestAsyncPredictionStudio:
         async_client.request.return_value = mock_response_model
         result = await async_ps.list_models(return_df=True)
         assert isinstance(result, pl.DataFrame)
-        assert result.shape == (2, 8)
+        assert result.shape == (2, 9)
         assert result.columns == [
             "model_id",
             "label",
@@ -296,6 +296,7 @@ class TestAsyncPredictionStudio:
             "modeling_technique",
             "source",
             "status",
+            "component_name",
             "last_update_time",
             "updated_by",
         ]

--- a/python/tests/infinity/test_base_client.py
+++ b/python/tests/infinity/test_base_client.py
@@ -78,6 +78,23 @@ class TestBaseClient:
         repo = {"repository_type": "S3", "repository_name": "TestRepo"}
         assert client._get_version(repo) == "24.2"
 
+    def test_get_version_24_1_camelcase(self):
+        # Real systems return camelCase repository keys.
+        client = SyncAPIClient(
+            base_url="https://example.com",
+            auth=httpx.BasicAuth("user", "pass"),
+        )
+        repo = {"repositoryName": "TestRepo"}
+        assert client._get_version(repo) == "24.1"
+
+    def test_get_version_24_2_camelcase(self):
+        client = SyncAPIClient(
+            base_url="https://example.com",
+            auth=httpx.BasicAuth("user", "pass"),
+        )
+        repo = {"repositoryType": "S3", "repositoryName": "TestRepo"}
+        assert client._get_version(repo) == "24.2"
+
     def test_get_version_unknown_warns(self):
         client = SyncAPIClient(
             base_url="https://example.com",
@@ -127,6 +144,19 @@ class TestBaseClient:
         mocker.patch.object(client, "get", return_value=repo_json)
         assert client._infer_version() == "24.1"
 
+    def test_infer_version_returns_26_when_model_categories_400(self, mocker):
+        # A non-404 client error (e.g. 400 when the model-category data
+        # dictionary is absent) means the v3 endpoint resolved, which only
+        # happens on 25+/26 systems -> 26.1.
+        client = SyncAPIClient(
+            base_url="https://example.com",
+            auth=httpx.BasicAuth("user", "pass"),
+        )
+        probe_response = MagicMock(spec=httpx.Response)
+        probe_response.status_code = 400
+        mocker.patch.object(client, "_request", return_value=probe_response)
+        assert client._infer_version() == "26.1"
+
     def test_infer_version_warns_on_connection_error(self, mocker):
         client = SyncAPIClient(
             base_url="https://example.com",
@@ -143,14 +173,6 @@ class TestBaseClient:
             pega_version="24.2",
         )
         assert client.pega_version == "24.2"
-
-    def test_application_name_stored(self):
-        client = SyncAPIClient(
-            base_url="https://example.com",
-            auth=httpx.BasicAuth("user", "pass"),
-            application_name="MyApp",
-        )
-        assert client.application_name == "MyApp"
 
 
 # ---------------------------------------------------------------------------
@@ -519,6 +541,14 @@ class TestAsyncInferVersion:
         mocker.patch.object(client, "get", new=MagicMock())
         mocker.patch.object(client, "_collect_awaitable_blocking", side_effect=[probe, repo])
         assert client._infer_version() == "24.1"
+
+    def test_returns_26_on_model_categories_400(self, mocker):
+        # Non-404 client error means the v3 endpoint resolved -> 26.1.
+        client = self._make_client()
+        probe = self._mock_probe(400)
+        mocker.patch.object(client, "_request", new=MagicMock())
+        mocker.patch.object(client, "_collect_awaitable_blocking", return_value=probe)
+        assert client._infer_version() == "26.1"
 
     def test_raises_pega_exception_on_401(self, mocker):
         client = self._make_client()

--- a/python/tests/infinity/test_base_client.py
+++ b/python/tests/infinity/test_base_client.py
@@ -174,6 +174,14 @@ class TestBaseClient:
         )
         assert client.pega_version == "24.2"
 
+    def test_application_name_stored(self):
+        client = SyncAPIClient(
+            base_url="https://example.com",
+            auth=httpx.BasicAuth("user", "pass"),
+            application_name="MyApp",
+        )
+        assert client.application_name == "MyApp"
+
 
 # ---------------------------------------------------------------------------
 # SyncAPIClient — request dispatch
@@ -469,17 +477,21 @@ class TestSyncClientFactories:
             base_url="https://example.com",
             client_id="test-id",
             client_secret="test-secret",
+            application_name="MyApp",
         )
         assert isinstance(client, SyncAPIClient)
         assert str(client._base_url) == "https://example.com"
+        assert client.application_name == "MyApp"
 
     def test_from_basic_auth(self):
         client = SyncAPIClient.from_basic_auth(
             base_url="https://example.com",
             user_name="admin",
             password="secret",
+            application_name="MyApp",
         )
         assert isinstance(client, SyncAPIClient)
+        assert client.application_name == "MyApp"
 
     def test_from_basic_auth_missing_fields_raises(self):
         with pytest.raises(ValueError):
@@ -496,8 +508,12 @@ class TestSyncClientFactories:
             "Client Secret\n"
             "test-secret\n",
         )
-        client = SyncAPIClient.from_client_credentials(str(cred_file))
+        client = SyncAPIClient.from_client_credentials(
+            str(cred_file),
+            application_name="MyApp",
+        )
         assert isinstance(client, SyncAPIClient)
+        assert client.application_name == "MyApp"
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/infinity/test_client.py
+++ b/python/tests/infinity/test_client.py
@@ -28,6 +28,14 @@ class TestInfinity:
         with pytest.raises(TypeError, match="unexpected keyword argument"):
             Infinity(base_url="x", auth=None, bogus=True)  # type: ignore[call-arg]
 
+    def test_init_stores_application_name(self):
+        client = Infinity(
+            base_url="https://example.com",
+            auth=None,
+            application_name="MyApp",
+        )
+        assert client.application_name == "MyApp"
+
     def test_init_with_explicit_version(self, mocker):
         """When pega_version is passed, _infer_version should NOT be called."""
         mocker.patch.object(
@@ -112,6 +120,14 @@ class TestAsyncInfinity:
     def test_init_rejects_unknown_kwarg(self):
         with pytest.raises(TypeError, match="unexpected keyword argument"):
             AsyncInfinity(base_url="x", auth=None, bogus=True)  # type: ignore[call-arg]
+
+    def test_init_stores_application_name(self):
+        client = AsyncInfinity(
+            base_url="https://example.com",
+            auth=None,
+            application_name="MyApp",
+        )
+        assert client.application_name == "MyApp"
 
     def test_init_with_explicit_version(self, mocker):
         mocker.patch.object(

--- a/python/tests/infinity/test_package_exports.py
+++ b/python/tests/infinity/test_package_exports.py
@@ -1,0 +1,83 @@
+"""Tests for the lazy re-exports on the ``pdstools.infinity`` package."""
+
+from __future__ import annotations
+
+import pytest
+
+import pdstools.infinity as inf
+from pdstools.infinity import (
+    ModelData,
+    ModelInstanceData,
+    NotificationData,
+    PredictionData,
+)
+from pdstools.infinity.resources.prediction_studio import schemas
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("ModelData", schemas.ModelData),
+        ("ModelInstanceData", schemas.ModelInstanceData),
+        ("NotificationData", schemas.NotificationData),
+        ("PredictionData", schemas.PredictionData),
+    ],
+)
+def test_data_model_reexport_is_canonical_class(name, expected):
+    """The package-level alias is the same object as the deep-path class."""
+    assert getattr(inf, name) is expected
+
+
+def test_data_models_in_all():
+    for name in (
+        "ModelData",
+        "ModelInstanceData",
+        "NotificationData",
+        "PredictionData",
+    ):
+        assert name in inf.__all__
+
+
+def test_client_entrypoints_in_all():
+    assert "Infinity" in inf.__all__
+    assert "AsyncInfinity" in inf.__all__
+
+
+def test_reexported_model_exposes_locked_schema():
+    """A re-exported model still drives the locked DataFrame schema."""
+    assert list(ModelData.polars_schema().keys()) == [
+        "model_id",
+        "label",
+        "model_type",
+        "modeling_technique",
+        "source",
+        "status",
+        "component_name",
+        "last_update_time",
+        "updated_by",
+    ]
+
+
+def test_unknown_attribute_raises():
+    with pytest.raises(AttributeError, match="has no attribute 'Nonexistent'"):
+        inf.__getattr__("Nonexistent")
+
+
+def test_data_model_missing_pydantic_returns_sentinel(monkeypatch):
+    """When pydantic is absent the lazy branch yields a deferred-error sentinel."""
+
+    def fake_find_spec(name: str):
+        if name == "pydantic":
+            return None
+        return object()
+
+    monkeypatch.setattr(inf, "find_spec", fake_find_spec)
+    sentinel = inf.__getattr__("PredictionData")
+    assert isinstance(sentinel, inf.DependencyNotFound)
+    assert sentinel.dependencies == ["pydantic"]
+
+
+def test_reexported_classes_are_pydantic_models():
+    for cls in (ModelData, ModelInstanceData, NotificationData, PredictionData):
+        assert hasattr(cls, "model_validate")
+        assert hasattr(cls, "polars_schema")

--- a/python/tests/infinity/test_pagination.py
+++ b/python/tests/infinity/test_pagination.py
@@ -198,6 +198,16 @@ class TestPaginatedList:
         with pytest.raises(ValueError, match="Json format unexpected"):
             list(pl_)
 
+    def test_empty_dict_response_yields_empty(self):
+        """An empty ``{}`` body (no items configured) is an empty page, not an
+        error — distinct from a populated dict missing the root key.
+        """
+        client = MagicMock()
+        client.request.return_value = {}
+        pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
+        assert list(pl_) == []
+        assert pl_.as_df().is_empty()
+
     def test_repr(self):
         client = _single_page_client()
         pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
@@ -449,6 +459,16 @@ class TestAsyncPaginatedList:
         apl = AsyncPaginatedList(_AsyncItem, client, "get", "/items", _root="items")
         with pytest.raises(ValueError, match="Json format unexpected"):
             await apl.collect()
+
+    @pytest.mark.asyncio
+    async def test_async_empty_dict_response_yields_empty(self):
+        """An empty ``{}`` body is an empty page, not an error (async)."""
+        client = MagicMock()
+        client.request = AsyncMock(return_value={})
+        apl = AsyncPaginatedList(_AsyncItem, client, "get", "/items", _root="items")
+        assert await apl.collect() == []
+        df = await apl.as_df()
+        assert df.is_empty()
 
     def test_async_repr(self):
         client = MagicMock()

--- a/python/tests/infinity/test_pagination.py
+++ b/python/tests/infinity/test_pagination.py
@@ -32,6 +32,17 @@ class _AsyncItem(AsyncAPIResource):
         self.name = name
 
 
+class _AsyncCustomIdItem(AsyncAPIResource):
+    """Async content class whose id lives on a non-default field name."""
+
+    _id_field = "model_id"
+
+    def __init__(self, client, *, model_id: str, name: str):
+        super().__init__(client=client)
+        self.model_id = model_id
+        self.name = name
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -102,14 +113,19 @@ class TestPaginatedList:
         assert item.id == "B"
         assert item.name == "Bob"
 
-    def test_getitem_by_string_id_requires_dict_content_class(self):
-        """String indexing expects the content class to support `in` and dict-like
-        item access. With SyncAPIResource subclasses it raises TypeError.
-        """
+    def test_getitem_by_string_id(self):
+        """String indexing looks up by the id field (defaults to ``id``)."""
         client = _single_page_client()
         pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
-        with pytest.raises(TypeError):
-            pl_["B"]
+        item = pl_["B"]
+        assert item.id == "B"
+        assert item.name == "Bob"
+
+    def test_getitem_by_string_id_missing_raises(self):
+        client = _single_page_client()
+        pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
+        with pytest.raises(IndexError):
+            pl_["Z"]
 
     def test_getitem_negative_index_raises(self):
         client = _single_page_client()
@@ -132,14 +148,13 @@ class TestPaginatedList:
         item = pl_.get(0)
         assert item.id == "A"
 
-    def test_get_by_string_returns_default_for_resource_classes(self):
-        """get() by string falls back to default because __getitem__ for string
-        fails with resource classes that don't support dict-like 'in' checks.
-        """
+    def test_get_by_string_id(self):
+        """get() by string resolves via the id field."""
         client = _single_page_client()
         pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
         result = pl_.get("C", "not_found")
-        assert result == "not_found"
+        assert result.id == "C"
+        assert result.name == "Charlie"
 
     def test_get_default_on_missing(self):
         client = _single_page_client()
@@ -236,6 +251,62 @@ class TestPaginatedList:
         sliced = pl_[0:3]
         item = sliced[1]
         assert item.id == "B"
+
+    def test_contains_by_id(self):
+        client = _single_page_client()
+        pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
+        assert "B" in pl_
+        assert "Z" not in pl_
+
+    def test_keys(self):
+        client = _single_page_client()
+        pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
+        assert pl_.keys() == ["A", "B", "C"]
+
+
+# ---------------------------------------------------------------------------
+# Custom _id_field resolution
+# ---------------------------------------------------------------------------
+
+
+class _CustomIdItem(SyncAPIResource):
+    """Content class whose id lives on a non-default field name."""
+
+    _id_field = "model_id"
+
+    def __init__(self, client, *, model_id: str, name: str):
+        super().__init__(client=client)
+        self.model_id = model_id
+        self.name = name
+
+
+class TestCustomIdField:
+    def _client(self):
+        client = MagicMock()
+        client.request.return_value = {
+            "items": [
+                {"model_id": "m1", "name": "First"},
+                {"model_id": "m2", "name": "Second"},
+            ],
+        }
+        return client
+
+    def test_getitem_uses_id_field(self):
+        pl_ = PaginatedList(_CustomIdItem, self._client(), "get", "/m", _root="items")
+        assert pl_["m2"].name == "Second"
+
+    def test_get_uses_id_field(self):
+        pl_ = PaginatedList(_CustomIdItem, self._client(), "get", "/m", _root="items")
+        assert pl_.get("m1").name == "First"
+
+    def test_contains_uses_id_field(self):
+        pl_ = PaginatedList(_CustomIdItem, self._client(), "get", "/m", _root="items")
+        assert "m1" in pl_
+        assert "nope" not in pl_
+
+    def test_keys_uses_id_field(self):
+        pl_ = PaginatedList(_CustomIdItem, self._client(), "get", "/m", _root="items")
+        assert pl_.keys() == ["m1", "m2"]
 
 
 # ---------------------------------------------------------------------------
@@ -396,3 +467,30 @@ class TestAsyncPaginatedList:
         await apl.collect()
         second_call = client.request.call_args_list[1]
         assert second_call == call("get", "/items", pageToken="tok")
+
+    @pytest.mark.asyncio
+    async def test_async_keys(self):
+        client = self._make_async_client(
+            [
+                _make_page(
+                    [{"id": "A", "name": "Alice"}, {"id": "B", "name": "Bob"}],
+                ),
+            ],
+        )
+        apl = AsyncPaginatedList(_AsyncItem, client, "get", "/items", _root="items")
+        assert await apl.keys() == ["A", "B"]
+
+    @pytest.mark.asyncio
+    async def test_async_get_uses_id_field(self):
+        client = MagicMock()
+        client.request = AsyncMock(
+            return_value={
+                "items": [
+                    {"model_id": "m1", "name": "First"},
+                    {"model_id": "m2", "name": "Second"},
+                ],
+            },
+        )
+        apl = AsyncPaginatedList(_AsyncCustomIdItem, client, "get", "/m", _root="items")
+        item = await apl.get("m2")
+        assert item.name == "Second"

--- a/python/tests/infinity/test_pagination.py
+++ b/python/tests/infinity/test_pagination.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call
 
 import polars as pl
 import pytest
 from pdstools.infinity.internal._pagination import AsyncPaginatedList, PaginatedList
 from pdstools.infinity.internal._resource import AsyncAPIResource, SyncAPIResource
+from pdstools.infinity.resources.prediction_studio.base import ChampionChallengerList
 
 # ---------------------------------------------------------------------------
 # Minimal content class for pagination tests.
@@ -40,6 +42,30 @@ class _AsyncCustomIdItem(AsyncAPIResource):
     def __init__(self, client, *, model_id: str, name: str):
         super().__init__(client=client)
         self.model_id = model_id
+        self.name = name
+
+
+class _LabeledItem(SyncAPIResource):
+    """Tiny sync resource with both id and label fields."""
+
+    _id_field = "model_id"
+
+    def __init__(self, client, *, model_id: str, label: str, name: str):
+        super().__init__(client=client)
+        self.model_id = model_id
+        self.label = label
+        self.name = name
+
+
+class _AsyncLabeledItem(AsyncAPIResource):
+    """Tiny async resource with both id and label fields."""
+
+    _id_field = "model_id"
+
+    def __init__(self, client, *, model_id: str, label: str, name: str):
+        super().__init__(client=client)
+        self.model_id = model_id
+        self.label = label
         self.name = name
 
 
@@ -91,6 +117,26 @@ def _empty_page_client():
     return client
 
 
+def _labeled_page():
+    return _make_page(
+        [
+            {"model_id": "m1", "label": "Alpha", "name": "First"},
+            {"model_id": "m2", "label": "Beta", "name": "Second"},
+            {"model_id": "m3", "label": "Gamma", "name": "Third"},
+        ],
+    )
+
+
+def _ambiguous_labeled_page():
+    return _make_page(
+        [
+            {"model_id": "m1", "label": "Shared", "name": "First"},
+            {"model_id": "m2", "label": "Shared", "name": "Second"},
+            {"model_id": "m3", "label": "Unique", "name": "Third"},
+        ],
+    )
+
+
 # ---------------------------------------------------------------------------
 # PaginatedList (sync)
 # ---------------------------------------------------------------------------
@@ -124,7 +170,7 @@ class TestPaginatedList:
     def test_getitem_by_string_id_missing_raises(self):
         client = _single_page_client()
         pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
-        with pytest.raises(IndexError):
+        with pytest.raises(KeyError, match="Available ids"):
             pl_["Z"]
 
     def test_getitem_negative_index_raises(self):
@@ -279,6 +325,38 @@ class TestPaginatedList:
         client = _single_page_client()
         pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
         assert pl_.keys() == ["A", "B", "C"]
+
+
+class TestLabeledPaginatedList:
+    def _client(self, page):
+        client = MagicMock()
+        client.request.return_value = page
+        return client
+
+    def test_getitem_by_label(self):
+        pl_ = PaginatedList(_LabeledItem, self._client(_labeled_page()), "get", "/m", _root="items")
+        assert pl_["Beta"].model_id == "m2"
+
+    def test_getitem_by_id_with_label_present(self):
+        pl_ = PaginatedList(_LabeledItem, self._client(_labeled_page()), "get", "/m", _root="items")
+        assert pl_["m1"].label == "Alpha"
+
+    def test_getitem_by_label_ambiguous_raises(self):
+        pl_ = PaginatedList(_LabeledItem, self._client(_ambiguous_labeled_page()), "get", "/m", _root="items")
+        with pytest.raises(KeyError, match="ambiguous"):
+            pl_["Shared"]
+
+    def test_getitem_missing_label_lists_available_labels(self):
+        pl_ = PaginatedList(_LabeledItem, self._client(_labeled_page()), "get", "/m", _root="items")
+        with pytest.raises(KeyError, match="Available labels: \\['Alpha', 'Beta', 'Gamma'\\]"):
+            pl_["Missing"]
+
+    def test_contains_get_and_keys_use_label_fallback(self):
+        pl_ = PaginatedList(_LabeledItem, self._client(_labeled_page()), "get", "/m", _root="items")
+        assert "Gamma" in pl_
+        assert pl_.get("Alpha").name == "First"
+        assert pl_.get("Missing", "fallback") == "fallback"
+        assert pl_.keys() == ["Alpha", "Beta", "Gamma"]
 
 
 # ---------------------------------------------------------------------------
@@ -521,3 +599,81 @@ class TestAsyncPaginatedList:
         apl = AsyncPaginatedList(_AsyncCustomIdItem, client, "get", "/m", _root="items")
         item = await apl.get("m2")
         assert item.name == "Second"
+
+
+class TestAsyncLabeledPaginatedList:
+    def _client(self, page):
+        client = MagicMock()
+        client.request = AsyncMock(return_value=page)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_async_get_by_label(self):
+        apl = AsyncPaginatedList(_AsyncLabeledItem, self._client(_labeled_page()), "get", "/m", _root="items")
+        assert (await apl.get("Beta")).model_id == "m2"
+
+    @pytest.mark.asyncio
+    async def test_async_get_by_id_with_label_present(self):
+        apl = AsyncPaginatedList(_AsyncLabeledItem, self._client(_labeled_page()), "get", "/m", _root="items")
+        assert (await apl.get("m1")).label == "Alpha"
+
+    @pytest.mark.asyncio
+    async def test_async_get_by_label_ambiguous_returns_default(self):
+        apl = AsyncPaginatedList(
+            _AsyncLabeledItem,
+            self._client(_ambiguous_labeled_page()),
+            "get",
+            "/m",
+            _root="items",
+        )
+        assert await apl.get("Shared", "fallback") == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_async_get_missing_label_returns_default(self):
+        apl = AsyncPaginatedList(_AsyncLabeledItem, self._client(_labeled_page()), "get", "/m", _root="items")
+        assert await apl.get("Missing", "fallback") == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_async_keys_prefer_labels(self):
+        apl = AsyncPaginatedList(_AsyncLabeledItem, self._client(_labeled_page()), "get", "/m", _root="items")
+        assert await apl.keys() == ["Alpha", "Beta", "Gamma"]
+
+
+def _cc(active_label: str, challenger_label: str | None = None):
+    challenger_model = None
+    if challenger_label is not None:
+        challenger_model = SimpleNamespace(label=challenger_label)
+    return SimpleNamespace(
+        active_model=SimpleNamespace(label=active_label),
+        challenger_model=challenger_model,
+    )
+
+
+class TestChampionChallengerList:
+    def test_string_lookup_uses_challenger_label(self):
+        ccs = ChampionChallengerList([_cc("Champion A", "Challenger A"), _cc("Champion B", "Challenger B")])
+        assert ccs["Challenger B"].active_model.label == "Champion B"
+
+    def test_string_lookup_falls_back_to_active_label(self):
+        ccs = ChampionChallengerList([_cc("Champion Only"), _cc("Champion B", "Challenger B")])
+        assert ccs["Champion Only"].active_model.label == "Champion Only"
+
+    def test_string_lookup_ambiguous_raises(self):
+        ccs = ChampionChallengerList([_cc("Champion A", "Shared"), _cc("Champion B", "Shared")])
+        with pytest.raises(KeyError, match="ambiguous"):
+            ccs["Shared"]
+
+    def test_missing_label_lists_available_labels(self):
+        ccs = ChampionChallengerList([_cc("Champion Only"), _cc("Champion B", "Challenger B")])
+        with pytest.raises(
+            KeyError,
+            match="Available challenger labels: \\['Champion Only', 'Challenger B'\\]",
+        ):
+            ccs["Missing"]
+
+    def test_contains_keys_and_integer_indexing(self):
+        ccs = ChampionChallengerList([_cc("Champion Only"), _cc("Champion B", "Challenger B")])
+        assert "Champion Only" in ccs
+        assert "Missing" not in ccs
+        assert ccs.keys() == ["Champion Only", "Challenger B"]
+        assert ccs[1].challenger_model.label == "Challenger B"

--- a/python/tests/infinity/test_pagination.py
+++ b/python/tests/infinity/test_pagination.py
@@ -262,6 +262,13 @@ class TestPaginatedList:
         item = sliced[1]
         assert item.id == "B"
 
+    def test_slice_getitem_index_out_of_bounds_raises(self):
+        client = _single_page_client()
+        pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")
+        sliced = pl_[0:3]
+        with pytest.raises(IndexError):
+            sliced[3]
+
     def test_contains_by_id(self):
         client = _single_page_client()
         pl_ = PaginatedList(_Item, client, "get", "/items", _root="items")

--- a/python/tests/prediction_studio/test_model_data.py
+++ b/python/tests/prediction_studio/test_model_data.py
@@ -1,0 +1,277 @@
+"""Exact-value tests for the Prediction Studio Pydantic data layer.
+
+These cover the ``ModelData`` / ``ModelDataV26_1`` payload models directly
+(alias handling, forward-compat field retention, Pega datetime parsing, and
+the locked ``model_dump`` schema) plus the ``_data_cls`` selection wired into
+the sync/async ``Model`` resources for both API versions.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from pdstools.infinity.resources.prediction_studio.schemas import (
+    ModelData,
+    ModelDataV26_1,
+    ResourceData,
+    parse_pega_datetime,
+)
+from pdstools.infinity.resources.prediction_studio.v24_2.model import (
+    AsyncModel as AsyncModelV24_2,
+)
+from pdstools.infinity.resources.prediction_studio.v24_2.model import (
+    Model as ModelV24_2,
+)
+from pdstools.infinity.resources.prediction_studio.v26_1.model import (
+    AsyncModel as AsyncModelV26_1,
+)
+from pdstools.infinity.resources.prediction_studio.v26_1.model import (
+    Model as ModelV26_1,
+)
+
+# A realistic camelCase payload as the Pega models endpoint returns it.
+_PAYLOAD = {
+    "modelId": "CDHSAMPLE-DATA-CUSTOMER!ADM_16330376371",
+    "label": "testModel_falcons",
+    "modelType": "Adaptive model",
+    "modelingTechnique": "Adaptive model - Bayesian",
+    "source": "Pega",
+    "status": "Completed",
+    "componentName": "MyComponent",
+    "lastUpdateTime": "20240718T120552.671 GMT",
+    "updatedBy": "operator@pega.com",
+}
+
+_V26_PAYLOAD = {**_PAYLOAD, "performance": 55.5, "performanceMeasure": "AUC"}
+
+_EXPECTED_DATETIME = datetime.datetime(2024, 7, 18, 12, 5, 52, 671000)
+
+_BASE_FIELD_ORDER = [
+    "model_id",
+    "label",
+    "model_type",
+    "modeling_technique",
+    "source",
+    "status",
+    "component_name",
+    "last_update_time",
+    "updated_by",
+]
+
+
+# --------------------------------------------------------------------------- #
+# parse_pega_datetime
+# --------------------------------------------------------------------------- #
+def test_parse_pega_datetime_parses_pega_string():
+    assert parse_pega_datetime("20240718T120552.671 GMT") == _EXPECTED_DATETIME
+
+
+def test_parse_pega_datetime_passthrough_datetime():
+    assert parse_pega_datetime(_EXPECTED_DATETIME) is _EXPECTED_DATETIME
+
+
+def test_parse_pega_datetime_none_and_empty():
+    assert parse_pega_datetime(None) is None
+    assert parse_pega_datetime("") is None
+
+
+def test_parse_pega_datetime_bad_string_raises():
+    with pytest.raises(ValueError):
+        parse_pega_datetime("not-a-date")
+
+
+def test_parse_pega_datetime_bad_type_raises():
+    with pytest.raises(ValueError):
+        parse_pega_datetime(12345)
+
+
+# --------------------------------------------------------------------------- #
+# ModelData
+# --------------------------------------------------------------------------- #
+def test_model_data_accepts_camelcase_aliases():
+    data = ModelData.model_validate(_PAYLOAD)
+    assert data.model_id == "CDHSAMPLE-DATA-CUSTOMER!ADM_16330376371"
+    assert data.label == "testModel_falcons"
+    assert data.model_type == "Adaptive model"
+    assert data.modeling_technique == "Adaptive model - Bayesian"
+    assert data.source == "Pega"
+    assert data.status == "Completed"
+    assert data.component_name == "MyComponent"
+    assert data.last_update_time == _EXPECTED_DATETIME
+    assert data.updated_by == "operator@pega.com"
+
+
+def test_model_data_accepts_snake_case_names():
+    data = ModelData.model_validate({"model_id": "A!B", "label": "x", "model_type": "Adaptive model"})
+    assert data.model_id == "A!B"
+    assert data.model_type == "Adaptive model"
+
+
+def test_model_data_parses_pega_datetime():
+    data = ModelData.model_validate(_PAYLOAD)
+    assert data.last_update_time == _EXPECTED_DATETIME
+
+
+def test_model_data_missing_optionals_default_to_none():
+    data = ModelData.model_validate({"modelId": "A!B", "label": "x"})
+    assert data.model_type is None
+    assert data.component_name is None
+    assert data.last_update_time is None
+    assert data.updated_by is None
+
+
+def test_model_data_dump_locks_schema_order():
+    data = ModelData.model_validate({"modelId": "A!B", "label": "x"})
+    # Even with everything optional missing, all base fields are present.
+    assert list(data.model_dump().keys()) == _BASE_FIELD_ORDER
+
+
+def test_model_data_retains_forward_compat_fields():
+    data = ModelData.model_validate({**_PAYLOAD, "futureField": "surprise"})
+    dump = data.model_dump()
+    assert dump["futureField"] == "surprise"
+    # Unknown extras land after the declared fields.
+    assert list(dump.keys()) == [*_BASE_FIELD_ORDER, "futureField"]
+
+
+def test_model_data_is_resource_data_subclass():
+    assert issubclass(ModelData, ResourceData)
+
+
+# --------------------------------------------------------------------------- #
+# ModelDataV26_1
+# --------------------------------------------------------------------------- #
+def test_model_data_v26_adds_performance_fields():
+    data = ModelDataV26_1.model_validate(_V26_PAYLOAD)
+    assert data.performance == 55.5
+    assert data.performance_measure == "AUC"
+
+
+def test_model_data_v26_dump_appends_performance_after_base():
+    data = ModelDataV26_1.model_validate(_V26_PAYLOAD)
+    assert list(data.model_dump().keys()) == [
+        *_BASE_FIELD_ORDER,
+        "performance",
+        "performance_measure",
+    ]
+
+
+def test_model_data_v26_inherits_datetime_validator():
+    data = ModelDataV26_1.model_validate(_V26_PAYLOAD)
+    assert data.last_update_time == _EXPECTED_DATETIME
+
+
+def test_model_data_v26_performance_defaults_to_none():
+    data = ModelDataV26_1.model_validate({"modelId": "A!B", "label": "x"})
+    assert data.performance is None
+    assert data.performance_measure is None
+
+
+# --------------------------------------------------------------------------- #
+# Resource wiring: _data_cls selection + attribute delegation
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("model_cls", [ModelV24_2, AsyncModelV24_2])
+def test_v24_2_model_uses_base_model_data(model_cls, mocker):
+    model = model_cls(client=mocker.MagicMock(), **_PAYLOAD)
+    assert type(model._data) is ModelData
+    assert list(model._public_dict.keys()) == _BASE_FIELD_ORDER
+
+
+@pytest.mark.parametrize("model_cls", [ModelV26_1, AsyncModelV26_1])
+def test_v26_1_model_uses_v26_model_data(model_cls, mocker):
+    model = model_cls(client=mocker.MagicMock(), **_V26_PAYLOAD)
+    assert type(model._data) is ModelDataV26_1
+    assert list(model._public_dict.keys()) == [
+        *_BASE_FIELD_ORDER,
+        "performance",
+        "performance_measure",
+    ]
+
+
+def test_model_attribute_access_delegates_to_data(mocker):
+    model = ModelV24_2(client=mocker.MagicMock(), **_PAYLOAD)
+    assert model.model_id == "CDHSAMPLE-DATA-CUSTOMER!ADM_16330376371"
+    assert model.last_update_time == _EXPECTED_DATETIME
+    assert model.component_name == "MyComponent"
+
+
+def test_model_public_dict_is_snake_case_with_values(mocker):
+    model = ModelV26_1(client=mocker.MagicMock(), **_V26_PAYLOAD)
+    public = model._public_dict
+    assert public["model_id"] == "CDHSAMPLE-DATA-CUSTOMER!ADM_16330376371"
+    assert public["last_update_time"] == _EXPECTED_DATETIME
+    assert public["performance"] == 55.5
+    assert public["performance_measure"] == "AUC"
+
+
+def test_model_unknown_attribute_raises(mocker):
+    model = ModelV24_2(client=mocker.MagicMock(), **_PAYLOAD)
+    with pytest.raises(AttributeError):
+        _ = model.definitely_not_a_field
+
+
+# --------------------------------------------------------------------------- #
+# Locked DataFrame schema (empty / all-null / forward-compat extras)
+# --------------------------------------------------------------------------- #
+def _list_models_df(ps_cls, models, mocker):
+    client = mocker.MagicMock()
+    client.request.return_value = {"models": models}
+    inst = ps_cls.__new__(ps_cls)
+    inst._client = client
+    return inst.list_models(return_df=True)
+
+
+def test_list_models_empty_keeps_locked_schema(mocker):
+    from pdstools.infinity.resources.prediction_studio.v24_2.prediction_studio._sync import (
+        PredictionStudio,
+    )
+
+    df = _list_models_df(PredictionStudio, [], mocker)
+    assert df.shape == (0, 9)
+    assert df.columns == _BASE_FIELD_ORDER
+
+
+def test_list_models_all_null_optionals_have_typed_columns(mocker):
+    import polars as pl
+
+    from pdstools.infinity.resources.prediction_studio.v24_2.prediction_studio._sync import (
+        PredictionStudio,
+    )
+
+    df = _list_models_df(PredictionStudio, [{"modelId": "A!B", "label": "x"}], mocker)
+    # Optional columns are correctly typed (not Null), so dtype-specific ops work.
+    assert df.schema["status"] == pl.String
+    assert df.schema["last_update_time"] == pl.Datetime
+    assert df.select(pl.col("last_update_time").dt.year()).to_dicts() == [{"last_update_time": None}]
+
+
+def test_list_models_extras_do_not_leak_into_dataframe(mocker):
+    from pdstools.infinity.resources.prediction_studio.v24_2.prediction_studio._sync import (
+        PredictionStudio,
+    )
+
+    df = _list_models_df(
+        PredictionStudio,
+        [
+            {"modelId": "A!B", "label": "x", "futureField": "surprise"},
+            {"modelId": "C!D", "label": "y", "anotherFuture": 7},
+        ],
+        mocker,
+    )
+    assert df.columns == _BASE_FIELD_ORDER
+
+
+def test_polars_schema_excludes_extras_and_types_fields():
+    import polars as pl
+
+    schema = ModelDataV26_1.polars_schema()
+    assert list(schema.keys()) == [
+        *_BASE_FIELD_ORDER,
+        "performance",
+        "performance_measure",
+    ]
+    assert schema["model_id"] == pl.String
+    assert schema["last_update_time"] == pl.Datetime
+    assert schema["performance"] == pl.Float64

--- a/python/tests/prediction_studio/test_model_instance_data.py
+++ b/python/tests/prediction_studio/test_model_instance_data.py
@@ -1,0 +1,171 @@
+"""Exact-value tests for the Prediction Studio ModelInstance Pydantic data layer.
+
+These cover the ``ModelInstanceData`` payload model directly
+(alias handling, forward-compat field retention, Pega datetime parsing, and
+the locked ``model_dump`` schema) plus the concrete ``ModelInstance`` and
+``AsyncModelInstance`` resources.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+import polars as pl
+
+from pdstools.infinity.resources.prediction_studio.schemas import (
+    ModelInstanceData,
+    ResourceData,
+    parse_pega_datetime,
+)
+from pdstools.infinity.resources.prediction_studio.base import (
+    ModelInstance,
+    AsyncModelInstance,
+)
+
+_PAYLOAD = {
+    "instanceID": "Sales-CreditCards-GoldCard",
+    "name": "Gold Card",
+    "type": "Adaptive model instance",
+    "status": "Active",
+    "active": True,
+    "lastUpdateTime": "20240718T120552.671 GMT",
+}
+
+_EXPECTED_DATETIME = datetime.datetime(2024, 7, 18, 12, 5, 52, 671000)
+
+_BASE_FIELD_ORDER = [
+    "instance_id",
+    "name",
+    "type",
+    "status",
+    "active",
+    "last_update_time",
+]
+
+
+# --------------------------------------------------------------------------- #
+# parse_pega_datetime
+# --------------------------------------------------------------------------- #
+def test_parse_pega_datetime_parses_pega_string():
+    assert parse_pega_datetime("20240718T120552.671 GMT") == _EXPECTED_DATETIME
+
+
+def test_parse_pega_datetime_passthrough_datetime():
+    assert parse_pega_datetime(_EXPECTED_DATETIME) is _EXPECTED_DATETIME
+
+
+def test_parse_pega_datetime_none_and_empty():
+    assert parse_pega_datetime(None) is None
+    assert parse_pega_datetime("") is None
+
+
+def test_parse_pega_datetime_bad_string_raises():
+    with pytest.raises(ValueError):
+        parse_pega_datetime("not-a-date")
+
+
+def test_parse_pega_datetime_bad_type_raises():
+    with pytest.raises(ValueError):
+        parse_pega_datetime(12345)
+
+
+# --------------------------------------------------------------------------- #
+# ModelInstanceData
+# --------------------------------------------------------------------------- #
+def test_model_instance_data_accepts_camelcase_aliases():
+    data = ModelInstanceData.model_validate(_PAYLOAD)
+    assert data.instance_id == "Sales-CreditCards-GoldCard"
+    assert data.name == "Gold Card"
+    assert data.type == "Adaptive model instance"
+    assert data.status == "Active"
+    assert data.active is True
+    assert data.last_update_time == _EXPECTED_DATETIME
+
+
+def test_model_instance_data_accepts_snake_case_names():
+    data = ModelInstanceData.model_validate({"instance_id": "A!B", "name": "x", "active": False})
+    assert data.instance_id == "A!B"
+    assert data.name == "x"
+    assert data.active is False
+
+
+def test_model_instance_data_parses_pega_datetime():
+    data = ModelInstanceData.model_validate(_PAYLOAD)
+    assert data.last_update_time == _EXPECTED_DATETIME
+
+
+def test_model_instance_data_missing_optionals_default_to_none():
+    data = ModelInstanceData.model_validate({"instanceID": "A!B"})
+    assert data.name is None
+    assert data.type is None
+    assert data.status is None
+    assert data.active is None
+    assert data.last_update_time is None
+
+
+def test_model_instance_data_active_bool_handling():
+    data_true = ModelInstanceData.model_validate({"instanceID": "A", "active": True})
+    assert data_true.active is True
+    data_false = ModelInstanceData.model_validate({"instanceID": "A", "active": False})
+    assert data_false.active is False
+
+
+def test_model_instance_data_dump_locks_schema_order():
+    data = ModelInstanceData.model_validate({"instanceID": "A!B"})
+    # Even with everything optional missing, all base fields are present.
+    assert list(data.model_dump().keys()) == _BASE_FIELD_ORDER
+
+
+def test_model_instance_data_retains_forward_compat_fields():
+    data = ModelInstanceData.model_validate({**_PAYLOAD, "futureField": "surprise"})
+    dump = data.model_dump()
+    assert dump["futureField"] == "surprise"
+    # Unknown extras land after the declared fields.
+    assert list(dump.keys()) == [*_BASE_FIELD_ORDER, "futureField"]
+
+
+def test_model_instance_data_is_resource_data_subclass():
+    assert issubclass(ModelInstanceData, ResourceData)
+
+
+# --------------------------------------------------------------------------- #
+# Resource wiring: attribute delegation
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("instance_cls", [ModelInstance, AsyncModelInstance])
+def test_model_instance_uses_model_instance_data(instance_cls, mocker):
+    instance = instance_cls(client=mocker.MagicMock(), **_PAYLOAD)
+    assert type(instance._data) is ModelInstanceData
+    assert list(instance._public_dict.keys()) == _BASE_FIELD_ORDER
+
+
+def test_model_instance_attribute_access_delegates_to_data(mocker):
+    instance = ModelInstance(client=mocker.MagicMock(), **_PAYLOAD)
+    assert instance.instance_id == "Sales-CreditCards-GoldCard"
+    assert instance.last_update_time == _EXPECTED_DATETIME
+    assert instance.name == "Gold Card"
+
+
+def test_model_instance_public_dict_is_snake_case_with_values(mocker):
+    instance = ModelInstance(client=mocker.MagicMock(), **_PAYLOAD)
+    public = instance._public_dict
+    assert public["instance_id"] == "Sales-CreditCards-GoldCard"
+    assert public["last_update_time"] == _EXPECTED_DATETIME
+    assert public["active"] is True
+
+
+def test_model_instance_unknown_attribute_raises(mocker):
+    instance = ModelInstance(client=mocker.MagicMock(), **_PAYLOAD)
+    with pytest.raises(AttributeError):
+        _ = instance.definitely_not_a_field
+
+
+# --------------------------------------------------------------------------- #
+# Locked DataFrame schema (empty / all-null / forward-compat extras)
+# --------------------------------------------------------------------------- #
+def test_polars_schema_excludes_extras_and_types_fields():
+    schema = ModelInstanceData.polars_schema()
+    assert list(schema.keys()) == _BASE_FIELD_ORDER
+    assert schema["instance_id"] == pl.String
+    assert schema["last_update_time"] == pl.Datetime
+    assert schema["active"] == pl.Boolean

--- a/python/tests/prediction_studio/test_notification_data.py
+++ b/python/tests/prediction_studio/test_notification_data.py
@@ -1,0 +1,215 @@
+"""Exact-value tests for the Prediction Studio ``NotificationData`` layer.
+
+These cover the ``NotificationData`` payload model directly (alias handling,
+forward-compat field retention, Pega datetime parsing, and the locked
+``model_dump`` schema) plus the ``_data`` wiring on the sync/async
+``Notification`` resources and the locked ``return_df=True`` DataFrame schema.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import polars as pl
+import pytest
+
+from pdstools.infinity.internal._pagination import PaginatedList
+from pdstools.infinity.resources.prediction_studio.base import (
+    AsyncNotification,
+    Notification,
+)
+from pdstools.infinity.resources.prediction_studio.schemas import (
+    NotificationData,
+    ResourceData,
+)
+
+# A realistic camelCase payload as the Pega notifications endpoint returns it.
+_PAYLOAD = {
+    "modelID": "CDHSAMPLE-DATA-CUSTOMER!ADM_16330376371",
+    "predictionID": "CDHSAMPLE-DATA-CUSTOMER!PREDICTCUSTOMERACCEPTSCARDS",
+    "context": "SalesContext",
+    "notificationType": "Performance",
+    "notificationID": "N-3",
+    "notificationMnemonic": "Model performance is at its minimum",
+    "description": "Performance dropped below threshold",
+    "modelType": "Adaptive model",
+    "impact": "High",
+    "triggerTime": "20240718T120552.671 GMT",
+}
+
+# Minimal payload: only the required fields (model/prediction scoping absent).
+_MINIMAL_PAYLOAD = {
+    "notificationType": "Performance",
+    "notificationID": "N-3",
+    "notificationMnemonic": "Min performance",
+    "description": "desc",
+    "modelType": "Adaptive model",
+    "impact": "High",
+    "triggerTime": "20240718T120552.671 GMT",
+}
+
+_EXPECTED_DATETIME = datetime.datetime(2024, 7, 18, 12, 5, 52, 671000)
+
+_FIELD_ORDER = [
+    "model_id",
+    "prediction_id",
+    "context",
+    "notification_type",
+    "notification_id",
+    "notification_mnemonic",
+    "description",
+    "model_type",
+    "impact",
+    "trigger_time",
+]
+
+
+# --------------------------------------------------------------------------- #
+# NotificationData
+# --------------------------------------------------------------------------- #
+def test_notification_data_accepts_camelcase_aliases():
+    data = NotificationData.model_validate(_PAYLOAD)
+    assert data.model_id == "CDHSAMPLE-DATA-CUSTOMER!ADM_16330376371"
+    assert data.prediction_id == "CDHSAMPLE-DATA-CUSTOMER!PREDICTCUSTOMERACCEPTSCARDS"
+    assert data.context == "SalesContext"
+    assert data.notification_type == "Performance"
+    assert data.notification_id == "N-3"
+    assert data.notification_mnemonic == "Model performance is at its minimum"
+    assert data.description == "Performance dropped below threshold"
+    assert data.model_type == "Adaptive model"
+    assert data.impact == "High"
+    assert data.trigger_time == _EXPECTED_DATETIME
+
+
+def test_notification_data_accepts_snake_case_names():
+    data = NotificationData.model_validate(
+        {
+            "notification_type": "Performance",
+            "notification_id": "N-3",
+            "notification_mnemonic": "m",
+            "description": "d",
+            "model_type": "Adaptive model",
+            "impact": "High",
+            "trigger_time": "20240718T120552.671 GMT",
+        },
+    )
+    assert data.notification_id == "N-3"
+    assert data.trigger_time == _EXPECTED_DATETIME
+
+
+def test_notification_data_parses_pega_datetime():
+    data = NotificationData.model_validate(_PAYLOAD)
+    assert data.trigger_time == _EXPECTED_DATETIME
+
+
+def test_notification_data_missing_scope_defaults_to_none():
+    data = NotificationData.model_validate(_MINIMAL_PAYLOAD)
+    assert data.model_id is None
+    assert data.prediction_id is None
+    assert data.context is None
+
+
+def test_notification_data_dump_locks_schema_order():
+    data = NotificationData.model_validate(_MINIMAL_PAYLOAD)
+    # Even with model/prediction scoping absent, all fields are present.
+    assert list(data.model_dump().keys()) == _FIELD_ORDER
+
+
+def test_notification_data_retains_forward_compat_fields():
+    data = NotificationData.model_validate({**_PAYLOAD, "futureField": "surprise"})
+    dump = data.model_dump()
+    assert dump["futureField"] == "surprise"
+    assert list(dump.keys()) == [*_FIELD_ORDER, "futureField"]
+
+
+def test_notification_data_is_resource_data_subclass():
+    assert issubclass(NotificationData, ResourceData)
+
+
+# --------------------------------------------------------------------------- #
+# Resource wiring: _data + attribute delegation
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("notification_cls", [Notification, AsyncNotification])
+def test_notification_uses_notification_data(notification_cls, mocker):
+    notification = notification_cls(client=mocker.MagicMock(), **_PAYLOAD)
+    assert type(notification._data) is NotificationData
+    assert list(notification._public_dict.keys()) == _FIELD_ORDER
+
+
+def test_notification_attribute_access_delegates_to_data(mocker):
+    notification = Notification(client=mocker.MagicMock(), **_PAYLOAD)
+    assert notification.notification_id == "N-3"
+    assert notification.model_id == "CDHSAMPLE-DATA-CUSTOMER!ADM_16330376371"
+    assert notification.trigger_time == _EXPECTED_DATETIME
+
+
+def test_notification_public_dict_has_snake_case_values(mocker):
+    notification = Notification(client=mocker.MagicMock(), **_PAYLOAD)
+    public = notification._public_dict
+    assert public["prediction_id"] == "CDHSAMPLE-DATA-CUSTOMER!PREDICTCUSTOMERACCEPTSCARDS"
+    assert public["trigger_time"] == _EXPECTED_DATETIME
+    assert public["impact"] == "High"
+
+
+def test_notification_minimal_payload_fills_none_columns(mocker):
+    notification = Notification(client=mocker.MagicMock(), **_MINIMAL_PAYLOAD)
+    public = notification._public_dict
+    assert public["model_id"] is None
+    assert public["prediction_id"] is None
+    assert public["context"] is None
+
+
+def test_notification_unknown_attribute_raises(mocker):
+    notification = Notification(client=mocker.MagicMock(), **_PAYLOAD)
+    with pytest.raises(AttributeError):
+        _ = notification.definitely_not_a_field
+
+
+# --------------------------------------------------------------------------- #
+# Locked DataFrame schema (empty / all-null scope / forward-compat extras)
+# --------------------------------------------------------------------------- #
+def _notifications_df(notifications, mocker):
+    client = mocker.MagicMock()
+    client.request.return_value = {"notifications": notifications}
+    pages: PaginatedList = PaginatedList(
+        Notification,
+        client,
+        "get",
+        "endpoint",
+        _root="notifications",
+    )
+    return pages.as_df()
+
+
+def test_notifications_empty_keeps_locked_schema(mocker):
+    df = _notifications_df([], mocker)
+    assert df.shape == (0, 10)
+    assert df.columns == _FIELD_ORDER
+
+
+def test_notifications_minimal_scope_have_typed_columns(mocker):
+    df = _notifications_df([_MINIMAL_PAYLOAD], mocker)
+    assert df.columns == _FIELD_ORDER
+    assert df.schema["model_id"] == pl.String
+    assert df.schema["prediction_id"] == pl.String
+    assert df.schema["trigger_time"] == pl.Datetime
+    assert df.select(pl.col("trigger_time").dt.year()).to_dicts() == [{"trigger_time": 2024}]
+
+
+def test_notifications_extras_do_not_leak_into_dataframe(mocker):
+    df = _notifications_df(
+        [
+            {**_PAYLOAD, "futureField": "surprise"},
+            {**_MINIMAL_PAYLOAD, "anotherFuture": 7},
+        ],
+        mocker,
+    )
+    assert df.columns == _FIELD_ORDER
+
+
+def test_notification_polars_schema_types_fields():
+    schema = NotificationData.polars_schema()
+    assert list(schema.keys()) == _FIELD_ORDER
+    assert schema["model_id"] == pl.String
+    assert schema["notification_id"] == pl.String
+    assert schema["trigger_time"] == pl.Datetime

--- a/python/tests/prediction_studio/test_prediction_data.py
+++ b/python/tests/prediction_studio/test_prediction_data.py
@@ -1,0 +1,195 @@
+"""Exact-value tests for the Prediction Studio Pydantic data layer.
+
+These cover the ``PredictionData`` payload models directly
+(alias handling, forward-compat field retention, Pega datetime parsing, and
+the locked ``model_dump`` schema) plus the ``_data_cls`` selection wired into
+the sync/async ``Prediction`` resources.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from pdstools.infinity.resources.prediction_studio.schemas import (
+    PredictionData,
+    ResourceData,
+)
+from pdstools.infinity.resources.prediction_studio.v24_2.prediction import (
+    AsyncPrediction as AsyncPredictionV24_2,
+    Prediction as PredictionV24_2,
+)
+from pdstools.infinity.resources.prediction_studio.v26_1.prediction import (
+    AsyncPrediction as AsyncPredictionV26_1,
+    Prediction as PredictionV26_1,
+)
+
+# A realistic camelCase payload as the Pega predictions endpoint returns it.
+_PAYLOAD = {
+    "predictionId": "CDHSAMPLE-DATA-CUSTOMER!PREDICTCUSTOMERACCEPTSCARDS",
+    "label": "Predict Cards Acceptance",
+    "objective": "Accept",
+    "subject": "Customer",
+    "status": "Completed",
+    "lastUpdateTime": "20240718T120557.925 GMT",
+}
+
+_EXPECTED_DATETIME = datetime.datetime(2024, 7, 18, 12, 5, 57, 925000)
+
+_BASE_FIELD_ORDER = [
+    "prediction_id",
+    "label",
+    "objective",
+    "subject",
+    "status",
+    "last_update_time",
+]
+
+
+# --------------------------------------------------------------------------- #
+# PredictionData
+# --------------------------------------------------------------------------- #
+def test_prediction_data_accepts_camelcase_aliases():
+    data = PredictionData.model_validate(_PAYLOAD)
+    assert data.prediction_id == "CDHSAMPLE-DATA-CUSTOMER!PREDICTCUSTOMERACCEPTSCARDS"
+    assert data.label == "Predict Cards Acceptance"
+    assert data.objective == "Accept"
+    assert data.subject == "Customer"
+    assert data.status == "Completed"
+    assert data.last_update_time == _EXPECTED_DATETIME
+
+
+def test_prediction_data_accepts_snake_case_names():
+    data = PredictionData.model_validate({"prediction_id": "A!B", "label": "x", "objective": "Accept"})
+    assert data.prediction_id == "A!B"
+    assert data.objective == "Accept"
+
+
+def test_prediction_data_parses_pega_datetime():
+    data = PredictionData.model_validate(_PAYLOAD)
+    assert data.last_update_time == _EXPECTED_DATETIME
+
+
+def test_prediction_data_missing_optionals_default_to_none():
+    data = PredictionData.model_validate({"predictionId": "A!B", "label": "x"})
+    assert data.objective is None
+    assert data.subject is None
+    assert data.last_update_time is None
+
+
+def test_prediction_data_dump_locks_schema_order():
+    data = PredictionData.model_validate({"predictionId": "A!B", "label": "x"})
+    # Even with everything optional missing, all base fields are present.
+    assert list(data.model_dump().keys()) == _BASE_FIELD_ORDER
+
+
+def test_prediction_data_retains_forward_compat_fields():
+    data = PredictionData.model_validate({**_PAYLOAD, "futureField": "surprise"})
+    dump = data.model_dump()
+    assert dump["futureField"] == "surprise"
+    # Unknown extras land after the declared fields.
+    assert list(dump.keys()) == [*_BASE_FIELD_ORDER, "futureField"]
+
+
+def test_prediction_data_is_resource_data_subclass():
+    assert issubclass(PredictionData, ResourceData)
+
+
+# --------------------------------------------------------------------------- #
+# Resource wiring: _data_cls selection + attribute delegation
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "pred_cls",
+    [
+        PredictionV24_2,
+        AsyncPredictionV24_2,
+        PredictionV26_1,
+        AsyncPredictionV26_1,
+    ],
+)
+def test_prediction_uses_prediction_data(pred_cls, mocker):
+    prediction = pred_cls(client=mocker.MagicMock(), **_PAYLOAD)
+    assert type(prediction._data) is PredictionData
+    assert list(prediction._public_dict.keys()) == _BASE_FIELD_ORDER
+
+
+def test_prediction_attribute_access_delegates_to_data(mocker):
+    prediction = PredictionV24_2(client=mocker.MagicMock(), **_PAYLOAD)
+    assert prediction.prediction_id == "CDHSAMPLE-DATA-CUSTOMER!PREDICTCUSTOMERACCEPTSCARDS"
+    assert prediction.last_update_time == _EXPECTED_DATETIME
+    assert prediction.subject == "Customer"
+
+
+def test_prediction_public_dict_is_snake_case_with_values(mocker):
+    prediction = PredictionV24_2(client=mocker.MagicMock(), **_PAYLOAD)
+    public = prediction._public_dict
+    assert public["prediction_id"] == "CDHSAMPLE-DATA-CUSTOMER!PREDICTCUSTOMERACCEPTSCARDS"
+    assert public["last_update_time"] == _EXPECTED_DATETIME
+    assert public["objective"] == "Accept"
+
+
+def test_prediction_unknown_attribute_raises(mocker):
+    prediction = PredictionV24_2(client=mocker.MagicMock(), **_PAYLOAD)
+    with pytest.raises(AttributeError):
+        _ = prediction.definitely_not_a_field
+
+
+# --------------------------------------------------------------------------- #
+# Locked DataFrame schema (empty / all-null / forward-compat extras)
+# --------------------------------------------------------------------------- #
+def _list_predictions_df(ps_cls, predictions, mocker):
+    client = mocker.MagicMock()
+    client.request.return_value = {"predictions": predictions}
+    inst = ps_cls.__new__(ps_cls)
+    inst._client = client
+    return inst.list_predictions(return_df=True)
+
+
+def test_list_predictions_empty_keeps_locked_schema(mocker):
+    from pdstools.infinity.resources.prediction_studio.v24_2.prediction_studio._sync import (
+        PredictionStudio,
+    )
+
+    df = _list_predictions_df(PredictionStudio, [], mocker)
+    assert df.shape == (0, 6)
+    assert df.columns == _BASE_FIELD_ORDER
+
+
+def test_list_predictions_all_null_optionals_have_typed_columns(mocker):
+    import polars as pl
+
+    from pdstools.infinity.resources.prediction_studio.v24_2.prediction_studio._sync import (
+        PredictionStudio,
+    )
+
+    df = _list_predictions_df(PredictionStudio, [{"predictionId": "A!B", "label": "x"}], mocker)
+    # Optional columns are correctly typed (not Null), so dtype-specific ops work.
+    assert df.schema["status"] == pl.String
+    assert df.schema["last_update_time"] == pl.Datetime
+    assert df.select(pl.col("last_update_time").dt.year()).to_dicts() == [{"last_update_time": None}]
+
+
+def test_list_predictions_extras_do_not_leak_into_dataframe(mocker):
+    from pdstools.infinity.resources.prediction_studio.v24_2.prediction_studio._sync import (
+        PredictionStudio,
+    )
+
+    df = _list_predictions_df(
+        PredictionStudio,
+        [
+            {"predictionId": "A!B", "label": "x", "futureField": "surprise"},
+            {"predictionId": "C!D", "label": "y", "anotherFuture": 7},
+        ],
+        mocker,
+    )
+    assert df.columns == _BASE_FIELD_ORDER
+
+
+def test_polars_schema_excludes_extras_and_types_fields():
+    import polars as pl
+
+    schema = PredictionData.polars_schema()
+    assert list(schema.keys()) == _BASE_FIELD_ORDER
+    assert schema["prediction_id"] == pl.String
+    assert schema["last_update_time"] == pl.Datetime

--- a/python/tests/prediction_studio/v24_2/test_model.py
+++ b/python/tests/prediction_studio/v24_2/test_model.py
@@ -135,6 +135,9 @@ def test_model_describe(model_client, mocker):
                 len(df) == 2,
                 df.columns
                 == [
+                    "model_id",
+                    "prediction_id",
+                    "context",
                     "notification_type",
                     "notification_id",
                     "notification_mnemonic",
@@ -143,7 +146,7 @@ def test_model_describe(model_client, mocker):
                     "impact",
                     "trigger_time",
                 ],
-                df.shape == (2, 7),
+                df.shape == (2, 10),
             ),
         ),
     ],

--- a/python/tests/prediction_studio/v24_2/test_prediction.py
+++ b/python/tests/prediction_studio/v24_2/test_prediction.py
@@ -206,6 +206,7 @@ def test_prediction_describe(prediction_client, mocker):
                 df.columns
                 == [
                     "model_id",
+                    "prediction_id",
                     "context",
                     "notification_type",
                     "notification_id",
@@ -215,7 +216,7 @@ def test_prediction_describe(prediction_client, mocker):
                     "impact",
                     "trigger_time",
                 ],
-                df.shape == (2, 9),
+                df.shape == (2, 10),
             ),
         ),
     ],

--- a/python/tests/prediction_studio/v24_2/test_prediction_studio.py
+++ b/python/tests/prediction_studio/v24_2/test_prediction_studio.py
@@ -163,6 +163,7 @@ def test_repository(prediction_studio_client, mocker):
                 "modeling_technique",
                 "source",
                 "status",
+                "component_name",
                 "last_update_time",
                 "updated_by",
             ],
@@ -192,7 +193,7 @@ def test_list_models(
     if return_df:
         assert len(result) == expected_length
         assert result.columns == expected_columns
-        assert result.shape == (2, 8)
+        assert result.shape == (2, 9)
         assert result[0]["model_id"][0] == "@BASECLASS!TESTMODEL_FALCONS"
         assert result[0]["label"][0] == "testModel_falcons"
         assert result[0]["model_type"][0] == "Adaptive model"

--- a/python/tests/prediction_studio/v24_2/test_prediction_studio.py
+++ b/python/tests/prediction_studio/v24_2/test_prediction_studio.py
@@ -275,6 +275,7 @@ def test_list_predictions(
     if return_df:
         assert len(result) == expected_length
         assert result.columns == expected_columns
+        assert result.shape == (2, 6)
 
 
 @pytest.mark.parametrize(

--- a/python/tests/prediction_studio/v26_1/test_model.py
+++ b/python/tests/prediction_studio/v26_1/test_model.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+import polars as pl
+import pytest
+
+from pdstools.infinity.internal._pagination import AsyncPaginatedList, PaginatedList
+from pdstools.infinity.resources.prediction_studio.v26_1.model import AsyncModel, Model
+
+mock_model = {
+    "modelId": "@BASECLASS!TESTMODEL_FALCONS",
+    "label": "testModel_falcons",
+    "modelType": "Adaptive model",
+    "modelingTechnique": "Adaptive model - Bayesian",
+    "source": "Pega",
+    "status": "Completed",
+    "lastUpdateTime": "20240718T120552.671 GMT",
+    "updatedBy": "Somnath Paul",
+}
+
+mock_response_instances = {
+    "instances": [
+        {
+            "instanceID": "Sales-CreditCards-GoldCard",
+            "name": "Gold Card",
+            "type": "Adaptive model instance",
+            "status": "Active",
+            "active": True,
+            "lastUpdateTime": "20240718T120552.671 GMT",
+        }
+    ]
+}
+
+
+@pytest.fixture
+def sync_model():
+    client = MagicMock()
+    return Model(client=client, **mock_model)
+
+
+@pytest.fixture
+def async_model():
+    client = MagicMock()
+    client.request = AsyncMock()
+    return AsyncModel(client=client, **mock_model)
+
+
+def test_list_instances_sync_returns_paginated_list(sync_model, mocker):
+    mocker.patch.object(
+        sync_model._client,
+        "request",
+        return_value=mock_response_instances.copy(),
+    )
+    result = sync_model.list_instances(return_df=False)
+
+    assert isinstance(result, PaginatedList)
+    elements = list(result)
+    assert len(elements) == 1
+    instance = elements[0]
+    assert instance.instance_id == "Sales-CreditCards-GoldCard"
+    assert instance.name == "Gold Card"
+    assert instance.type == "Adaptive model instance"
+    assert instance.status == "Active"
+    assert instance.active is True
+    assert instance.last_update_time is not None
+    assert instance.last_update_time.year == 2024
+
+
+def test_list_instances_sync_returns_df(sync_model, mocker):
+    mocker.patch.object(
+        sync_model._client,
+        "request",
+        return_value=mock_response_instances.copy(),
+    )
+    result = sync_model.list_instances(return_df=True)
+
+    assert isinstance(result, pl.DataFrame)
+    assert result.shape == (1, 6)
+    assert result.columns == [
+        "instance_id",
+        "name",
+        "type",
+        "status",
+        "active",
+        "last_update_time",
+    ]
+    assert result["instance_id"][0] == "Sales-CreditCards-GoldCard"
+
+
+@pytest.mark.asyncio
+async def test_list_instances_async_returns_paginated_list(async_model):
+    async_model._client.request.return_value = mock_response_instances.copy()
+    result = await async_model.list_instances(return_df=False)
+
+    assert isinstance(result, AsyncPaginatedList)
+    elements = await result.collect()
+    assert len(elements) == 1
+    instance = elements[0]
+    assert instance.instance_id == "Sales-CreditCards-GoldCard"
+    assert instance.name == "Gold Card"
+    assert instance.type == "Adaptive model instance"
+    assert instance.status == "Active"
+    assert instance.active is True
+    assert instance.last_update_time is not None
+
+
+@pytest.mark.asyncio
+async def test_list_instances_async_returns_df(async_model):
+    async_model._client.request.return_value = mock_response_instances.copy()
+    result = await async_model.list_instances(return_df=True)
+
+    assert isinstance(result, pl.DataFrame)
+    assert result.shape == (1, 6)
+    assert result.columns == [
+        "instance_id",
+        "name",
+        "type",
+        "status",
+        "active",
+        "last_update_time",
+    ]
+    assert result["instance_id"][0] == "Sales-CreditCards-GoldCard"

--- a/python/tests/prediction_studio/v26_1/test_prediction_studio.py
+++ b/python/tests/prediction_studio/v26_1/test_prediction_studio.py
@@ -143,6 +143,7 @@ def test_repository(prediction_studio_client, mocker):
                 "modeling_technique",
                 "source",
                 "status",
+                "component_name",
                 "last_update_time",
                 "updated_by",
                 "performance",
@@ -173,7 +174,7 @@ def test_list_models(
     if return_df:
         assert len(result) == expected_length
         assert result.columns == expected_columns
-        assert result.shape == (2, 10)
+        assert result.shape == (2, 11)
         assert result[0]["model_id"][0] == "@BASECLASS!TESTMODEL_FALCONS"
         assert result[0]["label"][0] == "testModel_falcons"
         assert result[0]["last_update_time"][0] == datetime.datetime(

--- a/python/tests/prediction_studio/v26_1/test_prediction_studio.py
+++ b/python/tests/prediction_studio/v26_1/test_prediction_studio.py
@@ -224,9 +224,6 @@ def test_get_model(prediction_studio_client, mocker, fetch_type, fetch_value):
                 "subject",
                 "status",
                 "last_update_time",
-                "type",
-                "performance",
-                "performance_measure",
             ],
         ),
     ],
@@ -252,6 +249,7 @@ def test_list_predictions(
     if return_df:
         assert len(result) == expected_length
         assert result.columns == expected_columns
+        assert result.shape == (2, 6)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Prediction Studio API: Pydantic data layer + model-instances endpoint

## Summary

Introduces a **Pydantic data layer** for the Prediction Studio resources in
`pdstools.infinity`, cleanly separating the API *payload data* from the
sync/async *resource behaviour*. This locks the DataFrame schemas produced by
the `return_df=True` code paths so that empty results, all-null optional
fields, and forward-compatible extra fields no longer change the output shape.

It also lands the original motivating feature — a **model-instances endpoint
wrapper for v26.1** — and a handful of correctness fixes uncovered along the
way (notably a dead string-id lookup on `PaginatedList` and a sync/async
schema divergence in `list_models`).

No resource methods are removed. `Infinity` / `AsyncInfinity` keep their
existing method surface; the new data models are additive re-exports. The one
public-surface change is the removal of the **dead, non-functional
`application_name` constructor parameter** (see Correctness fixes below).

## What changed

### 1. New Pydantic data layer (`resources/prediction_studio/schemas/`)

A shared `ResourceData` base (`_base.py`) provides:

- `populate_by_name` + `extra="allow"` so snake_case Python fields map to the
  camelCase Pega payload via `Field(alias=...)`, while unknown fields are
  tolerated for forward compatibility.
- `polars_schema()` — derives a **locked** Polars schema (stable column set +
  dtypes) from the declared fields, driving every `return_df=True` result.
- `public_dict` — the row representation used when materialising DataFrames.
- `parse_pega_datetime()` — parses Pega's `"20240718T120552.671 GMT"`
  timestamps into naive `datetime`s via a `mode="before"` field validator.

Four concrete models migrated to this pattern, each with a matching test file:

| Model | Resource |
|-------|----------|
| `ModelData` (+ `ModelDataV26_1`) | adaptive models |
| `PredictionData` | predictions |
| `ModelInstanceData` | model instances |
| `NotificationData` | notifications |

Each resource mixin now stores `self._data = <Model>.model_validate(payload)`
and delegates attribute reads to it via `__getattr__`, so
`prediction.prediction_id`, `model.label`, etc. keep working unchanged.

### 2. Schema-locked DataFrame materialisation

`PaginatedList`/`AsyncPaginatedList` build `return_df=True` frames through
`_frame_from_resources`, which reads `content_class._public_schema()` when
available. Result: conditional columns (e.g. `component_name`) are now
**always present** (null-filled) instead of appearing or disappearing based on
the payload. All sync and async `list_*` / `get_notifications` paths route
through `as_df()` for a consistent schema.

### 3. Mapping-style id lookup on `PaginatedList`

Extended the existing `PaginatedList` (rather than adding a parallel
`*Collection` hierarchy) into a mapping-style collection:

- Added `_resolve_id_field()` so `list[id]`, `id in list`, `.keys()`, and
  `.get(id)` honour each resource's declared `_id_field`
  (`prediction_id` / `model_id` / `instance_id` / `notification_id`),
  defaulting to `"id"`.
- **Bug fix:** the sync string-`__getitem__` branch previously ran
  `assert "id" in self._content_class`, which raises `TypeError` on a class
  object — string-id lookup was effectively dead for every migrated resource.
- Added sync `__contains__` / `keys()`; added async `keys()` and routed async
  `get()` through `_resolve_id_field`.

### 4. Re-exports

`ModelData`, `PredictionData`, `ModelInstanceData`, and `NotificationData` are
now importable from `pdstools.infinity` (lazily, gated on `pydantic` alone —
looser than the `httpx`-requiring client). Users can introspect the locked
schema (`ModelData.polars_schema()`), type-annotate, and validate without an
API call.

### 5. Model-instances endpoint wrapper (v26.1)

Adds the v26.1 model-instances endpoint wrapper that originally motivated this
branch, plus a cleaned-up `PredictionStudio.ipynb` example notebook.

## Correctness fixes

- **Dead string-id lookup** on `PaginatedList` (broken `assert`, see §3).
- **Sync/async `list_models` divergence** — the async `as_df` test expected 8
  columns, but the locked `ModelData` schema always emits `component_name`
  (9 columns). The locked schema is the intended contract; the assertion was
  stale.
- Removed leaked extra fields (`type` / `performance` / `performance_measure`)
  from version variants that should not expose them.

### Fixes from live testing (real Pega 26.1 / CDHSample)

The whole branch was validated end-to-end against a live Pega 26.1 instance
(adaptive models, predictions, notifications, champion/challengers all
returning real data through the locked schemas). Three robustness issues
surfaced and were fixed:

- **Empty `{}` list response crashed pagination.** An endpoint that returns an
  empty body (`{}`) when nothing is configured — e.g. `/v3/predictions` on an
  app with no predictions — previously raised
  `ValueError: Json format unexpected, predictions not found` because the root
  key was absent. Now an empty body yields zero items; a *populated* dict
  missing the expected root key is still a format error. Applied to both
  `PaginatedList` and `AsyncPaginatedList`.
- **Version auto-detection returned `None` on a genuine 26.1 system.** The
  `/v3/predictions/modelCategories` probe returned HTTP 400 (model-category
  data dictionary not configured), which only handled 200 and fell through to
  the 24.x fallback. A non-404 client error means the endpoint *resolved* (a
  pre-25 system 404s on the unknown path), so any non-404 client error now
  resolves to `26.1`. The repository fallback (`_get_version`) also checked
  snake_case keys while real systems return camelCase
  (`repositoryName`/`repositoryType`) — both casings are now accepted.
- **`application_name` was dead code.** It was stored on the client but never
  sent as a request header (confirmed by dumping outgoing headers). A
  client-credentials token's application context is fixed at issuance by the
  run-as operator's default access group and cannot be overridden by a caller
  header, so the parameter promised something it could never deliver. Removed
  from all constructors and `from_*` classmethods.

## Notes for reviewers

- **No facade split for `Prediction`.** A sub-namespace facade
  (`staged` / `metrics` / `cc`) was considered but dropped: the resource has
  only 7 public methods, well under the repo's ~20-method facade threshold, so
  splitting it would not earn the abstraction. The API stays flat.
- **Internal naming stays Pythonic** — camelCase Pega property names are
  translated at the (de)serialisation boundary via Pydantic aliases, not in
  field names.

## Testing

- New test files: `test_model_data.py`, `test_prediction_data.py`,
  `test_model_instance_data.py`, `test_notification_data.py`,
  `test_package_exports.py`, plus expanded `test_pagination.py` (mapping
  protocol + empty-`{}` response) and `test_base_client.py` (camelCase
  repository keys + 400-probe version detection), and a new
  `v26_1/test_model.py`.
- Full `python/tests/infinity/` + `python/tests/prediction_studio/` suite:
  **505 passed, 1 skipped** (onnx/local-model-utils excluded as usual).
- Validated end-to-end against a live Pega 26.1 instance (CDHSample): locked
  schemas, mapping protocol, predictions, notifications, and
  champion/challengers all confirmed against real data.
- `ruff check` / `ruff format` / pre-commit clean.
