### PR TITLE
feat(adm): add analysis-based agent health check

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -19,6 +19,7 @@ from ..utils.cdh_utils._io import _DATABRICKS_MODEL_SNAPSHOTS_COLUMNS
 from . import Schema
 from .trees import AGB
 from .Aggregates import Aggregates
+from .Analysis import Analysis
 from .BinAggregator import BinAggregator
 from .Plots import Plots
 from .Reports import Reports
@@ -47,6 +48,7 @@ class ADMDatamart:
     - `.plot` contains ready-made plots to analyze the data with
     - `.aggregates` contains mostly internal data aggregations queries
     - `.agb` contains analysis utilities for Adaptive Gradient Boosting models
+    - `.analysis` contains programmatic health findings and diagnostics
     - `.generate` leads to some ready-made reports, such as the Health Check
     - `.bin_aggregator` allows you to compare the bins across various models
 
@@ -101,6 +103,8 @@ class ADMDatamart:
     plot: Plots
     aggregates: Aggregates
     agb: AGB
+    analysis: Analysis
+    """Programmatic health findings accessor."""
     generate: Reports
     bin_aggregator: BinAggregator
     first_action_dates: pl.LazyFrame | None
@@ -124,6 +128,7 @@ class ADMDatamart:
         self.plot = Plots(datamart=self)
         self.aggregates = Aggregates(datamart=self)
         self.agb = AGB(datamart=self)
+        self.analysis = Analysis(datamart=self)
         self.generate = Reports(datamart=self)
 
         model_data_validated = self._validate_model_data(

--- a/python/pdstools/adm/Aggregates.py
+++ b/python/pdstools/adm/Aggregates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 __all__ = ["Aggregates"]
+import datetime
 import logging
 from typing import TYPE_CHECKING, Literal
 
@@ -26,6 +27,16 @@ class Aggregates:
 
     def __init__(self, datamart: "ADMDatamart"):
         self.datamart = datamart
+
+    @staticmethod
+    def _normalize_literal_query(query: QUERY | None) -> tuple[QUERY | None, bool | None]:
+        """Normalize literal-only queries for aggregate helper methods."""
+        if query is None:
+            return None, None
+        if query.meta.root_names():
+            return query, None
+        literal_value = pl.LazyFrame({"_": [1]}).select(query.alias("value")).collect().item()
+        return None, bool(literal_value)
 
     def last(
         self,
@@ -751,6 +762,31 @@ class Aggregates:
 
         return result
 
+    def channel_overview(
+        self,
+        *,
+        query: QUERY | None = None,
+    ) -> pl.DataFrame:
+        """Return the display-ready channel overview table."""
+        normalized_query, literal_value = self._normalize_literal_query(query)
+        overview = (
+            self.summary_by_channel(
+                query=normalized_query,
+                format_flags=True,
+            )
+            .drop(
+                [
+                    "ChannelDirectionGroup",
+                    "DateRange Min",
+                    "DateRange Max",
+                ]
+            )
+            .collect()
+        )
+        if literal_value is False:
+            return overview.head(0)
+        return overview
+
     def summary_by_configuration(
         self,
         *,
@@ -833,6 +869,34 @@ class Aggregates:
 
         return configuration_summary
 
+    def configuration_overview(
+        self,
+        *,
+        query: QUERY | None = None,
+    ) -> pl.DataFrame:
+        """Return the display-ready configuration overview table."""
+        normalized_query, literal_value = self._normalize_literal_query(query)
+        overview = (
+            self.summary_by_configuration(query=normalized_query)
+            .with_columns(
+                NBAD=pl.when(pl.col("usesNBAD").is_null())
+                .then(pl.lit("?"))
+                .when(pl.col("usesNBAD"))
+                .then(pl.lit("Yes"))
+                .otherwise(pl.lit("No")),
+                AGB=pl.when(pl.col("usesAGB").is_null())
+                .then(pl.lit("?"))
+                .when(pl.col("usesAGB"))
+                .then(pl.lit("Yes"))
+                .otherwise(pl.lit("No")),
+            )
+            .drop("usesNBAD", "usesAGB")
+            .collect()
+        )
+        if literal_value is False:
+            return overview.head(0)
+        return overview
+
     def predictors_global_overview(
         self,
         *,
@@ -890,6 +954,18 @@ class Aggregates:
             )
             .sort("PredictorName")
         )
+
+    def global_predictor_overview(
+        self,
+        *,
+        query: QUERY | None = None,
+    ) -> pl.DataFrame:
+        """Return the display-ready global predictor overview table."""
+        normalized_query, literal_value = self._normalize_literal_query(query)
+        overview = self.predictors_global_overview(query=normalized_query).collect()
+        if literal_value is False:
+            return overview.head(0)
+        return overview
 
     def predictors_overview(
         self,

--- a/python/pdstools/adm/Analysis.py
+++ b/python/pdstools/adm/Analysis.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["Analysis", "Finding"]
+__all__ = ["Analysis", "Finding", "HealthCheckPreAggregates"]
 
 import datetime
 import logging
@@ -76,6 +76,32 @@ class Finding:
         return f"{icon} [{self.category}] {self.title}"
 
 
+@dataclass
+class HealthCheckPreAggregates:
+    """Precomputed summaries reused across health-check outputs."""
+
+    last_data: pl.DataFrame
+    date_start: object | None = None
+    date_end: object | None = None
+    total_models: int | None = None
+    active_models: int | None = None
+    channel_count: int | None = None
+    configuration_count: int | None = None
+    action_count: int | None = None
+    treatment_count: int | None = None
+    response_count: int | None = None
+    positive_count: int | None = None
+    overall_avg_auc: float | None = None
+    active_avg_auc: float | None = None
+    predictor_count: int | None = None
+    channel_summary: pl.DataFrame | None = None
+    configuration_summary: pl.DataFrame | None = None
+    predictor_overview: pl.DataFrame | None = None
+    predictor_categories: pl.DataFrame | None = None
+    prediction_summary: pl.DataFrame | None = None
+    taxonomy_counts: dict[str, int] = field(default_factory=dict)
+
+
 def _gini(values: list[float]) -> float:
     """Compute the Gini coefficient for a list of non-negative values."""
     v = sorted(float(value) for value in values if not math.isnan(float(value)))
@@ -144,6 +170,175 @@ class Analysis:
     def __init__(self, datamart: "ADMDatamart") -> None:
         self.datamart = datamart
 
+    def compute_health_check_preaggregates(
+        self,
+        *,
+        active_filter: pl.Expr | None = None,
+        active_threshold_days: int = 30,
+        prediction: "Prediction | None" = None,
+        include_markdown_sections: bool = True,
+    ) -> HealthCheckPreAggregates:
+        """Compute reusable summaries for health-check generation.
+
+        Parameters
+        ----------
+        active_filter : pl.Expr, optional
+            Custom Polars expression defining which models count as active.
+            If not provided, a default filter based on ``active_threshold_days``
+            is constructed.
+        active_threshold_days : int, default 30
+            Default recency window used when ``active_filter`` is not provided.
+        prediction : Prediction, optional
+            Optional prediction data to summarize alongside ADM data.
+        include_markdown_sections : bool, default True
+            Whether to also precompute the compact tables currently used by the
+            Markdown health check (for example configuration summaries).
+
+        Returns
+        -------
+        HealthCheckPreAggregates
+            Materialized summaries that can be reused across multiple report
+            outputs within one run.
+        """
+        if active_filter is None:
+            active_filter = (
+                pl.col("LastUpdate") > (pl.col("LastUpdate").max() - datetime.timedelta(days=active_threshold_days))
+            ).fill_null(True)
+        return self._build_health_check_preaggregates(
+            active_filter=active_filter,
+            prediction=prediction,
+            include_markdown_sections=include_markdown_sections,
+        )
+
+    def _build_health_check_preaggregates(
+        self,
+        *,
+        active_filter: pl.Expr | None,
+        prediction: "Prediction | None" = None,
+        include_markdown_sections: bool = False,
+    ) -> HealthCheckPreAggregates:
+        """Precompute shared summaries reused across health-check outputs."""
+        last_data = self._get_last_data()
+        preaggregates = HealthCheckPreAggregates(last_data=last_data)
+
+        try:
+            metrics = last_data.select(
+                pl.col("ModelID").n_unique().alias("total_models"),
+                pl.col("Configuration").n_unique().alias("configuration_count"),
+                pl.sum("ResponseCount").alias("response_count"),
+                pl.sum("Positives").alias("positive_count"),
+            ).row(0, named=True)
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute health-check pre-aggregates: %s", exc)
+        else:
+            preaggregates.total_models = metrics["total_models"]
+            preaggregates.configuration_count = metrics["configuration_count"]
+            preaggregates.response_count = metrics["response_count"]
+            preaggregates.positive_count = metrics["positive_count"]
+
+        try:
+            all_columns = (
+                self.datamart.combined_data.collect_schema().names()
+                if self.datamart.predictor_data is not None
+                else self.datamart.model_data.collect_schema().names()
+            )
+            taxonomy_fields: list[tuple[str, str | list[str]]] = [
+                ("ActionCount", "Name"),
+                ("IssueCount", "Issue"),
+                ("ChannelsUsingADM", ["Channel", "Direction"]),
+            ]
+            if "Treatment" in all_columns:
+                taxonomy_fields.append(("TreatmentCount", "Treatment"))
+            preaggregates.taxonomy_counts = {
+                metric_id: report_utils.n_unique_values(self.datamart, all_columns, field_name)
+                for metric_id, field_name in taxonomy_fields
+            }
+            preaggregates.action_count = preaggregates.taxonomy_counts.get("ActionCount")
+            preaggregates.treatment_count = preaggregates.taxonomy_counts.get("TreatmentCount")
+            preaggregates.channel_count = preaggregates.taxonomy_counts.get("ChannelsUsingADM")
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute taxonomy-style pre-aggregate counts: %s", exc)
+
+        try:
+            preaggregates.overall_avg_auc = last_data.select(
+                cdh_utils.weighted_average_polars("Performance", "ResponseCount")
+            ).item()
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute overall AUC for health-check pre-aggregates: %s", exc)
+
+        try:
+            if active_filter is not None:
+                active_last_data = last_data.lazy().filter(active_filter)
+                preaggregates.active_models = active_last_data.select(pl.col("ModelID").n_unique()).collect().item()
+                preaggregates.active_avg_auc = (
+                    active_last_data.select(cdh_utils.weighted_average_polars("Performance", "ResponseCount"))
+                    .collect()
+                    .item()
+                )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute active model count for health-check pre-aggregates: %s", exc)
+
+        try:
+            date_range = (
+                self.datamart.model_data.select(
+                    pl.col("SnapshotTime").min().alias("start"),
+                    pl.col("SnapshotTime").max().alias("end"),
+                )
+                .collect()
+                .row(0, named=True)
+            )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute snapshot date range for health-check pre-aggregates: %s", exc)
+        else:
+            preaggregates.date_start = date_range["start"]
+            preaggregates.date_end = date_range["end"]
+
+        try:
+            preaggregates.channel_summary = self._health_check_channel_summary(
+                active_filter=active_filter,
+            )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute health-check channel pre-aggregates: %s", exc)
+
+        if include_markdown_sections:
+            try:
+                preaggregates.configuration_summary = self._health_check_configuration_summary(
+                    last_data=last_data,
+                    active_filter=active_filter,
+                )
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute health-check configuration pre-aggregates: %s", exc)
+
+        if self.datamart.predictor_data is not None:
+            try:
+                preaggregates.predictor_overview = self.datamart.aggregates.predictors_global_overview().collect()
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute health-check predictor pre-aggregates: %s", exc)
+            else:
+                preaggregates.predictor_count = preaggregates.predictor_overview.height
+                if include_markdown_sections:
+                    try:
+                        preaggregates.predictor_categories = (
+                            preaggregates.predictor_overview.lazy()
+                            .group_by("PredictorCategory")
+                            .agg(
+                                pl.col("PredictorName").n_unique().alias("Predictors"),
+                                pl.col("Mean").mean().alias("AvgPerformance"),
+                            )
+                            .sort("Predictors", descending=True)
+                            .collect()
+                        )
+                    except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                        logger.debug("Could not compute health-check predictor-category pre-aggregates: %s", exc)
+
+        if prediction is not None:
+            try:
+                preaggregates.prediction_summary = prediction.summary_by_channel().collect()
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute health-check prediction pre-aggregates: %s", exc)
+
+        return preaggregates
+
     # ── public API ──────────────────────────────────────────────────────
 
     def findings(
@@ -152,6 +347,7 @@ class Analysis:
         active_filter: pl.Expr | None = None,
         active_threshold_days: int = 30,
         prediction: "Prediction | None" = None,
+        preaggregates: HealthCheckPreAggregates | None = None,
     ) -> list[Finding]:
         """Run all diagnostic checks and return a list of findings.
 
@@ -178,7 +374,13 @@ class Analysis:
                 pl.col("LastUpdate") > (pl.col("LastUpdate").max() - datetime.timedelta(days=active_threshold_days))
             ).fill_null(True)
 
-        last_data = self._get_last_data()
+        preaggregates = preaggregates or self.compute_health_check_preaggregates(
+            active_filter=active_filter,
+            active_threshold_days=active_threshold_days,
+            prediction=prediction,
+            include_markdown_sections=False,
+        )
+        last_data = preaggregates.last_data
 
         results: list[Finding] = []
         dq_findings, invalid_channels = self._check_data_quality()
@@ -186,21 +388,22 @@ class Analysis:
         channel_findings, dead_channel_count, has_mature_low_perf_channel = self._check_channels(
             active_filter,
             invalid_channels=invalid_channels,
+            channel_summary=preaggregates.channel_summary,
         )
         results.extend(channel_findings)
         results.extend(self._check_configurations(last_data))
         results.extend(self._check_model_maturity(last_data))
         perf_findings, avg_auc = self._check_model_performance(last_data, active_filter)
         results.extend(perf_findings)
-        results.extend(self._check_taxonomy())
+        results.extend(self._check_taxonomy(preaggregates=preaggregates))
         results.extend(self._check_response_distribution(last_data, active_filter))
         results.extend(self._check_trends())
 
         if self.datamart.predictor_data is not None:
-            results.extend(self._check_predictors())
+            results.extend(self._check_predictors(predictor_overview=preaggregates.predictor_overview))
 
         if prediction is not None:
-            results.extend(self._check_predictions(prediction))
+            results.extend(self._check_predictions(prediction, pred_summary=preaggregates.prediction_summary))
 
         severity_order = {"critical": 0, "warning": 1, "info": 2, "success": 3}
         results.sort(key=lambda f: severity_order[f.severity])
@@ -208,7 +411,7 @@ class Analysis:
         headline = self._build_headline(
             results,
             last_data,
-            avg_auc,
+            preaggregates.overall_avg_auc,
             dead_channel_count=dead_channel_count,
             has_mature_low_perf_channel=has_mature_low_perf_channel,
         )
@@ -225,6 +428,7 @@ class Analysis:
         active_filter: pl.Expr | None = None,
         active_threshold_days: int = 30,
         prediction: "Prediction | None" = None,
+        preaggregates: HealthCheckPreAggregates | None = None,
     ) -> str:
         """Render findings as agent-friendly GitHub-flavored Markdown.
 
@@ -248,14 +452,20 @@ class Analysis:
         str
             Markdown document summarizing the findings.
         """
+        preaggregates = preaggregates or self.compute_health_check_preaggregates(
+            active_filter=active_filter,
+            active_threshold_days=active_threshold_days,
+            prediction=prediction,
+            include_markdown_sections=True,
+        )
         findings = self.findings(
             active_filter=active_filter,
             active_threshold_days=active_threshold_days,
             prediction=prediction,
+            preaggregates=preaggregates,
         )
         headline = next((finding for finding in findings if finding.category == "summary"), None)
         body_findings = [finding for finding in findings if finding.category != "summary"]
-        last_data = self._get_last_data()
 
         lines = [f"# {title}", ""]
         if subtitle:
@@ -267,10 +477,22 @@ class Analysis:
             lines.extend(["## Summary", "", f"**{headline.title}**", "", headline.detail, ""])
 
         lines.extend(
-            ["## Key Metrics", "", _markdown_table(self._key_metrics_table(last_data, findings, active_filter)), ""]
+            [
+                "## Key Metrics",
+                "",
+                _markdown_table(
+                    self._key_metrics_table(
+                        preaggregates.last_data,
+                        findings,
+                        active_filter,
+                        preaggregates=preaggregates,
+                    )
+                ),
+                "",
+            ]
         )
 
-        estate_sections = self._estate_snapshot_sections(active_filter)
+        estate_sections = self._estate_snapshot_sections(active_filter, preaggregates=preaggregates)
         if estate_sections:
             lines.extend(["## Estate Snapshot", ""])
             for section_title, section_table in estate_sections:
@@ -331,53 +553,46 @@ class Analysis:
         last_data: pl.DataFrame,
         findings: list[Finding],
         active_filter: pl.Expr | None,
+        *,
+        preaggregates: HealthCheckPreAggregates | None = None,
     ) -> pl.DataFrame:
         """Build a compact key-metrics table for markdown output."""
-        total_models = last_data.select(pl.col("ModelID").n_unique()).item()
-        active_models: int | None = None
-        try:
-            if active_filter is not None:
-                active_models = last_data.filter(active_filter).select(pl.col("ModelID").n_unique()).item()
-        except RECOVERABLE_ANALYSIS_ERRORS as exc:
-            logger.debug("Could not compute active model count for markdown metrics: %s", exc)
+        if preaggregates is None:
+            preaggregates = self._build_health_check_preaggregates(active_filter=active_filter)
 
-        date_range = self.datamart.model_data.select(
-            pl.col("SnapshotTime").min().alias("start"),
-            pl.col("SnapshotTime").max().alias("end"),
-        ).collect()
         avg_auc = next(
             (finding.data.get("avg_auc") for finding in findings if finding.category == "summary"),
             None,
         )
 
         metrics: list[tuple[str, object]] = [
-            ("Snapshot range", f"{date_range['start'].item():%Y-%m-%d} to {date_range['end'].item():%Y-%m-%d}"),
-            ("Models (latest snapshot)", total_models),
-            ("Active models", active_models),
             (
-                "Channels",
-                last_data.select(pl.concat_str(["Channel", "Direction"], separator="/").n_unique()).item(),
+                "Snapshot range",
+                (
+                    f"{preaggregates.date_start:%Y-%m-%d} to {preaggregates.date_end:%Y-%m-%d}"
+                    if preaggregates.date_start is not None and preaggregates.date_end is not None
+                    else None
+                ),
             ),
-            ("Configurations", last_data.select(pl.col("Configuration").n_unique()).item()),
-            ("Actions", last_data.select(pl.col("Name").n_unique()).item()),
+            ("Models (latest snapshot)", preaggregates.total_models),
+            ("Active models", preaggregates.active_models),
+            ("Channels", preaggregates.channel_count),
+            ("Configurations", preaggregates.configuration_count),
+            ("Actions", preaggregates.action_count),
+            ("Treatments", preaggregates.treatment_count),
+            ("Responses", preaggregates.response_count),
+            ("Positives", preaggregates.positive_count),
             (
-                "Treatments",
-                last_data.select(pl.col("Treatment").n_unique()).item() if "Treatment" in last_data.columns else None,
+                "Average AUC (latest snapshot)",
+                avg_auc * 100 if isinstance(avg_auc, float) else None,
             ),
-            ("Responses", last_data.select(pl.sum("ResponseCount")).item()),
-            ("Positives", last_data.select(pl.sum("Positives")).item()),
-            ("Average AUC (active)", avg_auc * 100 if isinstance(avg_auc, float) else None),
         ]
 
+        if isinstance(preaggregates.active_avg_auc, float):
+            metrics.append(("Average AUC (active)", preaggregates.active_avg_auc * 100))
+
         if self.datamart.predictor_data is not None:
-            try:
-                predictor_count = (
-                    self.datamart.aggregates.predictors_global_overview().select(pl.len()).collect().item()
-                )
-            except RECOVERABLE_ANALYSIS_ERRORS as exc:
-                logger.debug("Could not compute predictor count for markdown metrics: %s", exc)
-                predictor_count = None
-            metrics.append(("Predictors", predictor_count))
+            metrics.append(("Predictors", preaggregates.predictor_count))
 
         return pl.DataFrame(
             {
@@ -386,53 +601,48 @@ class Analysis:
             }
         )
 
-    def _estate_snapshot_sections(self, active_filter: pl.Expr | None) -> list[tuple[str, pl.DataFrame]]:
+    def _estate_snapshot_sections(
+        self,
+        active_filter: pl.Expr | None,
+        *,
+        preaggregates: HealthCheckPreAggregates | None = None,
+    ) -> list[tuple[str, pl.DataFrame]]:
         """Build compact orientation tables for the markdown report."""
         sections: list[tuple[str, pl.DataFrame]] = []
-
-        try:
-            channel_summary = (
-                self.datamart.aggregates.summary_by_channel(query=active_filter)
-                .select("ChannelDirection", "Responses", "Positives", "Performance", "CTR", "Actions")
-                .sort("Responses", descending=True)
-                .collect()
+        if preaggregates is None:
+            preaggregates = self._build_health_check_preaggregates(
+                active_filter=active_filter,
+                include_markdown_sections=True,
             )
-        except RECOVERABLE_ANALYSIS_ERRORS as exc:
-            logger.debug("Could not compute channel snapshot for markdown output: %s", exc)
-        else:
+
+        if preaggregates.channel_summary is not None:
+            channel_summary = preaggregates.channel_summary.select(
+                "ChannelDirection", "Responses", "Positives", "Performance", "CTR", "Actions"
+            ).sort("Responses", descending=True)
             if channel_summary.height > 0:
                 sections.append(("Top Channels by Responses", channel_summary))
 
-        try:
-            configuration_summary = (
-                self.datamart.aggregates.summary_by_configuration(query=active_filter)
-                .select("Configuration", "Channel", "Direction", "ResponseCount", "Positives", "Performance")
-                .sort("ResponseCount", descending=True)
-                .collect()
+        if preaggregates.configuration_summary is not None:
+            configuration_columns = [
+                col
+                for col in [
+                    "Configuration",
+                    "Channel",
+                    "Direction",
+                    "ResponseCount",
+                    "Positives",
+                    "Performance",
+                ]
+                if col in preaggregates.configuration_summary.columns
+            ]
+            configuration_summary = preaggregates.configuration_summary.select(configuration_columns).sort(
+                "ResponseCount", descending=True
             )
-        except RECOVERABLE_ANALYSIS_ERRORS as exc:
-            logger.debug("Could not compute configuration snapshot for markdown output: %s", exc)
-        else:
             if configuration_summary.height > 0:
                 sections.append(("Top Configurations by Responses", configuration_summary))
 
-        if self.datamart.predictor_data is not None:
-            try:
-                predictor_categories = (
-                    self.datamart.aggregates.predictors_global_overview()
-                    .group_by("PredictorCategory")
-                    .agg(
-                        pl.col("PredictorName").n_unique().alias("Predictors"),
-                        pl.col("Mean").mean().alias("AvgPerformance"),
-                    )
-                    .sort("Predictors", descending=True)
-                    .collect()
-                )
-            except RECOVERABLE_ANALYSIS_ERRORS as exc:
-                logger.debug("Could not compute predictor-category snapshot for markdown output: %s", exc)
-            else:
-                if predictor_categories.height > 0:
-                    sections.append(("Predictor Categories", predictor_categories))
+        if preaggregates.predictor_categories is not None and preaggregates.predictor_categories.height > 0:
+            sections.append(("Predictor Categories", preaggregates.predictor_categories))
 
         return sections
 
@@ -458,8 +668,26 @@ class Analysis:
     # ── private check methods ───────────────────────────────────────────
 
     def _get_last_data(self) -> pl.DataFrame:
+        last_data = self.datamart.aggregates.last()
+        keep_columns = [
+            "ModelID",
+            "Configuration",
+            "Channel",
+            "Direction",
+            "Issue",
+            "Group",
+            "Name",
+            "Treatment",
+            "ResponseCount",
+            "Positives",
+            "Performance",
+            "SuccessRate",
+            "LastUpdate",
+        ]
+        existing_columns = last_data.collect_schema().names()
+
         return (
-            self.datamart.aggregates.last()
+            last_data.select([col for col in keep_columns if col in existing_columns])
             .with_columns(pl.col(pl.Categorical).cast(pl.Utf8))
             .with_columns(
                 [
@@ -470,6 +698,103 @@ class Analysis:
                     pl.col("ResponseCount").fill_null(0),
                 ]
             )
+            .collect()
+        )
+
+    def _health_check_channel_summary(
+        self,
+        *,
+        active_filter: pl.Expr | None,
+    ) -> pl.DataFrame:
+        model_data = self.datamart._require_model_data()
+        if active_filter is not None:
+            model_data = model_data.filter(active_filter)
+
+        per_model = model_data.group_by(["Channel", "Direction", "ModelID"]).agg(
+            (pl.col("Positives").max() - pl.col("Positives").min()).alias("Positives"),
+            (pl.col("ResponseCount").max() - pl.col("ResponseCount").min()).alias("Responses"),
+            pl.col("Positives").max().alias("TotalPositives"),
+            pl.col("ResponseCount").max().alias("TotalResponseCount"),
+            pl.col("Performance").mean().alias("Performance"),
+        )
+
+        channel_metrics = per_model.group_by(["Channel", "Direction"]).agg(
+            pl.sum("Positives", "Responses", "TotalPositives", "TotalResponseCount"),
+            cdh_utils.weighted_performance_polars("Performance", "Responses").alias("Performance"),
+        )
+        channel_actions = model_data.group_by(["Channel", "Direction"]).agg(
+            pl.col("Name").n_unique().alias("Actions"),
+            pl.col("Name").unique().alias("AllActions"),
+        )
+
+        channel_summary = (
+            channel_metrics.join(
+                channel_actions,
+                on=["Channel", "Direction"],
+                nulls_equal=True,
+                how="left",
+            )
+            .with_columns(
+                CTR=pl.when(pl.col("Responses") > 0)
+                .then(pl.col("Positives") / pl.col("Responses"))
+                .otherwise(pl.lit(None)),
+                isValid=(pl.col("TotalPositives") >= 200) & (pl.col("TotalResponseCount") >= 1000),
+                ChannelDirection=pl.format("{}/{}", pl.col("Channel"), pl.col("Direction")),
+            )
+            .collect()
+        )
+
+        valid_channels = channel_summary.filter(pl.col("isValid"))
+        if valid_channels.height > 0:
+            omni = (
+                valid_channels.select("Channel", "Direction", "AllActions")
+                .with_columns(
+                    pl.col("AllActions")
+                    .map_batches(cdh_utils.overlap_lists_polars, return_dtype=pl.Float64)
+                    .alias("OmniChannel")
+                )
+                .drop("AllActions")
+            )
+            channel_summary = channel_summary.join(
+                omni,
+                on=["Channel", "Direction"],
+                nulls_equal=True,
+                how="left",
+            )
+        else:
+            channel_summary = channel_summary.with_columns(pl.lit(None).alias("OmniChannel"))
+
+        return channel_summary.select(
+            "ChannelDirection",
+            "Channel",
+            "Direction",
+            "Responses",
+            "Positives",
+            "Performance",
+            "CTR",
+            "Actions",
+            "OmniChannel",
+        )
+
+    def _health_check_configuration_summary(
+        self,
+        *,
+        last_data: pl.DataFrame,
+        active_filter: pl.Expr | None,
+    ) -> pl.DataFrame:
+        config_data = last_data.lazy()
+        if active_filter is not None:
+            config_data = config_data.filter(active_filter)
+
+        group_by_cols = ["Configuration"] + [col for col in ["Channel", "Direction"] if col in last_data.columns]
+
+        return (
+            config_data.group_by(group_by_cols)
+            .agg(
+                pl.sum("ResponseCount", "Positives"),
+                cdh_utils.weighted_average_polars("Performance", "ResponseCount").alias("Performance"),
+            )
+            .sort(group_by_cols)
             .collect()
         )
 
@@ -508,15 +833,23 @@ class Analysis:
             "success": "HEALTHY",
         }[severity]
 
+        critical_count = sum(1 for finding in results if finding.severity == "critical")
+        warning_count = sum(1 for finding in results if finding.severity == "warning")
         facts: list[str] = []
-        if pct_never_used > 10 or (severity != "success" and pct_never_used > 0):
+        if critical_count > 0:
+            noun = "critical finding" if critical_count == 1 else "critical findings"
+            facts.append(f"{critical_count} {noun}")
+        elif warning_count > 0:
+            noun = "warning" if warning_count == 1 else "warnings"
+            facts.append(f"{warning_count} {noun}")
+        if pct_never_used > 10:
             facts.append(f"{pct_never_used:.0f}% of models never used")
         if dead_channel_count >= 1:
             noun = "dead channel" if dead_channel_count == 1 else "dead channels"
             facts.append(f"{dead_channel_count} {noun}")
-        if has_mature_low_perf_channel and auc100 is not None:
-            facts.append(f"AUC {auc100:.1f} (low)")
-        elif auc100 is not None and (severity != "success" or not facts):
+        if has_mature_low_perf_channel and dead_channel_count == 0:
+            facts.append("low-performing channel present")
+        if auc100 is not None and (severity != "success" or not facts):
             facts.append(f"AUC {auc100:.1f}")
         if not facts:
             facts.append(f"{100 - pct_never_used:.0f}% of models in use")
@@ -610,6 +943,9 @@ class Analysis:
             logger.debug("Could not count models with invalid channel metadata: %s", exc)
             n_models = 0
 
+        if n_models <= 0:
+            return findings, invalid
+
         examples = ", ".join(f'"{(ch + "/" + dr) if ch or dr else "/"}"' for ch, dr in invalid_pairs[:3])
         findings.append(
             Finding(
@@ -640,16 +976,18 @@ class Analysis:
         active_filter: pl.Expr,
         *,
         invalid_channels: set[str] | None = None,
+        channel_summary: pl.DataFrame | None = None,
     ) -> tuple[list[Finding], int, bool]:
         findings: list[Finding] = []
         invalid_channels = invalid_channels or set()
         dead_channel_count = 0
         has_mature_low_perf_channel = False
-        try:
-            channel_summary = self.datamart.aggregates.summary_by_channel(query=active_filter).collect()
-        except RECOVERABLE_ANALYSIS_ERRORS as exc:
-            logger.debug("Could not compute channel summary: %s", exc)
-            return findings, dead_channel_count, has_mature_low_perf_channel
+        if channel_summary is None:
+            try:
+                channel_summary = self.datamart.aggregates.summary_by_channel(query=active_filter).collect()
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute channel summary: %s", exc)
+                return findings, dead_channel_count, has_mature_low_perf_channel
 
         # Collect dead channels into per-direction aggregate findings instead
         # of one ❌ per channel — the per-channel detail is rarely actionable
@@ -657,8 +995,14 @@ class Analysis:
         dead_by_direction: dict[str, list[str]] = {}
 
         for row in channel_summary.iter_rows(named=True):
-            ch = f"{row['Channel']}/{row['Direction']}"
-            if ch in invalid_channels:
+            channel = row.get("Channel")
+            direction = row.get("Direction")
+            ch = f"{channel}/{direction}"
+            if (
+                ch in invalid_channels
+                or self._is_invalid_channel_name(channel)
+                or self._is_invalid_channel_name(direction)
+            ):
                 continue
             responses = row.get("Responses", 0) or 0
             positives = row.get("Positives", 0) or 0
@@ -731,7 +1075,7 @@ class Analysis:
             noun = "channel has" if n == 1 else "channels have"
             findings.append(
                 Finding(
-                    severity="critical",
+                    severity="warning" if n == 1 else "critical",
                     category="channel",
                     title=(f"{n} {direction} {noun} zero responses (configured but inactive): {preview_str}"),
                     detail=(
@@ -1076,18 +1420,22 @@ class Analysis:
             Finding(
                 severity=severity,
                 category="model",
-                title=f"Overall average model performance is {label} (AUC {auc100:.1f})",
+                title=f"Average performance across active models is {label} (AUC {auc100:.1f})",
                 detail=(
                     f"Weighted average AUC across active models is {auc100:.1f}. "
                     f"Tiers: <58 low, 58-62 borderline, 62-70 healthy, ≥70 strong. {tail}"
                 ),
-                data={"weighted_avg_performance": avg_perf, "tier": label},
+                data={"active_weighted_avg_performance": avg_perf, "tier": label},
             )
         )
 
         return findings, avg_perf
 
-    def _check_taxonomy(self) -> list[Finding]:
+    def _check_taxonomy(
+        self,
+        *,
+        preaggregates: HealthCheckPreAggregates | None = None,
+    ) -> list[Finding]:
         findings: list[Finding] = []
         all_columns = (
             self.datamart.combined_data.collect_schema().names()
@@ -1096,18 +1444,41 @@ class Analysis:
         )
 
         checks = [
-            ("ActionCount", "Name", "Total actions"),
-            ("TreatmentCount", "Treatment", "Total treatments"),
-            ("IssueCount", "Issue", "Unique issues"),
-            ("ChannelsUsingADM", ["Channel", "Direction"], "Channels using ADM"),
+            (
+                "ActionCount",
+                "Name",
+                "Total actions",
+                preaggregates.taxonomy_counts.get("ActionCount") if preaggregates is not None else None,
+            ),
+            (
+                "TreatmentCount",
+                "Treatment",
+                "Total treatments",
+                preaggregates.taxonomy_counts.get("TreatmentCount") if preaggregates is not None else None,
+            ),
+            (
+                "IssueCount",
+                "Issue",
+                "Unique issues",
+                preaggregates.taxonomy_counts.get("IssueCount") if preaggregates is not None else None,
+            ),
+            (
+                "ChannelsUsingADM",
+                ["Channel", "Direction"],
+                "Channels using ADM",
+                preaggregates.taxonomy_counts.get("ChannelsUsingADM") if preaggregates is not None else None,
+            ),
         ]
 
-        for metric_id, field_name, label in checks:
-            try:
-                value = report_utils.n_unique_values(self.datamart, all_columns, field_name)
-            except RECOVERABLE_ANALYSIS_ERRORS as exc:
-                logger.debug("Could not compute taxonomy metric %s: %s", metric_id, exc)
-                continue
+        for metric_id, field_name, label, precomputed_value in checks:
+            if precomputed_value is not None:
+                value = precomputed_value
+            else:
+                try:
+                    value = report_utils.n_unique_values(self.datamart, all_columns, field_name)
+                except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                    logger.debug("Could not compute taxonomy metric %s: %s", metric_id, exc)
+                    continue
 
             rag = MetricLimits.evaluate_metric_rag(metric_id, value)
             if rag not in ("RED", "AMBER"):
@@ -1412,13 +1783,18 @@ class Analysis:
 
         return findings
 
-    def _check_predictors(self) -> list[Finding]:
+    def _check_predictors(self, *, predictor_overview: pl.DataFrame | None = None) -> list[Finding]:
         findings: list[Finding] = []
         min_perf = MetricLimits.minimum("ModelPerformance")
 
         # Poor predictors
-        try:
-            predictor_overview = self.datamart.aggregates.predictors_global_overview().collect()
+        if predictor_overview is None:
+            try:
+                predictor_overview = self.datamart.aggregates.predictors_global_overview().collect()
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute predictor performance overview: %s", exc)
+                predictor_overview = None
+        if predictor_overview is not None:
             poor_count = predictor_overview.filter(pl.col("Mean") < (min_perf * 100)).height
             total_predictors = predictor_overview.height
 
@@ -1446,8 +1822,6 @@ class Analysis:
                         },
                     )
                 )
-        except RECOVERABLE_ANALYSIS_ERRORS as exc:
-            logger.debug("Could not compute predictor performance overview: %s", exc)
 
         # Missing predictor data
         try:
@@ -1544,14 +1918,20 @@ class Analysis:
 
         return findings
 
-    def _check_predictions(self, prediction: "Prediction") -> list[Finding]:
+    def _check_predictions(
+        self,
+        prediction: "Prediction",
+        *,
+        pred_summary: pl.DataFrame | None = None,
+    ) -> list[Finding]:
         findings: list[Finding] = []
 
-        try:
-            pred_summary = prediction.summary_by_channel().collect()
-        except RECOVERABLE_ANALYSIS_ERRORS as exc:
-            logger.debug("Could not summarize prediction data by channel: %s", exc)
-            return findings
+        if pred_summary is None:
+            try:
+                pred_summary = prediction.summary_by_channel().collect()
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not summarize prediction data by channel: %s", exc)
+                return findings
 
         if "Lift" not in pred_summary.columns:
             return findings

--- a/python/pdstools/adm/Analysis.py
+++ b/python/pdstools/adm/Analysis.py
@@ -1,0 +1,1641 @@
+"""Programmatic ADM health findings built on top of ``ADMDatamart``."""
+
+from __future__ import annotations
+
+__all__ = ["Analysis", "Finding"]
+
+import datetime
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+import polars as pl
+
+from ..utils import cdh_utils, report_utils
+from ..utils.metric_limits import MetricLimits
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..adm.ADMDatamart import ADMDatamart
+    from ..prediction import Prediction
+
+logger = logging.getLogger(__name__)
+RECOVERABLE_ANALYSIS_ERRORS = (
+    pl.exceptions.PolarsError,
+    AttributeError,
+    KeyError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
+
+Severity = Literal["critical", "warning", "info", "success"]
+Category = Literal[
+    "channel",
+    "model",
+    "predictor",
+    "prediction",
+    "taxonomy",
+    "response_distribution",
+    "trend",
+    "configuration",
+    "data_quality",
+    "summary",
+]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single diagnostic finding from ADM health analysis.
+
+    Parameters
+    ----------
+    severity : Severity
+        One of "critical", "warning", or "info".
+    category : Category
+        The area of the analysis this finding relates to.
+    title : str
+        A short, one-line summary of the finding.
+    detail : str
+        A longer explanation with context and recommended action.
+    data : dict
+        Structured data for programmatic consumption.
+    """
+
+    severity: Severity
+    category: Category
+    title: str
+    detail: str
+    data: dict = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        if self.category == "summary":
+            icon = "🩺"
+        else:
+            icon = {"critical": "❌", "warning": "⚠️", "info": "ℹ️", "success": "✅"}[self.severity]
+        return f"{icon} [{self.category}] {self.title}"
+
+
+def _gini(values: list[float]) -> float:
+    """Compute the Gini coefficient for a list of non-negative values."""
+    v = sorted(float(value) for value in values if not math.isnan(float(value)))
+    n = len(v)
+    total = sum(v)
+    if n == 0 or total == 0:
+        return 0.0
+    weighted_sum = sum((index + 1) * value for index, value in enumerate(v))
+    return float((2 * weighted_sum - (n + 1) * total) / (n * total))
+
+
+def _format_markdown_value(value: object) -> str:
+    """Format a finding payload value for markdown output."""
+    if value is None:
+        return "N/A"
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return "N/A"
+        if value == 0:
+            return "0"
+        if abs(value) >= 1000:
+            return f"{value:,.0f}"
+        if abs(value) >= 1:
+            return f"{value:,.2f}"
+        return f"{value:.4f}"
+    if isinstance(value, list):
+        preview = ", ".join(_format_markdown_value(item) for item in value[:5])
+        if len(value) > 5:
+            preview += f" (+{len(value) - 5} more)"
+        return preview
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _markdown_table(df: pl.DataFrame, *, max_rows: int | None = None) -> str:
+    """Render a small Polars DataFrame as GitHub-flavored Markdown."""
+    if df.height == 0:
+        return "*No data available.*"
+
+    truncated = max_rows is not None and df.height > max_rows
+    table_df = df.head(max_rows) if truncated else df
+    header = "| " + " | ".join(table_df.columns) + " |"
+    separator = "| " + " | ".join("---" for _ in table_df.columns) + " |"
+    rows = ["| " + " | ".join(_format_markdown_value(value) for value in row) + " |" for row in table_df.iter_rows()]
+    markdown = "\n".join([header, separator, *rows])
+    if truncated:
+        markdown += f"\n\n*And {df.height - max_rows} more rows.*"
+    return markdown
+
+
+class Analysis:
+    """Automated diagnostic analysis for ADM model data.
+
+    Accessed as ``datamart.analysis``. Provides programmatic health findings
+    that would otherwise require a human to scan through charts and tables.
+
+    Examples
+    --------
+    >>> from pdstools import datasets
+    >>> dm = datasets.cdh_sample()
+    >>> for f in dm.analysis.findings():
+    ...     print(f)
+    """
+
+    def __init__(self, datamart: "ADMDatamart") -> None:
+        self.datamart = datamart
+
+    # ── public API ──────────────────────────────────────────────────────
+
+    def findings(
+        self,
+        *,
+        active_filter: pl.Expr | None = None,
+        active_threshold_days: int = 30,
+        prediction: "Prediction | None" = None,
+    ) -> list[Finding]:
+        """Run all diagnostic checks and return a list of findings.
+
+        Parameters
+        ----------
+        active_filter : pl.Expr, optional
+            A Polars expression that filters to "active" models.
+            If not provided, a default filter based on
+            ``active_threshold_days`` is constructed.
+        active_threshold_days : int, default 30
+            If ``active_filter`` is not given, models not updated in this
+            many days are considered inactive.
+        prediction : Prediction, optional
+            A :class:`~pdstools.prediction.Prediction` instance. If
+            provided, prediction-level findings are included.
+
+        Returns
+        -------
+        list[Finding]
+            Sorted by severity (critical first, then warning, then info).
+        """
+        if active_filter is None:
+            active_filter = (
+                pl.col("LastUpdate") > (pl.col("LastUpdate").max() - datetime.timedelta(days=active_threshold_days))
+            ).fill_null(True)
+
+        last_data = self._get_last_data()
+
+        results: list[Finding] = []
+        dq_findings, invalid_channels = self._check_data_quality()
+        results.extend(dq_findings)
+        channel_findings, dead_channel_count, has_mature_low_perf_channel = self._check_channels(
+            active_filter,
+            invalid_channels=invalid_channels,
+        )
+        results.extend(channel_findings)
+        results.extend(self._check_configurations(last_data))
+        results.extend(self._check_model_maturity(last_data))
+        perf_findings, avg_auc = self._check_model_performance(last_data, active_filter)
+        results.extend(perf_findings)
+        results.extend(self._check_taxonomy())
+        results.extend(self._check_response_distribution(last_data, active_filter))
+        results.extend(self._check_trends())
+
+        if self.datamart.predictor_data is not None:
+            results.extend(self._check_predictors())
+
+        if prediction is not None:
+            results.extend(self._check_predictions(prediction))
+
+        severity_order = {"critical": 0, "warning": 1, "info": 2, "success": 3}
+        results.sort(key=lambda f: severity_order[f.severity])
+
+        headline = self._build_headline(
+            results,
+            last_data,
+            avg_auc,
+            dead_channel_count=dead_channel_count,
+            has_mature_low_perf_channel=has_mature_low_perf_channel,
+        )
+        if headline is not None:
+            results.insert(0, headline)
+        return results
+
+    def markdown(
+        self,
+        *,
+        title: str = "ADM Health Check",
+        subtitle: str = "",
+        disclaimer: str = "",
+        active_filter: pl.Expr | None = None,
+        active_threshold_days: int = 30,
+        prediction: "Prediction | None" = None,
+    ) -> str:
+        """Render findings as agent-friendly GitHub-flavored Markdown.
+
+        Parameters
+        ----------
+        title : str, default "ADM Health Check"
+            Report title shown at the top of the markdown document.
+        subtitle : str, default ""
+            Optional subtitle shown below the title.
+        disclaimer : str, default ""
+            Optional disclaimer shown as a blockquote near the top.
+        active_filter : pl.Expr, optional
+            Custom Polars expression defining which models count as active.
+        active_threshold_days : int, default 30
+            Default recency window used when ``active_filter`` is not provided.
+        prediction : Prediction, optional
+            Optional prediction data for prediction-level findings.
+
+        Returns
+        -------
+        str
+            Markdown document summarizing the findings.
+        """
+        findings = self.findings(
+            active_filter=active_filter,
+            active_threshold_days=active_threshold_days,
+            prediction=prediction,
+        )
+        headline = next((finding for finding in findings if finding.category == "summary"), None)
+        body_findings = [finding for finding in findings if finding.category != "summary"]
+        last_data = self._get_last_data()
+
+        lines = [f"# {title}", ""]
+        if subtitle:
+            lines.extend([f"## {subtitle}", ""])
+        if disclaimer:
+            lines.extend([f"> **Disclaimer:** {disclaimer}", ""])
+
+        if headline is not None:
+            lines.extend(["## Summary", "", f"**{headline.title}**", "", headline.detail, ""])
+
+        lines.extend(
+            ["## Key Metrics", "", _markdown_table(self._key_metrics_table(last_data, findings, active_filter)), ""]
+        )
+
+        estate_sections = self._estate_snapshot_sections(active_filter)
+        if estate_sections:
+            lines.extend(["## Estate Snapshot", ""])
+            for section_title, section_table in estate_sections:
+                lines.extend([f"### {section_title}", "", _markdown_table(section_table, max_rows=5), ""])
+
+        lines.extend(["## Findings Overview", ""])
+        lines.extend(
+            ["### Findings by Severity", "", _markdown_table(self._findings_by_severity_table(body_findings)), ""]
+        )
+        lines.extend(
+            [
+                "### Findings by Category",
+                "",
+                _markdown_table(self._findings_by_category_table(body_findings), max_rows=10),
+                "",
+            ]
+        )
+
+        if not body_findings:
+            lines.extend(["## Findings", "", "No findings were generated.", ""])
+            return "\n".join(lines).strip() + "\n"
+
+        severity_order: list[Severity] = ["critical", "warning", "info", "success"]
+        section_titles = {
+            "critical": "Critical Findings",
+            "warning": "Warning Findings",
+            "info": "Informational Findings",
+            "success": "Positive Findings",
+        }
+
+        for severity in severity_order:
+            section_findings = [finding for finding in body_findings if finding.severity == severity]
+            if not section_findings:
+                continue
+            lines.extend([f"## {section_titles[severity]}", ""])
+            for finding in section_findings:
+                lines.extend(
+                    [
+                        f"### {finding.title}",
+                        "",
+                        f"- **Category:** `{finding.category}`",
+                        f"- **Severity:** `{finding.severity}`",
+                        "",
+                        finding.detail,
+                    ]
+                )
+                if finding.data:
+                    lines.append("")
+                    lines.append("Supporting data:")
+                    for key, value in finding.data.items():
+                        lines.append(f"- **{key}**: {_format_markdown_value(value)}")
+                lines.append("")
+
+        return "\n".join(lines).strip() + "\n"
+
+    def _key_metrics_table(
+        self,
+        last_data: pl.DataFrame,
+        findings: list[Finding],
+        active_filter: pl.Expr | None,
+    ) -> pl.DataFrame:
+        """Build a compact key-metrics table for markdown output."""
+        total_models = last_data.select(pl.col("ModelID").n_unique()).item()
+        active_models: int | None = None
+        try:
+            if active_filter is not None:
+                active_models = last_data.filter(active_filter).select(pl.col("ModelID").n_unique()).item()
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute active model count for markdown metrics: %s", exc)
+
+        date_range = self.datamart.model_data.select(
+            pl.col("SnapshotTime").min().alias("start"),
+            pl.col("SnapshotTime").max().alias("end"),
+        ).collect()
+        avg_auc = next(
+            (finding.data.get("avg_auc") for finding in findings if finding.category == "summary"),
+            None,
+        )
+
+        metrics: list[tuple[str, object]] = [
+            ("Snapshot range", f"{date_range['start'].item():%Y-%m-%d} to {date_range['end'].item():%Y-%m-%d}"),
+            ("Models (latest snapshot)", total_models),
+            ("Active models", active_models),
+            (
+                "Channels",
+                last_data.select(pl.concat_str(["Channel", "Direction"], separator="/").n_unique()).item(),
+            ),
+            ("Configurations", last_data.select(pl.col("Configuration").n_unique()).item()),
+            ("Actions", last_data.select(pl.col("Name").n_unique()).item()),
+            (
+                "Treatments",
+                last_data.select(pl.col("Treatment").n_unique()).item() if "Treatment" in last_data.columns else None,
+            ),
+            ("Responses", last_data.select(pl.sum("ResponseCount")).item()),
+            ("Positives", last_data.select(pl.sum("Positives")).item()),
+            ("Average AUC (active)", avg_auc * 100 if isinstance(avg_auc, float) else None),
+        ]
+
+        if self.datamart.predictor_data is not None:
+            try:
+                predictor_count = (
+                    self.datamart.aggregates.predictors_global_overview().select(pl.len()).collect().item()
+                )
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute predictor count for markdown metrics: %s", exc)
+                predictor_count = None
+            metrics.append(("Predictors", predictor_count))
+
+        return pl.DataFrame(
+            {
+                "Metric": [metric for metric, _ in metrics],
+                "Value": [_format_markdown_value(value) for _, value in metrics],
+            }
+        )
+
+    def _estate_snapshot_sections(self, active_filter: pl.Expr | None) -> list[tuple[str, pl.DataFrame]]:
+        """Build compact orientation tables for the markdown report."""
+        sections: list[tuple[str, pl.DataFrame]] = []
+
+        try:
+            channel_summary = (
+                self.datamart.aggregates.summary_by_channel(query=active_filter)
+                .select("ChannelDirection", "Responses", "Positives", "Performance", "CTR", "Actions")
+                .sort("Responses", descending=True)
+                .collect()
+            )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute channel snapshot for markdown output: %s", exc)
+        else:
+            if channel_summary.height > 0:
+                sections.append(("Top Channels by Responses", channel_summary))
+
+        try:
+            configuration_summary = (
+                self.datamart.aggregates.summary_by_configuration(query=active_filter)
+                .select("Configuration", "Channel", "Direction", "ResponseCount", "Positives", "Performance")
+                .sort("ResponseCount", descending=True)
+                .collect()
+            )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute configuration snapshot for markdown output: %s", exc)
+        else:
+            if configuration_summary.height > 0:
+                sections.append(("Top Configurations by Responses", configuration_summary))
+
+        if self.datamart.predictor_data is not None:
+            try:
+                predictor_categories = (
+                    self.datamart.aggregates.predictors_global_overview()
+                    .group_by("PredictorCategory")
+                    .agg(
+                        pl.col("PredictorName").n_unique().alias("Predictors"),
+                        pl.col("Mean").mean().alias("AvgPerformance"),
+                    )
+                    .sort("Predictors", descending=True)
+                    .collect()
+                )
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute predictor-category snapshot for markdown output: %s", exc)
+            else:
+                if predictor_categories.height > 0:
+                    sections.append(("Predictor Categories", predictor_categories))
+
+        return sections
+
+    @staticmethod
+    def _findings_by_severity_table(findings: list[Finding]) -> pl.DataFrame:
+        """Summarize findings by severity."""
+        severity_order = {"critical": 0, "warning": 1, "info": 2, "success": 3}
+        counts: dict[str, int] = {}
+        for finding in findings:
+            counts[finding.severity] = counts.get(finding.severity, 0) + 1
+        rows = sorted(counts.items(), key=lambda item: severity_order[item[0]])
+        return pl.DataFrame({"Severity": [severity for severity, _ in rows], "Count": [count for _, count in rows]})
+
+    @staticmethod
+    def _findings_by_category_table(findings: list[Finding]) -> pl.DataFrame:
+        """Summarize findings by category."""
+        counts: dict[str, int] = {}
+        for finding in findings:
+            counts[finding.category] = counts.get(finding.category, 0) + 1
+        rows = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        return pl.DataFrame({"Category": [category for category, _ in rows], "Count": [count for _, count in rows]})
+
+    # ── private check methods ───────────────────────────────────────────
+
+    def _get_last_data(self) -> pl.DataFrame:
+        return (
+            self.datamart.aggregates.last()
+            .with_columns(pl.col(pl.Categorical).cast(pl.Utf8))
+            .with_columns(
+                [
+                    pl.col(pl.Utf8).fill_null("NA"),
+                    pl.col(pl.Null).fill_null("NA"),
+                    pl.col("SuccessRate").fill_nan(0).fill_null(0),
+                    pl.col("Performance").fill_nan(0).fill_null(0),
+                    pl.col("ResponseCount").fill_null(0),
+                ]
+            )
+            .collect()
+        )
+
+    def _build_headline(
+        self,
+        results: list[Finding],
+        last_data: pl.DataFrame,
+        avg_auc: float | None,
+        *,
+        dead_channel_count: int,
+        has_mature_low_perf_channel: bool,
+    ) -> Finding | None:
+        """Compose a single one-line summary finding from underlying check output."""
+        total = last_data.height
+        if total == 0:
+            return None
+
+        # Pull the underlying numbers we need straight from the data so we
+        # don't depend on whether a particular check fired.
+        never_used = last_data.filter(pl.col("ResponseCount") == 0).height
+        pct_never_used = never_used / total * 100
+
+        auc100 = avg_auc * 100 if avg_auc is not None else None
+
+        severity_order = {"critical": 0, "warning": 1, "info": 2, "success": 3}
+        highest_severity = min(
+            (f.severity for f in results),
+            key=lambda severity: severity_order[severity],
+            default="success",
+        )
+        severity: Severity = highest_severity
+        verdict = {
+            "critical": "NEEDS ATTENTION",
+            "warning": "MIXED",
+            "info": "HEALTHY",
+            "success": "HEALTHY",
+        }[severity]
+
+        facts: list[str] = []
+        if pct_never_used > 10 or (severity != "success" and pct_never_used > 0):
+            facts.append(f"{pct_never_used:.0f}% of models never used")
+        if dead_channel_count >= 1:
+            noun = "dead channel" if dead_channel_count == 1 else "dead channels"
+            facts.append(f"{dead_channel_count} {noun}")
+        if has_mature_low_perf_channel and auc100 is not None:
+            facts.append(f"AUC {auc100:.1f} (low)")
+        elif auc100 is not None and (severity != "success" or not facts):
+            facts.append(f"AUC {auc100:.1f}")
+        if not facts:
+            facts.append(f"{100 - pct_never_used:.0f}% of models in use")
+
+        # Cap at 3 facts to keep the headline scannable.
+        facts = facts[:3]
+        body = ", ".join(facts) if facts else "no issues detected"
+        return Finding(
+            severity=severity,
+            category="summary",
+            title=f"Health: {verdict} — {body}",
+            detail=(
+                "Headline derived from the rest of the findings. Open the full list below for the per-area detail."
+            ),
+            data={
+                "verdict": verdict,
+                "pct_never_used": pct_never_used,
+                "dead_channel_count": dead_channel_count,
+                "has_mature_low_perf_channel": has_mature_low_perf_channel,
+                "avg_auc": avg_auc,
+                "facts": facts,
+            },
+        )
+
+    @staticmethod
+    def _is_invalid_channel_name(value: str | None) -> bool:
+        """Return True if a Channel/Direction value looks like missing metadata."""
+        if value is None:
+            return True
+        s = str(value).strip()
+        if not s or s == "/":
+            return True
+        # Catch values like "/Inbound" or "Web/" that come from concatenating
+        # an empty Channel with a Direction in upstream summaries.
+        if s.startswith("/") or s.endswith("/"):
+            return True
+        return False
+
+    def _check_data_quality(self) -> tuple[list[Finding], set[str]]:
+        """Detect malformed Channel/Direction values.
+
+        Returns
+        -------
+        list[Finding]
+            One ``data_quality`` finding if invalid values exist, else empty.
+        set[str]
+            Set of ``"Channel/Direction"`` strings considered invalid; callers
+            should exclude these from downstream channel-level findings to
+            avoid duplicating noise.
+        """
+        findings: list[Finding] = []
+        invalid: set[str] = set()
+        try:
+            rows = self.datamart.model_data.select(["Channel", "Direction"]).unique().collect()
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not collect channel/direction values: %s", exc)
+            return findings, invalid
+
+        invalid_pairs: list[tuple[str, str]] = []
+        for row in rows.iter_rows(named=True):
+            ch = row.get("Channel")
+            dr = row.get("Direction")
+            if self._is_invalid_channel_name(ch) or self._is_invalid_channel_name(dr):
+                ch_str = "" if ch is None else str(ch)
+                dr_str = "" if dr is None else str(dr)
+                invalid.add(f"{ch_str}/{dr_str}")
+                invalid_pairs.append((ch_str, dr_str))
+
+        if not invalid_pairs:
+            return findings, invalid
+
+        try:
+            invalid_df = pl.DataFrame(
+                {
+                    "Channel": [p[0] for p in invalid_pairs],
+                    "Direction": [p[1] for p in invalid_pairs],
+                }
+            )
+            n_models = (
+                self.datamart.model_data.select(
+                    pl.col("ModelID"),
+                    pl.col("Channel").cast(pl.Utf8),
+                    pl.col("Direction").cast(pl.Utf8),
+                )
+                .join(invalid_df.lazy(), on=["Channel", "Direction"], how="inner", nulls_equal=True)
+                .select(pl.col("ModelID").n_unique())
+                .collect()
+                .item()
+            )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not count models with invalid channel metadata: %s", exc)
+            n_models = 0
+
+        examples = ", ".join(f'"{(ch + "/" + dr) if ch or dr else "/"}"' for ch, dr in invalid_pairs[:3])
+        findings.append(
+            Finding(
+                severity="critical",
+                category="data_quality",
+                title=(
+                    f"{n_models:,} models have invalid Channel/Direction values "
+                    f"(e.g. {examples}) — likely missing channel metadata"
+                ),
+                detail=(
+                    "Some models have Channel or Direction set to an empty "
+                    "string, '/', or another malformed value. This usually "
+                    "means the channel was not populated when the model was "
+                    "created. Fix the upstream metadata or filter these "
+                    "models before reporting."
+                ),
+                data={
+                    "model_count": n_models,
+                    "invalid_count": len(invalid_pairs),
+                    "examples": [f"{ch}/{dr}" for ch, dr in invalid_pairs[:10]],
+                },
+            )
+        )
+        return findings, invalid
+
+    def _check_channels(
+        self,
+        active_filter: pl.Expr,
+        *,
+        invalid_channels: set[str] | None = None,
+    ) -> tuple[list[Finding], int, bool]:
+        findings: list[Finding] = []
+        invalid_channels = invalid_channels or set()
+        dead_channel_count = 0
+        has_mature_low_perf_channel = False
+        try:
+            channel_summary = self.datamart.aggregates.summary_by_channel(query=active_filter).collect()
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute channel summary: %s", exc)
+            return findings, dead_channel_count, has_mature_low_perf_channel
+
+        # Collect dead channels into per-direction aggregate findings instead
+        # of one ❌ per channel — the per-channel detail is rarely actionable
+        # and dwarfs everything else in the output.
+        dead_by_direction: dict[str, list[str]] = {}
+
+        for row in channel_summary.iter_rows(named=True):
+            ch = f"{row['Channel']}/{row['Direction']}"
+            if ch in invalid_channels:
+                continue
+            responses = row.get("Responses", 0) or 0
+            positives = row.get("Positives", 0) or 0
+            perf = row.get("Performance")
+            omni = row.get("OmniChannel")
+
+            if responses == 0:
+                direction = row.get("Direction") or "Unknown"
+                dead_by_direction.setdefault(direction, []).append(ch)
+                continue
+
+            if positives == 0:
+                findings.append(
+                    Finding(
+                        severity="critical",
+                        category="channel",
+                        title=f'Channel "{ch}" has zero positives',
+                        detail=(
+                            f"Channel has {responses:,} responses but no positive "
+                            "outcomes. Check that the response loop is correctly "
+                            "configured and outcome labels match the model setup."
+                        ),
+                        data={"channel": ch, "responses": responses, "positives": 0},
+                    )
+                )
+
+            if perf is not None and positives > 0:
+                perf_rate = perf / 100 if perf > 1 else perf
+                rag = MetricLimits.evaluate_metric_rag("ModelPerformance", perf_rate)
+                if rag == "RED":
+                    has_mature_low_perf_channel = True
+                    findings.append(
+                        Finding(
+                            severity="warning",
+                            category="channel",
+                            title=f'Channel "{ch}" has very low average performance (AUC {perf:.1f})',
+                            detail=(
+                                "The weighted average model performance for this "
+                                "channel is below the minimum threshold. Consider "
+                                "reviewing predictor availability and data quality."
+                            ),
+                            data={"channel": ch, "performance": perf_rate, "mature_low_perf": True},
+                        )
+                    )
+
+            if omni is not None and omni < 0.2 and positives > 0:
+                findings.append(
+                    Finding(
+                        severity="info",
+                        category="channel",
+                        title=f'Channel "{ch}" has low cross-channel overlap ({omni:.0%})',
+                        detail=(
+                            "This channel shares few actions with other channels. "
+                            "If an omni-channel strategy is intended, consider "
+                            "aligning actions across channels."
+                        ),
+                        data={"channel": ch, "omni_channel_pct": omni},
+                    )
+                )
+
+        # Emit one collapsed dead-channel finding per direction.
+        for direction in sorted(dead_by_direction):
+            channels = sorted(dead_by_direction[direction])
+            n = len(channels)
+            dead_channel_count += n
+            preview = channels[:5]
+            preview_str = ", ".join(preview)
+            if n > len(preview):
+                preview_str += f" (+{n - len(preview)} more)"
+            noun = "channel has" if n == 1 else "channels have"
+            findings.append(
+                Finding(
+                    severity="critical",
+                    category="channel",
+                    title=(f"{n} {direction} {noun} zero responses (configured but inactive): {preview_str}"),
+                    detail=(
+                        "Models exist for these channels but have never received "
+                        "any responses. Either the channel is not active or the "
+                        "decisioning integration is not triggering ADM models."
+                    ),
+                    data={
+                        "direction": direction,
+                        "dead_channel_count": n,
+                        "channels": channels,
+                    },
+                )
+            )
+
+        return findings, dead_channel_count, has_mature_low_perf_channel
+
+    def _check_configurations(self, last_data: pl.DataFrame) -> list[Finding]:
+        findings: list[Finding] = []
+
+        # Pre-compute the dominant Channel/Direction per Configuration so we
+        # can give callers a quick hint of which channel a problematic
+        # configuration belongs to. We pick the (Channel, Direction) pair
+        # with the highest model count, breaking ties on response volume.
+        try:
+            dominant = (
+                last_data.group_by(["Configuration", "Channel", "Direction"])
+                .agg(
+                    pl.len().alias("_n_models"),
+                    pl.sum("ResponseCount").alias("_resp"),
+                )
+                .sort(["Configuration", "_n_models", "_resp"], descending=[False, True, True])
+                .group_by("Configuration", maintain_order=True)
+                .agg(pl.first("Channel"), pl.first("Direction"))
+            )
+            dominant_map = {
+                row["Configuration"]: (row["Channel"], row["Direction"]) for row in dominant.iter_rows(named=True)
+            }
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute dominant channel per configuration: %s", exc)
+            dominant_map = {}
+
+        for config in last_data["Configuration"].unique().sort():
+            config_str = str(config)
+            config_lower = config_str.lower()
+            if any(
+                x in config_lower
+                for x in [
+                    "default_inbound",
+                    "default_outbound",
+                    "default_model",
+                ]
+            ):
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        category="configuration",
+                        title=f'Default configuration name: "{config_str}"',
+                        detail=(
+                            "Using default model configuration names is not "
+                            "recommended. Rename to a channel-specific name for "
+                            "clarity and to avoid unintended model sharing."
+                        ),
+                        data={"configuration": config_str},
+                    )
+                )
+
+            config_data = last_data.filter(pl.col("Configuration") == config_str)
+            total_responses = config_data.select(pl.sum("ResponseCount")).item() or 0
+            total_positives = config_data.select(pl.sum("Positives")).item() or 0
+
+            if total_responses > 0 and total_positives == 0:
+                ch_dr = dominant_map.get(config_str)
+                ch_hint = f" ({ch_dr[0]}/{ch_dr[1]})" if ch_dr else ""
+                findings.append(
+                    Finding(
+                        severity="critical",
+                        category="configuration",
+                        title=f'Configuration "{config_str}"{ch_hint} has no positives',
+                        detail=(
+                            f"Configuration has {total_responses:,} responses but "
+                            "zero positive outcomes. Check the outcome label "
+                            "configuration and response loop."
+                        ),
+                        data={
+                            "configuration": config_str,
+                            "responses": total_responses,
+                            "positives": 0,
+                            "channel": ch_dr[0] if ch_dr else None,
+                            "direction": ch_dr[1] if ch_dr else None,
+                        },
+                    )
+                )
+
+        return findings
+
+    def _check_model_maturity(self, last_data: pl.DataFrame) -> list[Finding]:
+        findings: list[Finding] = []
+        total = last_data.height
+        if total == 0:
+            return findings
+
+        bp_min_positives = MetricLimits.best_practice_min("TotalPositiveCount")
+        min_perf_floor = MetricLimits.minimum("ModelPerformance")
+        bp_min_perf = MetricLimits.best_practice_min("ModelPerformance")
+        # "Decent" performance means meeting the best-practice threshold
+        # (e.g. 0.55), not merely clearing the hard minimum (e.g. 0.52).
+        # The low-performance warning below uses the same boundary so the
+        # two cohorts are mutually exclusive and jointly cover all mature
+        # models — no silent gap, no synthetic bucket.
+
+        # Unused models
+        bp_max_unused = MetricLimits.best_practice_max("ModelsWithoutResponsesPercentage")
+        unused = last_data.filter(pl.col("ResponseCount") == 0).height
+        if unused > 0:
+            pct = unused / total * 100
+            warn_threshold_pct = (bp_max_unused or 0.2) * 100
+            findings.append(
+                Finding(
+                    severity="warning" if pct > warn_threshold_pct else "info",
+                    category="model",
+                    title=f"{unused:,} models ({pct:.0f}%) have never been used",
+                    detail=(
+                        "These models have zero responses — they exist but were "
+                        "never selected in decisioning. This is common for actions "
+                        "that were only tested or never activated."
+                    ),
+                    data={"count": unused, "total": total, "percentage": pct, "bucket": "never_used"},
+                )
+            )
+
+        # Models with responses but no positives
+        no_positives = last_data.filter((pl.col("ResponseCount") > 0) & (pl.col("Positives") == 0)).height
+        if no_positives > 0:
+            pct = no_positives / total * 100
+            findings.append(
+                Finding(
+                    severity="warning" if pct > 10 else "info",
+                    category="model",
+                    title=f"{no_positives:,} models ({pct:.0f}%) have responses but zero positives",
+                    detail=(
+                        "These models have been used in decisions but never received "
+                        "a positive response. This could indicate unattractive "
+                        "propositions or a broken response loop."
+                    ),
+                    data={
+                        "count": no_positives,
+                        "total": total,
+                        "percentage": pct,
+                        "bucket": "responses_no_positives",
+                    },
+                )
+            )
+
+        # Immature models — Positives in [1, bp_min) (mutually exclusive
+        # with the never-used and zero-positives buckets above).
+        if bp_min_positives is not None:
+            immature = last_data.filter((pl.col("Positives") > 0) & (pl.col("Positives") < bp_min_positives)).height
+            if immature > 0:
+                pct = immature / total * 100
+                findings.append(
+                    Finding(
+                        severity="info",
+                        category="model",
+                        title=f"{immature:,} models ({pct:.0f}%) are still immature (positives < {int(bp_min_positives)})",
+                        detail=(
+                            "These models are learning but have not yet received "
+                            "enough positive responses to be considered mature. "
+                            "This is normal for recently introduced actions."
+                        ),
+                        data={
+                            "count": immature,
+                            "total": total,
+                            "percentage": pct,
+                            "threshold": bp_min_positives,
+                            "bucket": "immature",
+                        },
+                    )
+                )
+
+        # Stuck at AUC=50
+        if bp_min_positives is not None:
+            stuck = last_data.filter((pl.col("Performance") == 0.5) & (pl.col("Positives") >= bp_min_positives)).height
+            if stuck > 0:
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        category="model",
+                        title=f"{stuck:,} models stuck at minimum performance (AUC=50) despite sufficient data",
+                        detail=(
+                            f"These models have ≥{int(bp_min_positives)} positives "
+                            "but model performance has not moved from the initial "
+                            "value. This may indicate data quality issues, lack of "
+                            "predictor variation, or technical problems."
+                        ),
+                        data={
+                            "count": stuck,
+                            "total": total,
+                            "threshold_positives": bp_min_positives,
+                        },
+                    )
+                )
+
+        # Low performance — anything below best practice (excluding the
+        # stuck-at-0.5 cohort, which gets its own finding above).
+        if bp_min_perf is not None and bp_min_positives is not None:
+            low_perf = last_data.filter(
+                (pl.col("Performance") > min_perf_floor)
+                & (pl.col("Performance") < bp_min_perf)
+                & (pl.col("Positives") >= bp_min_positives)
+            ).height
+            if low_perf > 0:
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        category="model",
+                        title=(f"{low_perf:,} mature models have low performance (AUC < {bp_min_perf * 100:.0f})"),
+                        detail=(
+                            "These models have sufficient positive responses but "
+                            "still fall below the best-practice AUC threshold. "
+                            "Consider reviewing predictor data or adding better "
+                            "features."
+                        ),
+                        data={
+                            "count": low_perf,
+                            "total": total,
+                            "min_performance": bp_min_perf,
+                        },
+                    )
+                )
+
+        # Suspiciously high performance
+        if bp_min_positives is not None:
+            bp_max_perf = MetricLimits.best_practice_max("ModelPerformance")
+            if bp_max_perf is not None:
+                suspicious = last_data.filter(
+                    (pl.col("Performance") > bp_max_perf) & (pl.col("Positives") >= bp_min_positives)
+                ).height
+                if suspicious > 0:
+                    findings.append(
+                        Finding(
+                            severity="warning",
+                            category="model",
+                            title=(
+                                f"{suspicious:,} models have suspiciously high "
+                                f"performance (AUC > {bp_max_perf * 100:.0f})"
+                            ),
+                            detail=(
+                                "Very high AUC values may indicate outcome leakers "
+                                "in the predictor set, or models with very few "
+                                "responses where the metric is unreliable."
+                            ),
+                            data={
+                                "count": suspicious,
+                                "total": total,
+                                "max_performance": bp_max_perf,
+                            },
+                        )
+                    )
+
+        # Mature low-performance models — count-only finding follows in
+        # _check_model_performance; not emitted here so the maturity
+        # percentage buckets remain a deliberate "visible cohorts" view
+        # rather than a forced 100 % decomposition.
+
+        # Healthy models summary
+        if bp_min_perf is not None and bp_min_positives is not None:
+            healthy = last_data.filter(
+                (pl.col("Performance") >= bp_min_perf) & (pl.col("Positives") >= bp_min_positives)
+            ).height
+            if healthy > 0:
+                pct = healthy / total * 100
+                findings.append(
+                    Finding(
+                        severity="info",
+                        category="model",
+                        title=f"{healthy:,} models ({pct:.0f}%) are mature with decent performance",
+                        detail=(
+                            f"These models have ≥{int(bp_min_positives)} positives and AUC ≥{bp_min_perf * 100:.0f}."
+                        ),
+                        data={
+                            "count": healthy,
+                            "total": total,
+                            "percentage": pct,
+                            "bucket": "mature_decent",
+                        },
+                    )
+                )
+
+        return findings
+
+    def _check_model_performance(
+        self,
+        last_data: pl.DataFrame,
+        active_filter: pl.Expr,
+    ) -> tuple[list[Finding], float | None]:
+        """Emit a tiered AUC finding and return the weighted average.
+
+        Returns
+        -------
+        list[Finding]
+            One finding describing the active-model AUC, if computable.
+        float | None
+            The weighted average AUC across active models on a 0-1 scale,
+            or ``None`` when not computable (no active data, all-NaN, etc.).
+        """
+        findings: list[Finding] = []
+
+        try:
+            active_data = last_data.filter(active_filter)
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not apply active filter for performance analysis: %s", exc)
+            return findings, None
+
+        if active_data.height == 0:
+            return findings, None
+
+        avg_perf = active_data.select(cdh_utils.weighted_average_polars("Performance", "ResponseCount")).item()
+
+        if avg_perf is None or math.isnan(avg_perf):
+            return findings, None
+
+        auc100 = avg_perf * 100
+        if auc100 < 58:
+            severity: Severity = "critical"
+            label = "low"
+            tail = "Investigate predictor availability and data quality."
+        elif auc100 < 62:
+            severity = "warning"
+            label = "borderline"
+            tail = "Performance is below the typical healthy range; review predictors and outcome labelling."
+        elif auc100 < 70:
+            severity = "info"
+            label = "healthy"
+            tail = "Performance is within the typical healthy range."
+        else:
+            severity = "success"
+            label = "strong"
+            tail = "Performance is well above the typical healthy range."
+
+        findings.append(
+            Finding(
+                severity=severity,
+                category="model",
+                title=f"Overall average model performance is {label} (AUC {auc100:.1f})",
+                detail=(
+                    f"Weighted average AUC across active models is {auc100:.1f}. "
+                    f"Tiers: <58 low, 58-62 borderline, 62-70 healthy, ≥70 strong. {tail}"
+                ),
+                data={"weighted_avg_performance": avg_perf, "tier": label},
+            )
+        )
+
+        return findings, avg_perf
+
+    def _check_taxonomy(self) -> list[Finding]:
+        findings: list[Finding] = []
+        all_columns = (
+            self.datamart.combined_data.collect_schema().names()
+            if self.datamart.predictor_data is not None
+            else self.datamart.model_data.collect_schema().names()
+        )
+
+        checks = [
+            ("ActionCount", "Name", "Total actions"),
+            ("TreatmentCount", "Treatment", "Total treatments"),
+            ("IssueCount", "Issue", "Unique issues"),
+            ("ChannelsUsingADM", ["Channel", "Direction"], "Channels using ADM"),
+        ]
+
+        for metric_id, field_name, label in checks:
+            try:
+                value = report_utils.n_unique_values(self.datamart, all_columns, field_name)
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute taxonomy metric %s: %s", metric_id, exc)
+                continue
+
+            rag = MetricLimits.evaluate_metric_rag(metric_id, value)
+            if rag not in ("RED", "AMBER"):
+                continue
+
+            bp_min = MetricLimits.best_practice_min(metric_id)
+            bp_max = MetricLimits.best_practice_max(metric_id)
+            hard_min = MetricLimits.minimum(metric_id)
+            hard_max = MetricLimits.maximum(metric_id)
+
+            severity: Severity = "warning" if rag == "RED" else "info"
+
+            if rag == "RED" and hard_min is not None and value < hard_min:
+                title = f"{label} ({value:,}) is below minimum ({hard_min:.0f})"
+            elif rag == "RED" and hard_max is not None and value > hard_max:
+                title = f"{label} ({value:,}) is above maximum ({hard_max:.0f})"
+            elif rag == "AMBER" and bp_min is not None and value < bp_min:
+                title = f"{label} ({value:,}) is below recommended (≥{bp_min:.0f})"
+            elif rag == "AMBER" and bp_max is not None and value > bp_max:
+                title = f"{label} ({value:,}) is above typical range (>{bp_max:.0f})"
+            elif bp_min is not None and value < bp_min:
+                title = f"{label} ({value:,}) is below recommended (≥{bp_min:.0f})"
+            elif bp_max is not None and value > bp_max:
+                title = f"{label} ({value:,}) is above typical range (>{bp_max:.0f})"
+            else:
+                # Both bounds undefined for this rag — fall back to a clear summary.
+                title = f"{label} ({value:,}) is outside the recommended range"
+
+            findings.append(
+                Finding(
+                    severity=severity,
+                    category="taxonomy",
+                    title=title,
+                    detail=(
+                        f"Recommended range: "
+                        f"{('≥' + format(bp_min, '.0f')) if bp_min is not None else '-'}"
+                        f" to "
+                        f"{('≤' + format(bp_max, '.0f')) if bp_max is not None else '-'}. "
+                        f"Hard limits: "
+                        f"{('≥' + format(hard_min, '.0f')) if hard_min is not None else '-'}"
+                        f" to "
+                        f"{('≤' + format(hard_max, '.0f')) if hard_max is not None else '-'}."
+                    ),
+                    data={
+                        "metric_id": metric_id,
+                        "value": value,
+                        "best_practice_min": bp_min,
+                        "best_practice_max": bp_max,
+                        "minimum": hard_min,
+                        "maximum": hard_max,
+                    },
+                )
+            )
+
+        # Check predictor counts per configuration
+        if self.datamart.predictor_data is not None:
+            try:
+                pred_counts = (
+                    self.datamart.combined_data.filter(pl.col("EntryType") != "Classifier")
+                    .group_by("Configuration")
+                    .agg(pl.col("PredictorName").n_unique().alias("n_predictors"))
+                    .collect()
+                )
+                for row in pred_counts.iter_rows(named=True):
+                    rag = MetricLimits.evaluate_metric_rag("PredictorCount", row["n_predictors"])
+                    if rag in ("RED", "AMBER"):
+                        findings.append(
+                            Finding(
+                                severity="warning" if rag == "RED" else "info",
+                                category="taxonomy",
+                                title=(f'Configuration "{row["Configuration"]}" has {row["n_predictors"]} predictors'),
+                                detail=(
+                                    f"The recommended range is "
+                                    f"{MetricLimits.best_practice_min('PredictorCount'):.0f}"
+                                    f"-{MetricLimits.best_practice_max('PredictorCount'):.0f} "
+                                    f"predictors per configuration."
+                                ),
+                                data={
+                                    "configuration": row["Configuration"],
+                                    "n_predictors": row["n_predictors"],
+                                },
+                            )
+                        )
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute predictor counts per configuration: %s", exc)
+
+        return findings
+
+    def _check_response_distribution(
+        self,
+        last_data: pl.DataFrame,
+        active_filter: pl.Expr,
+    ) -> list[Finding]:
+        findings: list[Finding] = []
+
+        try:
+            active_data = last_data.filter(active_filter)
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not apply active filter for response distribution: %s", exc)
+            return findings
+
+        if active_data.height == 0:
+            return findings
+
+        resp = active_data["ResponseCount"].to_list()
+        gini_resp = _gini(resp)
+
+        if gini_resp > 0.9:
+            findings.append(
+                Finding(
+                    severity="warning",
+                    category="response_distribution",
+                    title=f"Response distribution is highly skewed (Gini={gini_resp:.2f})",
+                    detail=(
+                        "A very small number of models receive the vast majority "
+                        "of responses. This may indicate over-leveraging of certain "
+                        "actions or that prioritization rules are too aggressive."
+                    ),
+                    data={"gini_responses": gini_resp},
+                )
+            )
+        elif gini_resp > 0.7:
+            findings.append(
+                Finding(
+                    severity="info",
+                    category="response_distribution",
+                    title=f"Response distribution is moderately skewed (Gini={gini_resp:.2f})",
+                    detail=(
+                        "Some actions receive substantially more responses than "
+                        "others. This is common but worth monitoring — verify that "
+                        "high-volume actions are intentionally prioritized."
+                    ),
+                    data={"gini_responses": gini_resp},
+                )
+            )
+
+        # Check positives distribution too
+        pos = active_data["Positives"].to_list()
+        gini_pos = _gini(pos)
+        if gini_pos > 0.9:
+            findings.append(
+                Finding(
+                    severity="warning",
+                    category="response_distribution",
+                    title=f"Positive response distribution is highly skewed (Gini={gini_pos:.2f})",
+                    detail=(
+                        "Positive responses are concentrated in a few models. "
+                        "Check whether the high-converting actions are truly the "
+                        "best options or if this is driven by exposure bias."
+                    ),
+                    data={"gini_positives": gini_pos},
+                )
+            )
+
+        # Performance vs volume: what % of volume is at low AUC
+        bp_min_perf = MetricLimits.best_practice_min("ModelPerformance")
+        total_resp = active_data.select(pl.sum("ResponseCount")).item() or 0
+        if total_resp > 0 and bp_min_perf is not None:
+            low_auc_resp = (
+                active_data.filter(pl.col("Performance") < bp_min_perf).select(pl.sum("ResponseCount")).item() or 0
+            )
+            low_auc_pct = low_auc_resp / total_resp * 100
+            auc_threshold_str = f"AUC < {bp_min_perf * 100:.0f}"
+            if low_auc_pct > 50:
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        category="response_distribution",
+                        title=(
+                            f"{low_auc_pct:.0f}% of response volume is driven by "
+                            f"low-performance models ({auc_threshold_str})"
+                        ),
+                        detail=(
+                            "Most responses come from models with very low "
+                            "predictive performance. Targeting is sub-optimal. "
+                            "Consider improving predictor data or allowing models "
+                            "more time to mature."
+                        ),
+                        data={
+                            "low_auc_response_pct": low_auc_pct,
+                            "low_auc_responses": low_auc_resp,
+                            "total_responses": total_resp,
+                        },
+                    )
+                )
+            elif low_auc_pct > 30:
+                findings.append(
+                    Finding(
+                        severity="info",
+                        category="response_distribution",
+                        title=(
+                            f"{low_auc_pct:.0f}% of response volume is from "
+                            f"low-performance models ({auc_threshold_str})"
+                        ),
+                        detail=("A notable portion of responses comes from models that are not yet performing well."),
+                        data={
+                            "low_auc_response_pct": low_auc_pct,
+                            "low_auc_responses": low_auc_resp,
+                            "total_responses": total_resp,
+                        },
+                    )
+                )
+
+        return findings
+
+    def _check_trends(self) -> list[Finding]:
+        findings: list[Finding] = []
+
+        try:
+            snapshots = self.datamart.model_data.select(pl.col("SnapshotTime").unique()).collect()
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not collect snapshot times for trend analysis: %s", exc)
+            return findings
+
+        n_snapshots = snapshots.height
+        if n_snapshots < 3:
+            return findings
+
+        try:
+            by_expr = pl.concat_str(pl.col("Channel"), pl.col("Direction"), separator="/").alias("Channel/Direction")
+
+            trend = (
+                self.datamart.model_data.with_columns(by_expr)
+                .group_by(["SnapshotTime", "Channel/Direction"])
+                .agg(
+                    (cdh_utils.weighted_average_polars("Performance", "ResponseCount") * 100).round(1).alias("AvgPerf"),
+                    pl.sum("ResponseCount").alias("TotalResp"),
+                )
+                .sort(["Channel/Direction", "SnapshotTime"])
+                .collect()
+            )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not build per-channel trend data: %s", exc)
+            return findings
+
+        for channel in trend["Channel/Direction"].unique().sort():
+            ch_trend = trend.filter(pl.col("Channel/Direction") == channel)
+            if ch_trend.height < 3:
+                continue
+
+            perfs = ch_trend["AvgPerf"].to_list()
+            first_half = perfs[: len(perfs) // 2]
+            second_half = perfs[len(perfs) // 2 :]
+
+            avg_first = sum(first_half) / len(first_half) if first_half else 0
+            avg_second = sum(second_half) / len(second_half) if second_half else 0
+            change = avg_second - avg_first
+
+            if change < -3:
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        category="trend",
+                        title=(f'Performance declining for channel "{channel}" (Δ{change:+.1f} AUC)'),
+                        detail=(
+                            f"Average model performance dropped from "
+                            f"{avg_first:.1f} to {avg_second:.1f} over the data "
+                            "period. This may indicate data quality degradation, "
+                            "concept drift, or configuration changes."
+                        ),
+                        data={
+                            "channel": channel,
+                            "start_perf": avg_first,
+                            "end_perf": avg_second,
+                            "change": change,
+                        },
+                    )
+                )
+
+            # Check for response volume drops
+            resps = ch_trend["TotalResp"].to_list()
+            if len(resps) >= 3:
+                resp_first = resps[:3]
+                resp_last = resps[-3:]
+                avg_resp_first = sum(resp_first) / len(resp_first)
+                avg_resp_last = sum(resp_last) / len(resp_last)
+                if avg_resp_first > 0:
+                    resp_change = (avg_resp_last - avg_resp_first) / avg_resp_first
+                    if resp_change < -0.5:
+                        findings.append(
+                            Finding(
+                                severity="warning",
+                                category="trend",
+                                title=(
+                                    f"Response volume dropped significantly for "
+                                    f'channel "{channel}" ({resp_change:+.0%})'
+                                ),
+                                detail=(
+                                    "Response counts have dropped by more than 50% "
+                                    "between the start and end of the data period. "
+                                    "This may indicate that models were reset, "
+                                    "actions were deactivated, or traffic patterns changed."
+                                ),
+                                data={
+                                    "channel": channel,
+                                    "start_avg_responses": avg_resp_first,
+                                    "end_avg_responses": avg_resp_last,
+                                    "change_pct": resp_change,
+                                },
+                            )
+                        )
+
+        return findings
+
+    def _check_predictors(self) -> list[Finding]:
+        findings: list[Finding] = []
+        min_perf = MetricLimits.minimum("ModelPerformance")
+
+        # Poor predictors
+        try:
+            predictor_overview = self.datamart.aggregates.predictors_global_overview().collect()
+            poor_count = predictor_overview.filter(pl.col("Mean") < (min_perf * 100)).height
+            total_predictors = predictor_overview.height
+
+            if poor_count > 0:
+                pct = poor_count / total_predictors * 100 if total_predictors > 0 else 0
+                findings.append(
+                    Finding(
+                        severity="warning" if pct > 30 else "info",
+                        category="predictor",
+                        title=(
+                            f"{poor_count} of {total_predictors} predictors "
+                            f"({pct:.0f}%) have poor performance "
+                            f"(mean AUC < {min_perf * 100:.0f})"
+                        ),
+                        detail=(
+                            "These predictors consistently perform below the "
+                            "minimum threshold across all models. They may "
+                            "indicate data sourcing issues. Be cautious with "
+                            "removal — they may be valuable for specific actions."
+                        ),
+                        data={
+                            "poor_predictor_count": poor_count,
+                            "total_predictors": total_predictors,
+                            "threshold": min_perf * 100,
+                        },
+                    )
+                )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute predictor performance overview: %s", exc)
+
+        # Missing predictor data
+        try:
+            all_columns = self.datamart.combined_data.collect_schema().names()
+            gb_cols = report_utils.polars_subset_to_existing_cols(all_columns, ["PredictorCategory", "PredictorName"])
+
+            missing = (
+                self.datamart.aggregates.last(table="predictor_data")
+                .filter(pl.col("PredictorName") != "Classifier")
+                .filter(pl.col("PredictorCategory") != "IH")
+                .group_by(gb_cols)
+                .agg(
+                    pl.col("BinResponseCount").filter(pl.col("BinSymbol") == "MISSING").sum().alias("MissingCount"),
+                    pl.sum("BinResponseCount").alias("TotalResponses"),
+                )
+                .with_columns((pl.col("MissingCount") / pl.col("TotalResponses")).alias("MissingPct"))
+                .filter(~pl.col("MissingPct").is_nan())
+                .filter(pl.col("MissingPct") > 0.5)
+                .collect()
+            )
+
+            if missing.height > 0:
+                names = missing["PredictorName"].to_list()
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        category="predictor",
+                        title=f"{missing.height} predictors have >50% missing values",
+                        detail=(
+                            "These predictors (excluding IH) have high rates of "
+                            "missing data, which may indicate data pipeline issues. "
+                            f"Examples: {', '.join(names[:5])}"
+                        ),
+                        data={
+                            "count": missing.height,
+                            "predictor_names": names[:20],
+                        },
+                    )
+                )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute missing predictor data rates: %s", exc)
+
+        # Check for IH predictor proportion
+        try:
+            ih_counts = (
+                self.datamart.combined_data.filter(pl.col("EntryType") != "Classifier")
+                .group_by("Configuration")
+                .agg(
+                    pl.col("PredictorName").filter(pl.col("PredictorCategory") == "IH").n_unique().alias("IH_count"),
+                    pl.col("PredictorName").n_unique().alias("Total"),
+                )
+                .collect()
+            )
+
+            for row in ih_counts.iter_rows(named=True):
+                if row["IH_count"] > 100:
+                    findings.append(
+                        Finding(
+                            severity="info",
+                            category="predictor",
+                            title=(f'Configuration "{row["Configuration"]}" has {row["IH_count"]} IH predictors'),
+                            detail=(
+                                "More than 100 Interaction History (IH) predictors "
+                                "may cause performance issues. Consider reducing "
+                                "the number of IH predictors."
+                            ),
+                            data={
+                                "configuration": row["Configuration"],
+                                "ih_predictor_count": row["IH_count"],
+                                "total_predictors": row["Total"],
+                            },
+                        )
+                    )
+                elif row["IH_count"] == 0 and row["Total"] > 0:
+                    findings.append(
+                        Finding(
+                            severity="info",
+                            category="predictor",
+                            title=(f'Configuration "{row["Configuration"]}" has no IH predictors'),
+                            detail=(
+                                "No Interaction History predictors are present. "
+                                "IH predictors are typically valuable for "
+                                "personalization and are recommended."
+                            ),
+                            data={
+                                "configuration": row["Configuration"],
+                                "ih_predictor_count": 0,
+                                "total_predictors": row["Total"],
+                            },
+                        )
+                    )
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not compute IH predictor proportions: %s", exc)
+
+        return findings
+
+    def _check_predictions(self, prediction: "Prediction") -> list[Finding]:
+        findings: list[Finding] = []
+
+        try:
+            pred_summary = prediction.summary_by_channel().collect()
+        except RECOVERABLE_ANALYSIS_ERRORS as exc:
+            logger.debug("Could not summarize prediction data by channel: %s", exc)
+            return findings
+
+        if "Lift" not in pred_summary.columns:
+            return findings
+
+        for row in pred_summary.iter_rows(named=True):
+            ch = f"{row.get('Channel', '?')}/{row.get('Direction', '?')}"
+            lift = row.get("Lift")
+
+            if lift is not None and not math.isnan(lift):
+                if lift < 0:
+                    findings.append(
+                        Finding(
+                            severity="critical",
+                            category="prediction",
+                            title=f'Negative engagement lift ({lift * 100:.0f}%) for "{ch}"',
+                            detail=(
+                                "Models are performing worse than random selection. "
+                                "This indicates misconfiguration, data problems, or "
+                                "that the control group setup needs review."
+                            ),
+                            data={"channel": ch, "lift": lift},
+                        )
+                    )
+                elif lift < 0.1:
+                    findings.append(
+                        Finding(
+                            severity="warning",
+                            category="prediction",
+                            title=f'Very low engagement lift ({lift * 100:.0f}%) for "{ch}"',
+                            detail=(
+                                "The model-driven group is barely outperforming "
+                                "the random group. The models may need better "
+                                "predictors or more training data."
+                            ),
+                            data={"channel": ch, "lift": lift},
+                        )
+                    )
+
+            # Check for default prediction names
+            pred_name = row.get("Prediction", "")
+            if pred_name and "default" in str(pred_name).lower():
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        category="prediction",
+                        title=f'Default prediction name: "{pred_name}"',
+                        detail=(
+                            "Using default prediction names (e.g., "
+                            "'PredictInboundDefaultPropensity') may indicate "
+                            "that the prediction configuration was not customized."
+                        ),
+                        data={"prediction_name": pred_name, "channel": ch},
+                    )
+                )
+
+            # Check control group size
+            ctrl_pct = row.get("ControlPercentage")
+            if ctrl_pct is not None and not math.isnan(ctrl_pct):
+                if ctrl_pct > 0.10:
+                    findings.append(
+                        Finding(
+                            severity="warning",
+                            category="prediction",
+                            title=(f'Large control group ({ctrl_pct:.1%}) for "{ch}"'),
+                            detail=(
+                                "The control group is larger than typical (1-5%). "
+                                "A larger control group means more customers are "
+                                "receiving random rather than optimized offers."
+                            ),
+                            data={"channel": ch, "control_pct": ctrl_pct},
+                        )
+                    )
+                elif ctrl_pct < 0.005:
+                    findings.append(
+                        Finding(
+                            severity="info",
+                            category="prediction",
+                            title=(f'Very small control group ({ctrl_pct:.2%}) for "{ch}"'),
+                            detail=(
+                                "The control group may be too small for reliable "
+                                "lift measurement. Consider increasing to 1-2%."
+                            ),
+                            data={"channel": ch, "control_pct": ctrl_pct},
+                        )
+                    )
+
+        return findings

--- a/python/pdstools/adm/Analysis.py
+++ b/python/pdstools/adm/Analysis.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["Analysis", "Finding", "HealthCheckPreAggregates"]
+__all__ = ["Analysis", "Finding", "HealthCheckPreAggregates", "_format_markdown_value"]
 
 import datetime
 import logging
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Literal
 
 import polars as pl
 
+from .HealthCheckMarkdown import HealthCheckMarkdownRenderer, _format_markdown_value
 from ..utils import cdh_utils, report_utils
 from ..utils.metric_limits import MetricLimits
 
@@ -94,6 +95,7 @@ class HealthCheckPreAggregates:
     overall_avg_auc: float | None = None
     active_avg_auc: float | None = None
     predictor_count: int | None = None
+    channel_overview: pl.DataFrame | None = None
     channel_summary: pl.DataFrame | None = None
     configuration_summary: pl.DataFrame | None = None
     predictor_overview: pl.DataFrame | None = None
@@ -113,46 +115,6 @@ def _gini(values: list[float]) -> float:
     return float((2 * weighted_sum - (n + 1) * total) / (n * total))
 
 
-def _format_markdown_value(value: object) -> str:
-    """Format a finding payload value for markdown output."""
-    if value is None:
-        return "N/A"
-    if isinstance(value, bool):
-        return "Yes" if value else "No"
-    if isinstance(value, float):
-        if math.isnan(value) or math.isinf(value):
-            return "N/A"
-        if value == 0:
-            return "0"
-        if abs(value) >= 1000:
-            return f"{value:,.0f}"
-        if abs(value) >= 1:
-            return f"{value:,.2f}"
-        return f"{value:.4f}"
-    if isinstance(value, list):
-        preview = ", ".join(_format_markdown_value(item) for item in value[:5])
-        if len(value) > 5:
-            preview += f" (+{len(value) - 5} more)"
-        return preview
-    return str(value).replace("|", "\\|").replace("\n", " ")
-
-
-def _markdown_table(df: pl.DataFrame, *, max_rows: int | None = None) -> str:
-    """Render a small Polars DataFrame as GitHub-flavored Markdown."""
-    if df.height == 0:
-        return "*No data available.*"
-
-    truncated = max_rows is not None and df.height > max_rows
-    table_df = df.head(max_rows) if truncated else df
-    header = "| " + " | ".join(table_df.columns) + " |"
-    separator = "| " + " | ".join("---" for _ in table_df.columns) + " |"
-    rows = ["| " + " | ".join(_format_markdown_value(value) for value in row) + " |" for row in table_df.iter_rows()]
-    markdown = "\n".join([header, separator, *rows])
-    if truncated:
-        markdown += f"\n\n*And {df.height - max_rows} more rows.*"
-    return markdown
-
-
 class Analysis:
     """Automated diagnostic analysis for ADM model data.
 
@@ -169,6 +131,105 @@ class Analysis:
 
     def __init__(self, datamart: "ADMDatamart") -> None:
         self.datamart = datamart
+
+    def _markdown_renderer(self) -> HealthCheckMarkdownRenderer:
+        return HealthCheckMarkdownRenderer(self)
+
+    def health_check_active_filter(self, *, active_threshold_days: int = 30) -> pl.Expr:
+        """Return the shared active-model filter used by health checks."""
+        return (
+            pl.col("LastUpdate") > (pl.col("LastUpdate").max() - datetime.timedelta(days=active_threshold_days))
+        ).fill_null(True)
+
+    def health_check_active_threshold_date_string(self, *, active_threshold_days: int = 30) -> str:
+        """Return the shared cutoff-date string for the active-model filter."""
+        return (
+            self.datamart.model_data.select(
+                (pl.col("LastUpdate").max() - datetime.timedelta(days=active_threshold_days))
+                .dt.strftime("%v")
+                .alias("cutoff")
+            )
+            .collect()
+            .item()
+            .strip()
+        )
+
+    def health_check_maturity_criteria(self) -> list[tuple[str, str, pl.Expr]]:
+        """Return the shared maturity bucket definitions for health checks."""
+        min_responses = MetricLimits.minimum("TotalResponseCount")
+        min_positives = MetricLimits.minimum("TotalPositiveCount")
+        bp_min_positives = MetricLimits.best_practice_min("TotalPositiveCount")
+        min_perf = MetricLimits.minimum("ModelPerformance")
+
+        return [
+            ("last_snapshot", "Number of models in last snapshot", pl.lit(True)),
+            (
+                "never_used",
+                "Models that have never been used (responses = 0)",
+                pl.col("ResponseCount") < min_responses,
+            ),
+            (
+                "responses_no_positives",
+                "Models that have been used (responses > 0) but never received a positive response",
+                (pl.col("Positives") < min_positives) & (pl.col("ResponseCount") >= min_responses),
+            ),
+            (
+                "immature",
+                f"Models that are still in an immature phase of learning (positives < {int(bp_min_positives)})",
+                (pl.col("Positives") < bp_min_positives) & (pl.col("Positives") >= min_positives),
+            ),
+            (
+                "stuck_at_50",
+                "Models that have received sufficient responses but are still at their minimum performance (AUC = 50)",
+                (pl.col("Performance") == 0.5) & (pl.col("Positives") >= bp_min_positives),
+            ),
+            (
+                "low_performance",
+                f"Models that have received sufficient responses but still have a low performance (AUC < {min_perf})",
+                (pl.col("Performance") > 0.5)
+                & (pl.col("Performance") < min_perf)
+                & (pl.col("Positives") >= bp_min_positives),
+            ),
+            (
+                "mature_decent",
+                f"Models with sufficient positive responses (≥ {int(bp_min_positives)}) and a decent performance (≥ {min_perf})",
+                (pl.col("Performance") >= min_perf) & (pl.col("Positives") >= bp_min_positives),
+            ),
+        ]
+
+    def health_check_maturity_overview(
+        self,
+        *,
+        last_data: pl.DataFrame | None = None,
+        active_filter: pl.Expr | None = None,
+        active_threshold_days: int = 30,
+    ) -> pl.DataFrame:
+        """Return the shared maturity-overview table used by health checks."""
+        if last_data is None:
+            last_data = self._get_last_data()
+        if active_filter is None:
+            active_filter = self.health_check_active_filter(active_threshold_days=active_threshold_days)
+
+        active_last_data = last_data.lazy().filter(active_filter)
+        return pl.concat(
+            [
+                active_last_data.group_by(None)
+                .agg(
+                    pl.lit(label).alias("Category"),
+                    pl.col("Name").filter(filter_expression).len().alias("Number of Models"),
+                    (
+                        cdh_utils.weighted_average_polars(
+                            pl.col("Performance").filter(filter_expression),
+                            pl.col("ResponseCount").filter(filter_expression),
+                        )
+                        * 100.0
+                    ).alias("Average Performance"),
+                )
+                .drop("literal")
+                .collect()
+                for _, label, filter_expression in self.health_check_maturity_criteria()
+            ]
+        )
 
     def compute_health_check_preaggregates(
         self,
@@ -201,9 +262,7 @@ class Analysis:
             outputs within one run.
         """
         if active_filter is None:
-            active_filter = (
-                pl.col("LastUpdate") > (pl.col("LastUpdate").max() - datetime.timedelta(days=active_threshold_days))
-            ).fill_null(True)
+            active_filter = self.health_check_active_filter(active_threshold_days=active_threshold_days)
         return self._build_health_check_preaggregates(
             active_filter=active_filter,
             prediction=prediction,
@@ -302,16 +361,21 @@ class Analysis:
 
         if include_markdown_sections:
             try:
-                preaggregates.configuration_summary = self._health_check_configuration_summary(
-                    last_data=last_data,
-                    active_filter=active_filter,
+                preaggregates.channel_overview = self.datamart.aggregates.channel_overview(query=active_filter)
+            except RECOVERABLE_ANALYSIS_ERRORS as exc:
+                logger.debug("Could not compute shared health-check channel overview: %s", exc)
+            try:
+                preaggregates.configuration_summary = self.datamart.aggregates.configuration_overview(
+                    query=active_filter
                 )
             except RECOVERABLE_ANALYSIS_ERRORS as exc:
                 logger.debug("Could not compute health-check configuration pre-aggregates: %s", exc)
 
         if self.datamart.predictor_data is not None:
             try:
-                preaggregates.predictor_overview = self.datamart.aggregates.predictors_global_overview().collect()
+                preaggregates.predictor_overview = self.datamart.aggregates.global_predictor_overview(
+                    query=active_filter
+                )
             except RECOVERABLE_ANALYSIS_ERRORS as exc:
                 logger.debug("Could not compute health-check predictor pre-aggregates: %s", exc)
             else:
@@ -370,9 +434,7 @@ class Analysis:
             Sorted by severity (critical first, then warning, then info).
         """
         if active_filter is None:
-            active_filter = (
-                pl.col("LastUpdate") > (pl.col("LastUpdate").max() - datetime.timedelta(days=active_threshold_days))
-            ).fill_null(True)
+            active_filter = self.health_check_active_filter(active_threshold_days=active_threshold_days)
 
         preaggregates = preaggregates or self.compute_health_check_preaggregates(
             active_filter=active_filter,
@@ -452,101 +514,15 @@ class Analysis:
         str
             Markdown document summarizing the findings.
         """
-        preaggregates = preaggregates or self.compute_health_check_preaggregates(
-            active_filter=active_filter,
-            active_threshold_days=active_threshold_days,
-            prediction=prediction,
-            include_markdown_sections=True,
-        )
-        findings = self.findings(
+        return self._markdown_renderer().render(
+            title=title,
+            subtitle=subtitle,
+            disclaimer=disclaimer,
             active_filter=active_filter,
             active_threshold_days=active_threshold_days,
             prediction=prediction,
             preaggregates=preaggregates,
         )
-        headline = next((finding for finding in findings if finding.category == "summary"), None)
-        body_findings = [finding for finding in findings if finding.category != "summary"]
-
-        lines = [f"# {title}", ""]
-        if subtitle:
-            lines.extend([f"## {subtitle}", ""])
-        if disclaimer:
-            lines.extend([f"> **Disclaimer:** {disclaimer}", ""])
-
-        if headline is not None:
-            lines.extend(["## Summary", "", f"**{headline.title}**", "", headline.detail, ""])
-
-        lines.extend(
-            [
-                "## Key Metrics",
-                "",
-                _markdown_table(
-                    self._key_metrics_table(
-                        preaggregates.last_data,
-                        findings,
-                        active_filter,
-                        preaggregates=preaggregates,
-                    )
-                ),
-                "",
-            ]
-        )
-
-        estate_sections = self._estate_snapshot_sections(active_filter, preaggregates=preaggregates)
-        if estate_sections:
-            lines.extend(["## Estate Snapshot", ""])
-            for section_title, section_table in estate_sections:
-                lines.extend([f"### {section_title}", "", _markdown_table(section_table, max_rows=5), ""])
-
-        lines.extend(["## Findings Overview", ""])
-        lines.extend(
-            ["### Findings by Severity", "", _markdown_table(self._findings_by_severity_table(body_findings)), ""]
-        )
-        lines.extend(
-            [
-                "### Findings by Category",
-                "",
-                _markdown_table(self._findings_by_category_table(body_findings), max_rows=10),
-                "",
-            ]
-        )
-
-        if not body_findings:
-            lines.extend(["## Findings", "", "No findings were generated.", ""])
-            return "\n".join(lines).strip() + "\n"
-
-        severity_order: list[Severity] = ["critical", "warning", "info", "success"]
-        section_titles = {
-            "critical": "Critical Findings",
-            "warning": "Warning Findings",
-            "info": "Informational Findings",
-            "success": "Positive Findings",
-        }
-
-        for severity in severity_order:
-            section_findings = [finding for finding in body_findings if finding.severity == severity]
-            if not section_findings:
-                continue
-            lines.extend([f"## {section_titles[severity]}", ""])
-            for finding in section_findings:
-                lines.extend(
-                    [
-                        f"### {finding.title}",
-                        "",
-                        f"- **Category:** `{finding.category}`",
-                        f"- **Severity:** `{finding.severity}`",
-                        "",
-                        finding.detail,
-                    ]
-                )
-                if finding.data:
-                    lines.append("")
-                    lines.append("Supporting data:")
-                    for key, value in finding.data.items():
-                        lines.append(f"- **{key}**: {_format_markdown_value(value)}")
-                lines.append("")
-
-        return "\n".join(lines).strip() + "\n"
 
     def _key_metrics_table(
         self,
@@ -557,48 +533,11 @@ class Analysis:
         preaggregates: HealthCheckPreAggregates | None = None,
     ) -> pl.DataFrame:
         """Build a compact key-metrics table for markdown output."""
-        if preaggregates is None:
-            preaggregates = self._build_health_check_preaggregates(active_filter=active_filter)
-
-        avg_auc = next(
-            (finding.data.get("avg_auc") for finding in findings if finding.category == "summary"),
-            None,
-        )
-
-        metrics: list[tuple[str, object]] = [
-            (
-                "Snapshot range",
-                (
-                    f"{preaggregates.date_start:%Y-%m-%d} to {preaggregates.date_end:%Y-%m-%d}"
-                    if preaggregates.date_start is not None and preaggregates.date_end is not None
-                    else None
-                ),
-            ),
-            ("Models (latest snapshot)", preaggregates.total_models),
-            ("Active models", preaggregates.active_models),
-            ("Channels", preaggregates.channel_count),
-            ("Configurations", preaggregates.configuration_count),
-            ("Actions", preaggregates.action_count),
-            ("Treatments", preaggregates.treatment_count),
-            ("Responses", preaggregates.response_count),
-            ("Positives", preaggregates.positive_count),
-            (
-                "Average AUC (latest snapshot)",
-                avg_auc * 100 if isinstance(avg_auc, float) else None,
-            ),
-        ]
-
-        if isinstance(preaggregates.active_avg_auc, float):
-            metrics.append(("Average AUC (active)", preaggregates.active_avg_auc * 100))
-
-        if self.datamart.predictor_data is not None:
-            metrics.append(("Predictors", preaggregates.predictor_count))
-
-        return pl.DataFrame(
-            {
-                "Metric": [metric for metric, _ in metrics],
-                "Value": [_format_markdown_value(value) for _, value in metrics],
-            }
+        return self._markdown_renderer().key_metrics_table(
+            last_data,
+            findings,
+            active_filter,
+            preaggregates=preaggregates,
         )
 
     def _estate_snapshot_sections(
@@ -608,62 +547,20 @@ class Analysis:
         preaggregates: HealthCheckPreAggregates | None = None,
     ) -> list[tuple[str, pl.DataFrame]]:
         """Build compact orientation tables for the markdown report."""
-        sections: list[tuple[str, pl.DataFrame]] = []
-        if preaggregates is None:
-            preaggregates = self._build_health_check_preaggregates(
-                active_filter=active_filter,
-                include_markdown_sections=True,
-            )
-
-        if preaggregates.channel_summary is not None:
-            channel_summary = preaggregates.channel_summary.select(
-                "ChannelDirection", "Responses", "Positives", "Performance", "CTR", "Actions"
-            ).sort("Responses", descending=True)
-            if channel_summary.height > 0:
-                sections.append(("Top Channels by Responses", channel_summary))
-
-        if preaggregates.configuration_summary is not None:
-            configuration_columns = [
-                col
-                for col in [
-                    "Configuration",
-                    "Channel",
-                    "Direction",
-                    "ResponseCount",
-                    "Positives",
-                    "Performance",
-                ]
-                if col in preaggregates.configuration_summary.columns
-            ]
-            configuration_summary = preaggregates.configuration_summary.select(configuration_columns).sort(
-                "ResponseCount", descending=True
-            )
-            if configuration_summary.height > 0:
-                sections.append(("Top Configurations by Responses", configuration_summary))
-
-        if preaggregates.predictor_categories is not None and preaggregates.predictor_categories.height > 0:
-            sections.append(("Predictor Categories", preaggregates.predictor_categories))
-
-        return sections
+        return self._markdown_renderer().estate_snapshot_sections(
+            active_filter,
+            preaggregates=preaggregates,
+        )
 
     @staticmethod
     def _findings_by_severity_table(findings: list[Finding]) -> pl.DataFrame:
         """Summarize findings by severity."""
-        severity_order = {"critical": 0, "warning": 1, "info": 2, "success": 3}
-        counts: dict[str, int] = {}
-        for finding in findings:
-            counts[finding.severity] = counts.get(finding.severity, 0) + 1
-        rows = sorted(counts.items(), key=lambda item: severity_order[item[0]])
-        return pl.DataFrame({"Severity": [severity for severity, _ in rows], "Count": [count for _, count in rows]})
+        return HealthCheckMarkdownRenderer.findings_by_severity_table(findings)
 
     @staticmethod
     def _findings_by_category_table(findings: list[Finding]) -> pl.DataFrame:
         """Summarize findings by category."""
-        counts: dict[str, int] = {}
-        for finding in findings:
-            counts[finding.category] = counts.get(finding.category, 0) + 1
-        rows = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
-        return pl.DataFrame({"Category": [category for category, _ in rows], "Count": [count for _, count in rows]})
+        return HealthCheckMarkdownRenderer.findings_by_category_table(findings)
 
     # ── private check methods ───────────────────────────────────────────
 
@@ -1179,16 +1076,12 @@ class Analysis:
             return findings
 
         bp_min_positives = MetricLimits.best_practice_min("TotalPositiveCount")
-        bp_min_perf = MetricLimits.best_practice_min("ModelPerformance")
-        # "Decent" performance means meeting the best-practice threshold
-        # (e.g. 0.55), not merely clearing the hard minimum (e.g. 0.52).
-        # The low-performance warning below uses the same boundary so the
-        # two cohorts are mutually exclusive and jointly cover all mature
-        # models — no silent gap, no synthetic bucket.
+        min_perf = MetricLimits.minimum("ModelPerformance")
+        criteria = {key: expr for key, _, expr in self.health_check_maturity_criteria()}
 
         # Unused models
         bp_max_unused = MetricLimits.best_practice_max("ModelsWithoutResponsesPercentage")
-        unused = last_data.filter(pl.col("ResponseCount") == 0).height
+        unused = last_data.filter(criteria["never_used"]).height
         if unused > 0:
             pct = unused / total * 100
             warn_threshold_pct = (bp_max_unused or 0.2) * 100
@@ -1207,7 +1100,7 @@ class Analysis:
             )
 
         # Models with responses but no positives
-        no_positives = last_data.filter((pl.col("ResponseCount") > 0) & (pl.col("Positives") == 0)).height
+        no_positives = last_data.filter(criteria["responses_no_positives"]).height
         if no_positives > 0:
             pct = no_positives / total * 100
             findings.append(
@@ -1232,7 +1125,7 @@ class Analysis:
         # Immature models — Positives in [1, bp_min) (mutually exclusive
         # with the never-used and zero-positives buckets above).
         if bp_min_positives is not None:
-            immature = last_data.filter((pl.col("Positives") > 0) & (pl.col("Positives") < bp_min_positives)).height
+            immature = last_data.filter(criteria["immature"]).height
             if immature > 0:
                 pct = immature / total * 100
                 findings.append(
@@ -1257,7 +1150,7 @@ class Analysis:
 
         # Stuck at AUC=50
         if bp_min_positives is not None:
-            stuck = last_data.filter((pl.col("Performance") == 0.5) & (pl.col("Positives") >= bp_min_positives)).height
+            stuck = last_data.filter(criteria["stuck_at_50"]).height
             if stuck > 0:
                 findings.append(
                     Finding(
@@ -1278,30 +1171,25 @@ class Analysis:
                     )
                 )
 
-        # Low performance — anything below best practice (excluding the
-        # stuck-at-0.5 cohort, which gets its own finding above).
-        if bp_min_perf is not None and bp_min_positives is not None:
-            low_perf = last_data.filter(
-                (pl.col("Performance") > 0.5)
-                & (pl.col("Performance") < bp_min_perf)
-                & (pl.col("Positives") >= bp_min_positives)
-            ).height
+        if min_perf is not None and bp_min_positives is not None:
+            low_perf = last_data.filter(criteria["low_performance"]).height
             if low_perf > 0:
                 findings.append(
                     Finding(
                         severity="warning",
                         category="model",
-                        title=(f"{low_perf:,} mature models have low performance (AUC < {bp_min_perf * 100:.0f})"),
+                        title=(f"{low_perf:,} mature models have low performance (AUC < {min_perf * 100:.0f})"),
                         detail=(
                             "These models have sufficient positive responses but "
-                            "still fall below the best-practice AUC threshold. "
+                            "still fall below the minimum AUC threshold used in the "
+                            "health check. "
                             "Consider reviewing predictor data or adding better "
                             "features."
                         ),
                         data={
                             "count": low_perf,
                             "total": total,
-                            "min_performance": bp_min_perf,
+                            "min_performance": min_perf,
                         },
                     )
                 )
@@ -1341,10 +1229,8 @@ class Analysis:
         # rather than a forced 100 % decomposition.
 
         # Healthy models summary
-        if bp_min_perf is not None and bp_min_positives is not None:
-            healthy = last_data.filter(
-                (pl.col("Performance") >= bp_min_perf) & (pl.col("Positives") >= bp_min_positives)
-            ).height
+        if min_perf is not None and bp_min_positives is not None:
+            healthy = last_data.filter(criteria["mature_decent"]).height
             if healthy > 0:
                 pct = healthy / total * 100
                 findings.append(
@@ -1352,9 +1238,7 @@ class Analysis:
                         severity="info",
                         category="model",
                         title=f"{healthy:,} models ({pct:.0f}%) are mature with decent performance",
-                        detail=(
-                            f"These models have ≥{int(bp_min_positives)} positives and AUC ≥{bp_min_perf * 100:.0f}."
-                        ),
+                        detail=(f"These models have ≥{int(bp_min_positives)} positives and AUC ≥{min_perf * 100:.0f}."),
                         data={
                             "count": healthy,
                             "total": total,

--- a/python/pdstools/adm/Analysis.py
+++ b/python/pdstools/adm/Analysis.py
@@ -673,28 +673,6 @@ class Analysis:
             "OmniChannel",
         )
 
-    def _health_check_configuration_summary(
-        self,
-        *,
-        last_data: pl.DataFrame,
-        active_filter: pl.Expr | None,
-    ) -> pl.DataFrame:
-        config_data = last_data.lazy()
-        if active_filter is not None:
-            config_data = config_data.filter(active_filter)
-
-        group_by_cols = ["Configuration"] + [col for col in ["Channel", "Direction"] if col in last_data.columns]
-
-        return (
-            config_data.group_by(group_by_cols)
-            .agg(
-                pl.sum("ResponseCount", "Positives"),
-                cdh_utils.weighted_average_polars("Performance", "ResponseCount").alias("Performance"),
-            )
-            .sort(group_by_cols)
-            .collect()
-        )
-
     def _build_headline(
         self,
         results: list[Finding],
@@ -1873,12 +1851,12 @@ class Analysis:
             # Check control group size
             ctrl_pct = row.get("ControlPercentage")
             if ctrl_pct is not None and not math.isnan(ctrl_pct):
-                if ctrl_pct > 0.10:
+                if ctrl_pct > 10:
                     findings.append(
                         Finding(
                             severity="warning",
                             category="prediction",
-                            title=(f'Large control group ({ctrl_pct:.1%}) for "{ch}"'),
+                            title=(f'Large control group ({ctrl_pct:.1f}%) for "{ch}"'),
                             detail=(
                                 "The control group is larger than typical (1-5%). "
                                 "A larger control group means more customers are "
@@ -1887,12 +1865,12 @@ class Analysis:
                             data={"channel": ch, "control_pct": ctrl_pct},
                         )
                     )
-                elif ctrl_pct < 0.005:
+                elif ctrl_pct < 0.5:
                     findings.append(
                         Finding(
                             severity="info",
                             category="prediction",
-                            title=(f'Very small control group ({ctrl_pct:.2%}) for "{ch}"'),
+                            title=(f'Very small control group ({ctrl_pct:.1f}%) for "{ch}"'),
                             detail=(
                                 "The control group may be too small for reliable "
                                 "lift measurement. Consider increasing to 1-2%."

--- a/python/pdstools/adm/Analysis.py
+++ b/python/pdstools/adm/Analysis.py
@@ -1179,7 +1179,6 @@ class Analysis:
             return findings
 
         bp_min_positives = MetricLimits.best_practice_min("TotalPositiveCount")
-        min_perf_floor = MetricLimits.minimum("ModelPerformance")
         bp_min_perf = MetricLimits.best_practice_min("ModelPerformance")
         # "Decent" performance means meeting the best-practice threshold
         # (e.g. 0.55), not merely clearing the hard minimum (e.g. 0.52).
@@ -1283,7 +1282,7 @@ class Analysis:
         # stuck-at-0.5 cohort, which gets its own finding above).
         if bp_min_perf is not None and bp_min_positives is not None:
             low_perf = last_data.filter(
-                (pl.col("Performance") > min_perf_floor)
+                (pl.col("Performance") > 0.5)
                 & (pl.col("Performance") < bp_min_perf)
                 & (pl.col("Positives") >= bp_min_positives)
             ).height

--- a/python/pdstools/adm/HealthCheckMarkdown.py
+++ b/python/pdstools/adm/HealthCheckMarkdown.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from .Analysis import Analysis, Finding, HealthCheckPreAggregates, Severity
+
+
+def _format_markdown_value(value: object) -> str:
+    """Format a finding payload value for markdown output."""
+    if value is None:
+        return "N/A"
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return "N/A"
+        if value == 0:
+            return "0"
+        if abs(value) >= 1000:
+            return f"{value:,.0f}"
+        if abs(value) >= 1:
+            return f"{value:,.2f}"
+        return f"{value:.4f}"
+    if isinstance(value, list):
+        preview = ", ".join(_format_markdown_value(item) for item in value[:5])
+        if len(value) > 5:
+            preview += f" (+{len(value) - 5} more)"
+        return preview
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _markdown_table(df: pl.DataFrame, *, max_rows: int | None = None) -> str:
+    """Render a small Polars DataFrame as GitHub-flavored Markdown."""
+    if df.height == 0:
+        return "*No data available.*"
+
+    truncated = max_rows is not None and df.height > max_rows
+    table_df = df.head(max_rows) if truncated else df
+    header = "| " + " | ".join(table_df.columns) + " |"
+    separator = "| " + " | ".join("---" for _ in table_df.columns) + " |"
+    rows = ["| " + " | ".join(_format_markdown_value(value) for value in row) + " |" for row in table_df.iter_rows()]
+    markdown = "\n".join([header, separator, *rows])
+    if truncated:
+        markdown += f"\n\n*And {df.height - max_rows} more rows.*"
+    return markdown
+
+
+class HealthCheckMarkdownRenderer:
+    """Render health-check findings as GitHub-flavored Markdown."""
+
+    def __init__(self, analysis: Analysis) -> None:
+        self.analysis = analysis
+
+    def render(
+        self,
+        *,
+        title: str = "ADM Health Check",
+        subtitle: str = "",
+        disclaimer: str = "",
+        active_filter: pl.Expr | None = None,
+        active_threshold_days: int = 30,
+        prediction=None,
+        preaggregates: HealthCheckPreAggregates | None = None,
+    ) -> str:
+        """Render the health-check findings as a markdown document."""
+        preaggregates = preaggregates or self.analysis.compute_health_check_preaggregates(
+            active_filter=active_filter,
+            active_threshold_days=active_threshold_days,
+            prediction=prediction,
+            include_markdown_sections=True,
+        )
+        findings = self.analysis.findings(
+            active_filter=active_filter,
+            active_threshold_days=active_threshold_days,
+            prediction=prediction,
+            preaggregates=preaggregates,
+        )
+        headline = next((finding for finding in findings if finding.category == "summary"), None)
+        body_findings = [finding for finding in findings if finding.category != "summary"]
+
+        lines = [f"# {title}", ""]
+        if subtitle:
+            lines.extend([f"## {subtitle}", ""])
+        if disclaimer:
+            lines.extend([f"> **Disclaimer:** {disclaimer}", ""])
+
+        if headline is not None:
+            lines.extend(["## Summary", "", f"**{headline.title}**", "", headline.detail, ""])
+
+        lines.extend(
+            [
+                "## Key Metrics",
+                "",
+                _markdown_table(
+                    self.analysis._key_metrics_table(
+                        preaggregates.last_data,
+                        findings,
+                        active_filter,
+                        preaggregates=preaggregates,
+                    )
+                ),
+                "",
+            ]
+        )
+
+        estate_sections = self.analysis._estate_snapshot_sections(active_filter, preaggregates=preaggregates)
+        if estate_sections:
+            lines.extend(["## Estate Snapshot", ""])
+            for section_title, section_table in estate_sections:
+                lines.extend([f"### {section_title}", "", _markdown_table(section_table, max_rows=5), ""])
+
+        lines.extend(["## Findings Overview", ""])
+        lines.extend(
+            [
+                "### Findings by Severity",
+                "",
+                _markdown_table(self.analysis._findings_by_severity_table(body_findings)),
+                "",
+            ]
+        )
+        lines.extend(
+            [
+                "### Findings by Category",
+                "",
+                _markdown_table(self.analysis._findings_by_category_table(body_findings), max_rows=10),
+                "",
+            ]
+        )
+
+        if not body_findings:
+            lines.extend(["## Findings", "", "No findings were generated.", ""])
+            return "\n".join(lines).strip() + "\n"
+
+        severity_order: list[Severity] = ["critical", "warning", "info", "success"]
+        section_titles = {
+            "critical": "Critical Findings",
+            "warning": "Warning Findings",
+            "info": "Informational Findings",
+            "success": "Positive Findings",
+        }
+
+        for severity in severity_order:
+            section_findings = [finding for finding in body_findings if finding.severity == severity]
+            if not section_findings:
+                continue
+            lines.extend([f"## {section_titles[severity]}", ""])
+            for finding in section_findings:
+                lines.extend(
+                    [
+                        f"### {finding.title}",
+                        "",
+                        f"- **Category:** `{finding.category}`",
+                        f"- **Severity:** `{finding.severity}`",
+                        "",
+                        finding.detail,
+                    ]
+                )
+                if finding.data:
+                    lines.append("")
+                    lines.append("Supporting data:")
+                    for key, value in finding.data.items():
+                        lines.append(f"- **{key}**: {_format_markdown_value(value)}")
+                lines.append("")
+
+        return "\n".join(lines).strip() + "\n"
+
+    def key_metrics_table(
+        self,
+        last_data: pl.DataFrame,
+        findings: list[Finding],
+        active_filter: pl.Expr | None,
+        *,
+        preaggregates: HealthCheckPreAggregates | None = None,
+    ) -> pl.DataFrame:
+        """Build a compact key-metrics table for markdown output."""
+        if preaggregates is None:
+            preaggregates = self.analysis._build_health_check_preaggregates(active_filter=active_filter)
+
+        avg_auc = next(
+            (finding.data.get("avg_auc") for finding in findings if finding.category == "summary"),
+            None,
+        )
+
+        metrics: list[tuple[str, object]] = [
+            (
+                "Snapshot range",
+                (
+                    f"{preaggregates.date_start:%Y-%m-%d} to {preaggregates.date_end:%Y-%m-%d}"
+                    if preaggregates.date_start is not None and preaggregates.date_end is not None
+                    else None
+                ),
+            ),
+            ("Models (latest snapshot)", preaggregates.total_models),
+            ("Active models", preaggregates.active_models),
+            ("Channels", preaggregates.channel_count),
+            ("Configurations", preaggregates.configuration_count),
+            ("Actions", preaggregates.action_count),
+            ("Treatments", preaggregates.treatment_count),
+            ("Responses", preaggregates.response_count),
+            ("Positives", preaggregates.positive_count),
+            (
+                "Average AUC (latest snapshot)",
+                avg_auc * 100 if isinstance(avg_auc, float) else None,
+            ),
+        ]
+
+        if isinstance(preaggregates.active_avg_auc, float):
+            metrics.append(("Average AUC (active)", preaggregates.active_avg_auc * 100))
+
+        if self.analysis.datamart.predictor_data is not None:
+            metrics.append(("Predictors", preaggregates.predictor_count))
+
+        return pl.DataFrame(
+            {
+                "Metric": [metric for metric, _ in metrics],
+                "Value": [_format_markdown_value(value) for _, value in metrics],
+            }
+        )
+
+    def estate_snapshot_sections(
+        self,
+        active_filter: pl.Expr | None,
+        *,
+        preaggregates: HealthCheckPreAggregates | None = None,
+    ) -> list[tuple[str, pl.DataFrame]]:
+        """Build compact orientation tables for the markdown report."""
+        sections: list[tuple[str, pl.DataFrame]] = []
+        if preaggregates is None:
+            preaggregates = self.analysis._build_health_check_preaggregates(
+                active_filter=active_filter,
+                include_markdown_sections=True,
+            )
+
+        if preaggregates.channel_overview is not None:
+            channel_summary = (
+                preaggregates.channel_overview.filter(
+                    ~(
+                        pl.col("Channel").map_elements(self.analysis._is_invalid_channel_name, return_dtype=pl.Boolean)
+                        | pl.col("Direction").map_elements(
+                            self.analysis._is_invalid_channel_name,
+                            return_dtype=pl.Boolean,
+                        )
+                    )
+                )
+                .select(
+                    "ChannelDirection",
+                    "Responses",
+                    "Positives",
+                    "Performance",
+                    "CTR",
+                    pl.col("Used Actions").alias("Actions"),
+                )
+                .sort("Responses", descending=True)
+            )
+            if channel_summary.height > 0:
+                sections.append(("Top Channels by Responses", channel_summary))
+        elif preaggregates.channel_summary is not None:
+            channel_summary = preaggregates.channel_summary.select(
+                "ChannelDirection", "Responses", "Positives", "Performance", "CTR", "Actions"
+            ).sort("Responses", descending=True)
+            if channel_summary.height > 0:
+                sections.append(("Top Channels by Responses", channel_summary))
+
+        if preaggregates.configuration_summary is not None:
+            configuration_columns = [
+                col
+                for col in [
+                    "Configuration",
+                    "Channel",
+                    "Direction",
+                    "ResponseCount",
+                    "Positives",
+                    "Performance",
+                ]
+                if col in preaggregates.configuration_summary.columns
+            ]
+            configuration_summary = preaggregates.configuration_summary.select(configuration_columns).sort(
+                "ResponseCount", descending=True
+            )
+            if configuration_summary.height > 0:
+                sections.append(("Top Configurations by Responses", configuration_summary))
+
+        if preaggregates.predictor_categories is not None and preaggregates.predictor_categories.height > 0:
+            sections.append(("Predictor Categories", preaggregates.predictor_categories))
+
+        return sections
+
+    @staticmethod
+    def findings_by_severity_table(findings: list[Finding]) -> pl.DataFrame:
+        """Summarize findings by severity."""
+        severity_order = {"critical": 0, "warning": 1, "info": 2, "success": 3}
+        counts: dict[str, int] = {}
+        for finding in findings:
+            counts[finding.severity] = counts.get(finding.severity, 0) + 1
+        rows = sorted(counts.items(), key=lambda item: severity_order[item[0]])
+        return pl.DataFrame({"Severity": [severity for severity, _ in rows], "Count": [count for _, count in rows]})
+
+    @staticmethod
+    def findings_by_category_table(findings: list[Finding]) -> pl.DataFrame:
+        """Summarize findings by category."""
+        counts: dict[str, int] = {}
+        for finding in findings:
+            counts[finding.category] = counts.get(finding.category, 0) + 1
+        rows = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        return pl.DataFrame({"Category": [category for category, _ in rows], "Count": [count for _, count in rows]})

--- a/python/pdstools/adm/Reports.py
+++ b/python/pdstools/adm/Reports.py
@@ -414,7 +414,7 @@ class Reports(LazyNamespace):
             if not keep_temp_files and temp_dir.exists() and temp_dir.is_dir():
                 shutil.rmtree(temp_dir, ignore_errors=True)
 
-    def health_check_agent(
+    def health_check_markdown(
         self,
         name: str | None = None,
         *,
@@ -425,7 +425,7 @@ class Reports(LazyNamespace):
         disclaimer: str = "",
         output_dir: str | PathLike[str] | None = None,
     ) -> Path:
-        """Generate an agent-ready Markdown health check report.
+        """Generate a Markdown health check report.
 
         Unlike :meth:`health_check`, this method does not use Quarto. It renders
         a lightweight GitHub-flavored Markdown document directly from

--- a/python/pdstools/adm/Reports.py
+++ b/python/pdstools/adm/Reports.py
@@ -414,6 +414,72 @@ class Reports(LazyNamespace):
             if not keep_temp_files and temp_dir.exists() and temp_dir.is_dir():
                 shutil.rmtree(temp_dir, ignore_errors=True)
 
+    def health_check_agent(
+        self,
+        name: str | None = None,
+        *,
+        query: QUERY | None = None,
+        prediction: Prediction | None = None,
+        title: str = "ADM Health Check",
+        subtitle: str = "",
+        disclaimer: str = "",
+        output_dir: str | PathLike[str] | None = None,
+    ) -> Path:
+        """Generate an agent-ready Markdown health check report.
+
+        Unlike :meth:`health_check`, this method does not use Quarto. It renders
+        a lightweight GitHub-flavored Markdown document directly from
+        ``dm.analysis.findings()``.
+
+        Parameters
+        ----------
+        name : str, optional
+            Base file name of the report.
+        query : QUERY, optional
+            Extra filter applied to the datamart data before rendering.
+        prediction : Prediction, optional
+            Prediction object to include in the report.
+        title : str, default "ADM Health Check"
+            Title shown at the top of the markdown report.
+        subtitle : str, default ""
+            Optional subtitle shown under the title.
+        disclaimer : str, default ""
+            Optional disclaimer rendered near the top of the report.
+        output_dir : str or path-like, optional
+            Directory where the markdown file will be written. Defaults to the
+            current working directory.
+
+        Returns
+        -------
+        Path
+            The path to the generated markdown file.
+        """
+        target_datamart = self.datamart
+        if query is not None:
+            from .ADMDatamart import ADMDatamart
+
+            target_datamart = ADMDatamart(
+                model_df=self.datamart.model_data,
+                predictor_df=self.datamart.predictor_data,
+                query=query,
+                extract_pyname_keys=False,
+            )
+
+        output_dir_path = Path(output_dir) if output_dir is not None else Path.cwd()
+        output_dir_path.mkdir(parents=True, exist_ok=True)
+        output_filename = get_output_filename(name, "HealthCheck", None, "md")
+        output_path = output_dir_path / output_filename
+        output_path.write_text(
+            target_datamart.analysis.markdown(
+                title=title,
+                subtitle=subtitle,
+                disclaimer=disclaimer,
+                prediction=prediction,
+            ),
+            encoding="utf-8",
+        )
+        return output_path
+
     def excel_report(
         self,
         name: str | PathLike[str] = Path("Tables.xlsx"),

--- a/python/pdstools/adm/Reports.py
+++ b/python/pdstools/adm/Reports.py
@@ -462,6 +462,11 @@ class Reports(LazyNamespace):
             The path to the generated markdown file.
         """
         target_datamart = self.datamart
+        if query is not None and preaggregates is not None:
+            raise ValueError(
+                "health_check_markdown() does not support passing both query and preaggregates; "
+                "preaggregates must match the filtered datamart scope."
+            )
         if query is not None:
             from .ADMDatamart import ADMDatamart
 

--- a/python/pdstools/adm/Reports.py
+++ b/python/pdstools/adm/Reports.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from ..prediction.Prediction import Prediction
     from .ADMDatamart import ADMDatamart
+    from .Analysis import HealthCheckPreAggregates
 
 logger = logging.getLogger(__name__)
 
@@ -420,6 +421,7 @@ class Reports(LazyNamespace):
         *,
         query: QUERY | None = None,
         prediction: Prediction | None = None,
+        preaggregates: HealthCheckPreAggregates | None = None,
         title: str = "ADM Health Check",
         subtitle: str = "",
         disclaimer: str = "",
@@ -439,6 +441,11 @@ class Reports(LazyNamespace):
             Extra filter applied to the datamart data before rendering.
         prediction : Prediction, optional
             Prediction object to include in the report.
+        preaggregates : HealthCheckPreAggregates, optional
+            Reusable precomputed summaries produced by
+            ``dm.analysis.compute_health_check_preaggregates()``. When
+            provided, the markdown report reuses them instead of recomputing
+            the same health-check summaries.
         title : str, default "ADM Health Check"
             Title shown at the top of the markdown report.
         subtitle : str, default ""
@@ -475,6 +482,7 @@ class Reports(LazyNamespace):
                 subtitle=subtitle,
                 disclaimer=disclaimer,
                 prediction=prediction,
+                preaggregates=preaggregates,
             ),
             encoding="utf-8",
         )

--- a/python/pdstools/prediction/Prediction.py
+++ b/python/pdstools/prediction/Prediction.py
@@ -92,6 +92,7 @@ class Prediction:
         df: pl.LazyFrame,
         *,
         query: QUERY | None = None,
+        _materialize_validated: bool = True,
     ):
         """Initialize the Prediction class.
 
@@ -107,11 +108,16 @@ class Prediction:
         """
         self.plot = PredictionPlots(prediction=self)
 
-        validated = self._validate_prediction_data(df)
+        validated = self._validate_prediction_data(df, materialize=_materialize_validated)
         self.predictions = cdh_utils._apply_query(validated, query)
 
     @classmethod
-    def _validate_prediction_data(cls, df: pl.LazyFrame) -> pl.LazyFrame:
+    def _validate_prediction_data(
+        cls,
+        df: pl.LazyFrame,
+        *,
+        materialize: bool = True,
+    ) -> pl.LazyFrame:
         """Normalize raw prediction snapshot data into the standard shape.
 
         Filters to ``pyModelType == "PREDICTION"``, renames the raw
@@ -123,23 +129,20 @@ class Prediction:
         Returns the resulting LazyFrame; does not mutate ``df``.
         """
         prepped = (
-            (
-                df.filter(pl.col.pyModelType == "PREDICTION")
-                .with_columns(
-                    Performance=pl.col("pyValue").cast(pl.Float32, strict=False),
-                )
-                .rename(
-                    {
-                        "pyPositives": "Positives",
-                        "pyNegatives": "Negatives",
-                        "pyCount": "ResponseCount",
-                    },
-                )
+            df.filter(pl.col.pyModelType == "PREDICTION")
+            .with_columns(
+                Performance=pl.col("pyValue").cast(pl.Float32, strict=False),
             )
-            # collect/lazy hopefully helps to zoom in into issues
-            .collect()
-            .lazy()
+            .rename(
+                {
+                    "pyPositives": "Positives",
+                    "pyNegatives": "Negatives",
+                    "pyCount": "ResponseCount",
+                },
+            )
         )
+        if materialize:
+            prepped = prepped.collect().lazy()
         prepped = cls._normalize_performance_scale(prepped)
         prepped = cls._parse_snapshot_time(prepped)
 
@@ -436,7 +439,7 @@ class Prediction:
             cache_file_prefix + "prediction_data",
             cache_directory=cache_directory,
         )
-        return cls(prediction_data, query=query)
+        return cls(prediction_data, query=query, _materialize_validated=False)
 
     @classmethod
     def from_databricks_view(

--- a/python/pdstools/prediction/Prediction.py
+++ b/python/pdstools/prediction/Prediction.py
@@ -204,10 +204,11 @@ class Prediction:
         """Normalize Performance from Pega's 50-100 scale to 0.5-1.0 scale."""
         if "Performance" not in df.collect_schema().names():
             return df
-        perf_max = df.select(pl.col("Performance").max()).collect().item()
-        if perf_max is not None and perf_max > 1.0:
-            df = df.with_columns(Performance=pl.col("Performance") / 100.0)
-        return df
+        return df.with_columns(
+            Performance=pl.when(pl.col("Performance").max() > 1.0)
+            .then(pl.col("Performance") / 100.0)
+            .otherwise(pl.col("Performance"))
+        )
 
     @staticmethod
     def _parse_snapshot_time(df: pl.LazyFrame) -> pl.LazyFrame:
@@ -511,7 +512,7 @@ class Prediction:
             )
         )
 
-        return cls(prediction_data, query=query)
+        return cls(prediction_data, query=query, _materialize_validated=False)
 
     def save_data(self, path: os.PathLike | str = ".") -> os.PathLike | None:
         """Cache predictions to a file.

--- a/python/pdstools/reports/HealthCheck.qmd
+++ b/python/pdstools/reports/HealthCheck.qmd
@@ -196,16 +196,12 @@ else:
 # not been updated for a while. We set a threshold date based on the last
 # date in the data.
 
-active_models_threshold_date_expr = (
-    pl.col("LastUpdate").max() - datetime.timedelta(days=threshold_updated_days)
-) #.dt.truncate("1mo")
-active_models_filter_expr = (
-    pl.col("LastUpdate") > active_models_threshold_date_expr
-).fill_null(True)
-
-active_models_threshold_date_string = datamart.model_data.select(
-    active_models_threshold_date_expr.dt.strftime("%v")
-).collect().item().strip()
+active_models_filter_expr = datamart.analysis.health_check_active_filter(
+    active_threshold_days=threshold_updated_days
+)
+active_models_threshold_date_string = datamart.analysis.health_check_active_threshold_date_string(
+    active_threshold_days=threshold_updated_days
+)
 ```
 
 This document gives a global overview of the Adaptive models and (if available) the predictors of the models. It is generated from a Python markdown (Quarto) file in the [Pega Data Scientist Tools](https://github.com/pegasystems/pega-datascientist-tools). PDS Tools is open-source software and comes without guarantees.
@@ -277,16 +273,11 @@ In a typical Next Best Action Designer setup, treatments for a channels are mode
 
 ```{python}
 df_channel_overview = (
-    datamart.aggregates.summary_by_channel(
+    datamart.aggregates.channel_overview(
         query=active_models_filter_expr,
-        format_flags=True
-    )
-    .drop(
+    ).drop(
         [
-            "ChannelDirectionGroup",
             "ChannelDirection",
-            "DateRange Min",
-            "DateRange Max",
             # Great KPI but this table currently is over
             # the whole period, so there's no added info
             # in New Actions. Would be different if we report
@@ -294,7 +285,6 @@ df_channel_overview = (
             # "New Actions",
         ]
     )
-    .collect()
 )
 ```
 
@@ -990,24 +980,13 @@ There are **{last_data.filter(active_models_filter_expr).select(pl.col("ModelID"
 In the standard configuration there is one Adaptive model per treatment/action for a configuration.
 
 ```{python}
-model_overview = datamart.aggregates.summary_by_configuration(query=active_models_filter_expr)
+model_overview = datamart.aggregates.configuration_overview(
+    query=active_models_filter_expr
+)
 
 display(
     report_utils.create_metric_gttable(
-        model_overview.with_columns(
-            NBAD=pl.when(pl.col("usesNBAD").is_null())
-            .then(pl.lit("?"))
-            .when(pl.col("usesNBAD"))
-            .then(pl.lit("Yes"))
-            .otherwise(pl.lit("No")),
-            AGB=pl.when(pl.col("usesAGB").is_null())
-            .then(pl.lit("?"))
-            .when(pl.col("usesAGB"))
-            .then(pl.lit("Yes"))
-            .otherwise(pl.lit("No")),
-        )
-        .drop("usesNBAD", "usesAGB")
-        .collect(),
+        model_overview,
         title="Model Overview",
         subtitle=f"models updated since {active_models_threshold_date_string}",
         column_to_metric={
@@ -1493,9 +1472,10 @@ If predictors perform poorly across all models, that may be because of data sour
 ```{python}
 if datamart.predictor_data is not None:
     bad_predictors = (
-        datamart.aggregates.predictors_global_overview(query=active_models_filter_expr)
+        datamart.aggregates.global_predictor_overview(
+            query=active_models_filter_expr
+        )
         .filter(pl.col("Mean") < (MetricLimits.minimum("ModelPerformance")*100))
-        .collect()
     )
     # responses_column_index = bad_predictors.columns.index("Response Count")
 
@@ -1702,61 +1682,10 @@ For the full list of models, export the data into an Excel sheet from Pega or fr
 All below lists are guidance. With new treatments/actions being introduced regularly, you would expect a small percentage of the models to be at their initial stages, but that percentage should be small.
 
 ```{python}
-maturity_criteria = {
-    "Number of models in last snapshot": True,
-    f"Models that have never been used (responses = 0)": (
-        pl.col("ResponseCount") < MetricLimits.minimum("TotalResponseCount")
-    ),
-    f"Models that have been used (responses > 0) but never received a positive response": (
-        (pl.col("Positives") < MetricLimits.minimum("TotalPositiveCount"))
-        & (pl.col("ResponseCount") >= MetricLimits.minimum("TotalResponseCount"))
-    ),
-    f"Models that are still in an immature phase of learning (positives < {int(MetricLimits.best_practice_min('TotalPositiveCount'))})": (
-        (pl.col("Positives") < MetricLimits.best_practice_min("TotalPositiveCount"))
-        & (pl.col("Positives") >= MetricLimits.minimum("TotalPositiveCount"))
-    ),
-    "Models that have received sufficient responses but are still at their minimum performance (AUC = 50)": (
-        (pl.col("Performance") == 0.5)
-        & (
-            pl.col("Positives")
-            >= MetricLimits.best_practice_min("TotalPositiveCount")
-        )
-    ),
-    f"Models that have received sufficient responses but still have a low performance (AUC < {MetricLimits.minimum('ModelPerformance')})": (
-        (pl.col("Performance") > 0.5)
-        & (pl.col("Performance") < MetricLimits.minimum("ModelPerformance"))
-        & (
-            pl.col("Positives")
-            >= MetricLimits.best_practice_min("TotalPositiveCount")
-        )
-    ),
-    f"Models with sufficient positive responses (≥ {int(MetricLimits.best_practice_min('TotalPositiveCount'))}) and a decent performance (≥ {MetricLimits.minimum('ModelPerformance')})": (
-        (pl.col("Performance") >= MetricLimits.minimum("ModelPerformance"))
-        & (
-            pl.col("Positives")
-            >= MetricLimits.best_practice_min("TotalPositiveCount")
-        )
-    ),
-}
-
-maturity_overview = pl.concat(
-    [
-        last_data.filter(active_models_filter_expr)
-        .group_by(None)
-        .agg(
-            pl.lit(name).alias("Category"),
-            pl.col("Name").filter(filter_expression).len().alias("Number of Models"),
-            (
-                cdh_utils.weighted_average_polars(
-                    pl.col("Performance").filter(filter_expression),
-                    pl.col("ResponseCount").filter(filter_expression),
-                )
-                * 100.0
-            ).alias("Average Performance"),
-        )
-        .drop("literal")
-        for name, filter_expression in maturity_criteria.items()
-    ]
+maturity_criteria = datamart.analysis.health_check_maturity_criteria()
+maturity_overview = datamart.analysis.health_check_maturity_overview(
+    last_data=last_data,
+    active_filter=active_models_filter_expr,
 )
 
 display(
@@ -1816,7 +1745,7 @@ else:
         pl.concat(
             [
                 datamart.model_data.group_by(by).agg(
-                    pl.lit(name).alias("Category"),
+                    pl.lit(label).alias("Category"),
                     pl.col("Name").filter(filter_expression).len().alias("Number of Models"),
                     (
                         cdh_utils.weighted_average_polars(
@@ -1826,7 +1755,7 @@ else:
                         * 100.0
                     ).alias("Average Performance"),
                 )
-                for name, filter_expression in maturity_criteria.items()
+                for _, label, filter_expression in maturity_criteria
             ]
         )
         .with_columns(pl.concat_str(facet.split("/"), separator="/").alias(facet))

--- a/python/tests/adm/test_Analysis.py
+++ b/python/tests/adm/test_Analysis.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import polars as pl
 import pytest
+from polars.testing import assert_frame_equal
 from pdstools import ADMDatamart, datasets
 from pdstools.adm.Analysis import (
     Analysis,
@@ -14,6 +15,8 @@ from pdstools.adm.Analysis import (
     _format_markdown_value,
     _gini,
 )
+from pdstools.utils import cdh_utils
+from pdstools.utils.metric_limits import MetricLimits
 
 
 def _make_dm(rows: list[dict]) -> ADMDatamart:
@@ -399,13 +402,14 @@ class TestAnalysisNamespace:
 
     def test_estate_snapshot_sections_handle_aggregate_failures(self, sample_dm):
         with (
+            patch.object(sample_dm.aggregates, "channel_overview", side_effect=RuntimeError("boom")),
             patch.object(sample_dm.analysis, "_health_check_channel_summary", side_effect=RuntimeError("boom")),
             patch.object(
-                sample_dm.analysis,
-                "_health_check_configuration_summary",
+                sample_dm.aggregates,
+                "configuration_overview",
                 side_effect=RuntimeError("boom"),
             ),
-            patch.object(sample_dm.aggregates, "predictors_global_overview", side_effect=RuntimeError("boom")),
+            patch.object(sample_dm.aggregates, "global_predictor_overview", side_effect=RuntimeError("boom")),
         ):
             sections = sample_dm.analysis._estate_snapshot_sections(pl.lit(True))
         assert sections == []
@@ -439,6 +443,201 @@ class TestAnalysisNamespace:
         title, table = sections[0]
         assert title == "Top Configurations by Responses"
         assert table.columns == ["Configuration", "ResponseCount", "Positives", "Performance"]
+
+    def test_estate_snapshot_sections_exclude_invalid_channel_rows(self, analysis):
+        preaggregates = HealthCheckPreAggregates(
+            last_data=_make_last_data([{}]),
+            channel_overview=pl.DataFrame(
+                [
+                    {
+                        "Channel": None,
+                        "Direction": None,
+                        "ChannelDirection": None,
+                        "Configuration": "Cfg0",
+                        "Duration": 1.0,
+                        "isValid": True,
+                        "Issues": 1,
+                        "Groups": 1,
+                        "Actions": 1,
+                        "Used Actions": 1,
+                        "New Actions": 0,
+                        "Treatments": 1,
+                        "Used Treatments": 1,
+                        "usesNBAD": None,
+                        "usesAGB": None,
+                        "Responses": 5000,
+                        "Positives": 100,
+                        "Performance": 0.6,
+                        "CTR": 0.02,
+                        "OmniChannel": None,
+                        "NBAD": "?",
+                        "AGB": "?",
+                    },
+                    {
+                        "Channel": "Web",
+                        "Direction": "Inbound",
+                        "ChannelDirection": "Web/Inbound",
+                        "Configuration": "Cfg1",
+                        "Duration": 1.0,
+                        "isValid": True,
+                        "Issues": 1,
+                        "Groups": 1,
+                        "Actions": 2,
+                        "Used Actions": 2,
+                        "New Actions": 0,
+                        "Treatments": 2,
+                        "Used Treatments": 2,
+                        "usesNBAD": None,
+                        "usesAGB": None,
+                        "Responses": 1000,
+                        "Positives": 50,
+                        "Performance": 0.7,
+                        "CTR": 0.05,
+                        "OmniChannel": 0.8,
+                        "NBAD": "?",
+                        "AGB": "?",
+                    },
+                ]
+            ),
+        )
+
+        sections = analysis._estate_snapshot_sections(pl.lit(True), preaggregates=preaggregates)
+
+        title, table = sections[0]
+        assert title == "Top Channels by Responses"
+        assert table.to_dicts() == [
+            {
+                "ChannelDirection": "Web/Inbound",
+                "Responses": 1000,
+                "Positives": 50,
+                "Performance": 0.7,
+                "CTR": 0.05,
+                "Actions": 2,
+            }
+        ]
+
+    def test_health_check_channel_overview_matches_legacy_quarto_expression(self, sample_dm):
+        active_filter = (
+            pl.col("LastUpdate") > (pl.col("LastUpdate").max() - __import__("datetime").timedelta(days=30))
+        ).fill_null(True)
+
+        shared = sample_dm.aggregates.channel_overview(query=active_filter)
+        legacy = (
+            sample_dm.aggregates.summary_by_channel(
+                query=active_filter,
+                format_flags=True,
+            )
+            .drop(
+                [
+                    "ChannelDirectionGroup",
+                    "DateRange Min",
+                    "DateRange Max",
+                ]
+            )
+            .collect()
+        )
+
+        assert_frame_equal(shared, legacy)
+
+    def test_health_check_active_filter_matches_legacy_expression(self, sample_dm):
+        shared = sample_dm.analysis.health_check_active_filter(active_threshold_days=30)
+        legacy = (
+            pl.col("LastUpdate") > (pl.col("LastUpdate").max() - __import__("datetime").timedelta(days=30))
+        ).fill_null(True)
+
+        shared_ids = sample_dm.model_data.filter(shared).select("ModelID").collect().sort("ModelID")
+        legacy_ids = sample_dm.model_data.filter(legacy).select("ModelID").collect().sort("ModelID")
+
+        assert_frame_equal(shared_ids, legacy_ids)
+
+    def test_health_check_maturity_overview_matches_legacy_quarto_expression(self, analysis):
+        active_filter = analysis.health_check_active_filter(active_threshold_days=30)
+        last_data = analysis._get_last_data()
+        shared = analysis.health_check_maturity_overview(last_data=last_data, active_filter=active_filter)
+
+        min_responses = MetricLimits.minimum("TotalResponseCount")
+        min_positives = MetricLimits.minimum("TotalPositiveCount")
+        bp_min_positives = MetricLimits.best_practice_min("TotalPositiveCount")
+        min_perf = MetricLimits.minimum("ModelPerformance")
+        legacy_criteria = [
+            ("Number of models in last snapshot", pl.lit(True)),
+            ("Models that have never been used (responses = 0)", pl.col("ResponseCount") < min_responses),
+            (
+                "Models that have been used (responses > 0) but never received a positive response",
+                (pl.col("Positives") < min_positives) & (pl.col("ResponseCount") >= min_responses),
+            ),
+            (
+                f"Models that are still in an immature phase of learning (positives < {int(bp_min_positives)})",
+                (pl.col("Positives") < bp_min_positives) & (pl.col("Positives") >= min_positives),
+            ),
+            (
+                "Models that have received sufficient responses but are still at their minimum performance (AUC = 50)",
+                (pl.col("Performance") == 0.5) & (pl.col("Positives") >= bp_min_positives),
+            ),
+            (
+                f"Models that have received sufficient responses but still have a low performance (AUC < {min_perf})",
+                (pl.col("Performance") > 0.5)
+                & (pl.col("Performance") < min_perf)
+                & (pl.col("Positives") >= bp_min_positives),
+            ),
+            (
+                f"Models with sufficient positive responses (≥ {int(bp_min_positives)}) and a decent performance (≥ {min_perf})",
+                (pl.col("Performance") >= min_perf) & (pl.col("Positives") >= bp_min_positives),
+            ),
+        ]
+        legacy = pl.concat(
+            [
+                last_data.lazy()
+                .filter(active_filter)
+                .group_by(None)
+                .agg(
+                    pl.lit(label).alias("Category"),
+                    pl.col("Name").filter(filter_expression).len().alias("Number of Models"),
+                    (
+                        cdh_utils.weighted_average_polars(
+                            pl.col("Performance").filter(filter_expression),
+                            pl.col("ResponseCount").filter(filter_expression),
+                        )
+                        * 100.0
+                    ).alias("Average Performance"),
+                )
+                .drop("literal")
+                .collect()
+                for label, filter_expression in legacy_criteria
+            ]
+        )
+
+        assert_frame_equal(shared, legacy)
+
+    def test_health_check_configuration_overview_matches_legacy_quarto_expression(self, sample_dm):
+        active_filter = sample_dm.analysis.health_check_active_filter(active_threshold_days=30)
+        shared = sample_dm.aggregates.configuration_overview(query=active_filter)
+        legacy = (
+            sample_dm.aggregates.summary_by_configuration(query=active_filter)
+            .with_columns(
+                NBAD=pl.when(pl.col("usesNBAD").is_null())
+                .then(pl.lit("?"))
+                .when(pl.col("usesNBAD"))
+                .then(pl.lit("Yes"))
+                .otherwise(pl.lit("No")),
+                AGB=pl.when(pl.col("usesAGB").is_null())
+                .then(pl.lit("?"))
+                .when(pl.col("usesAGB"))
+                .then(pl.lit("Yes"))
+                .otherwise(pl.lit("No")),
+            )
+            .drop("usesNBAD", "usesAGB")
+            .collect()
+        )
+
+        assert_frame_equal(shared, legacy)
+
+    def test_health_check_predictor_overview_matches_legacy_quarto_expression(self, sample_dm):
+        active_filter = sample_dm.analysis.health_check_active_filter(active_threshold_days=30)
+        shared = sample_dm.aggregates.global_predictor_overview(query=active_filter)
+        legacy = sample_dm.aggregates.predictors_global_overview(query=active_filter).collect()
+
+        assert_frame_equal(shared, legacy)
 
     def test_findings_have_valid_severity(self, analysis):
         for f in analysis.findings():

--- a/python/tests/adm/test_Analysis.py
+++ b/python/tests/adm/test_Analysis.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock, patch
 import polars as pl
 import pytest
 from pdstools import ADMDatamart, datasets
-from pdstools.adm.Analysis import Analysis, Finding, _format_markdown_value, _gini
+from pdstools.adm.Analysis import (
+    Analysis,
+    Finding,
+    HealthCheckPreAggregates,
+    _format_markdown_value,
+    _gini,
+)
 
 
 def _make_dm(rows: list[dict]) -> ADMDatamart:
@@ -216,6 +222,138 @@ class TestAnalysisNamespace:
         markdown = analysis.markdown(disclaimer="Use with caution")
         assert "> **Disclaimer:** Use with caution" in markdown
 
+    def test_compute_health_check_preaggregates_returns_reusable_object(self, analysis):
+        preaggregates = analysis.compute_health_check_preaggregates()
+        assert isinstance(preaggregates, HealthCheckPreAggregates)
+        assert preaggregates.last_data.height > 0
+
+    def test_compute_health_check_preaggregates_builds_minimal_channel_and_config_summaries(self):
+        dm = _make_dm(
+            [
+                {
+                    "ModelID": "m1",
+                    "SnapshotTime": "20250101",
+                    "Configuration": "CfgA",
+                    "Name": "ActionA",
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Positives": 10,
+                    "ResponseCount": 100,
+                    "Performance": 0.60,
+                },
+                {
+                    "ModelID": "m1",
+                    "SnapshotTime": "20250102",
+                    "Configuration": "CfgA",
+                    "Name": "ActionA",
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Positives": 25,
+                    "ResponseCount": 250,
+                    "Performance": 0.65,
+                },
+                {
+                    "ModelID": "m2",
+                    "SnapshotTime": "20250101",
+                    "Configuration": "CfgA",
+                    "Name": "ActionB",
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Positives": 0,
+                    "ResponseCount": 0,
+                    "Performance": 0.70,
+                },
+                {
+                    "ModelID": "m2",
+                    "SnapshotTime": "20250102",
+                    "Configuration": "CfgA",
+                    "Name": "ActionB",
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Positives": 20,
+                    "ResponseCount": 100,
+                    "Performance": 0.80,
+                },
+            ]
+        )
+
+        preaggregates = dm.analysis.compute_health_check_preaggregates(include_markdown_sections=True)
+
+        channel_row = preaggregates.channel_summary.row(0, named=True)
+        assert channel_row["ChannelDirection"] == "Web/Inbound"
+        assert channel_row["Responses"] == 250
+        assert channel_row["Positives"] == 35
+        assert channel_row["Actions"] == 2
+        assert channel_row["CTR"] == pytest.approx(0.14)
+        assert channel_row["Performance"] == pytest.approx(0.675)
+
+        config_row = preaggregates.configuration_summary.row(0, named=True)
+        assert config_row["Configuration"] == "CfgA"
+        assert config_row["Channel"] == "Web"
+        assert config_row["Direction"] == "Inbound"
+        assert config_row["ResponseCount"] == 350
+        assert config_row["Positives"] == 45
+        assert config_row["Performance"] == pytest.approx((0.65 * 250 + 0.80 * 100) / 350)
+
+    def test_compute_health_check_preaggregates_preserves_all_history_taxonomy_counts(self):
+        dm = _make_dm(
+            [
+                {
+                    "ModelID": "m1",
+                    "SnapshotTime": "20250101",
+                    "Configuration": "CfgA",
+                    "Name": "ActionA",
+                    "Treatment": "T1",
+                    "Issue": "Sales",
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                },
+                {
+                    "ModelID": "m1",
+                    "SnapshotTime": "20250102",
+                    "Configuration": "CfgA",
+                    "Name": "ActionA",
+                    "Treatment": "T1",
+                    "Issue": "Sales",
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                },
+                {
+                    "ModelID": "m2",
+                    "SnapshotTime": "20250101",
+                    "Configuration": "CfgB",
+                    "Name": "ActionB",
+                    "Treatment": "T2",
+                    "Issue": "Service",
+                    "Channel": "Email",
+                    "Direction": "Outbound",
+                },
+            ]
+        )
+
+        preaggregates = dm.analysis.compute_health_check_preaggregates(include_markdown_sections=False)
+
+        assert preaggregates.action_count == 2
+        assert preaggregates.treatment_count == 2
+        assert preaggregates.channel_count == 2
+        assert preaggregates.taxonomy_counts["IssueCount"] == 2
+
+    def test_markdown_accepts_preaggregates_without_rebuilding(self, analysis):
+        preaggregates = analysis.compute_health_check_preaggregates()
+        with patch.object(
+            analysis, "compute_health_check_preaggregates", side_effect=RuntimeError("should not rebuild")
+        ):
+            markdown = analysis.markdown(preaggregates=preaggregates)
+        assert markdown.startswith("# ADM Health Check")
+
+    def test_findings_accepts_preaggregates_without_rebuilding(self, analysis):
+        preaggregates = analysis.compute_health_check_preaggregates(include_markdown_sections=False)
+        with patch.object(
+            analysis, "compute_health_check_preaggregates", side_effect=RuntimeError("should not rebuild")
+        ):
+            findings = analysis.findings(preaggregates=preaggregates)
+        assert findings
+
     def test_markdown_handles_summary_only(self, analysis):
         summary = Finding(
             severity="success",
@@ -261,35 +399,46 @@ class TestAnalysisNamespace:
 
     def test_estate_snapshot_sections_handle_aggregate_failures(self, sample_dm):
         with (
-            patch.object(sample_dm.aggregates, "summary_by_channel", side_effect=RuntimeError("boom")),
-            patch.object(sample_dm.aggregates, "summary_by_configuration", side_effect=RuntimeError("boom")),
+            patch.object(sample_dm.analysis, "_health_check_channel_summary", side_effect=RuntimeError("boom")),
+            patch.object(
+                sample_dm.analysis,
+                "_health_check_configuration_summary",
+                side_effect=RuntimeError("boom"),
+            ),
             patch.object(sample_dm.aggregates, "predictors_global_overview", side_effect=RuntimeError("boom")),
         ):
             sections = sample_dm.analysis._estate_snapshot_sections(pl.lit(True))
         assert sections == []
 
     def test_estate_snapshot_sections_include_predictor_categories(self, sample_dm):
-        with patch.object(
-            sample_dm.aggregates,
-            "summary_by_configuration",
-            return_value=pl.DataFrame(
+        sections = sample_dm.analysis._estate_snapshot_sections(pl.lit(True))
+        titles = [title for title, _ in sections]
+        assert "Top Channels by Responses" in titles
+        assert "Top Configurations by Responses" in titles
+        assert "Predictor Categories" in titles
+
+    def test_estate_snapshot_sections_allow_configuration_summary_without_channel_direction(
+        self,
+        analysis,
+    ):
+        preaggregates = HealthCheckPreAggregates(
+            last_data=_make_last_data([{}]),
+            configuration_summary=pl.DataFrame(
                 [
                     {
                         "Configuration": "Cfg1",
-                        "Channel": "Web",
-                        "Direction": "Inbound",
                         "ResponseCount": 1000,
                         "Positives": 50,
                         "Performance": 0.65,
                     }
                 ]
-            ).lazy(),
-        ):
-            sections = sample_dm.analysis._estate_snapshot_sections(pl.lit(True))
-        titles = [title for title, _ in sections]
-        assert "Top Channels by Responses" in titles
-        assert "Top Configurations by Responses" in titles
-        assert "Predictor Categories" in titles
+            ),
+        )
+
+        sections = analysis._estate_snapshot_sections(pl.lit(True), preaggregates=preaggregates)
+        title, table = sections[0]
+        assert title == "Top Configurations by Responses"
+        assert table.columns == ["Configuration", "ResponseCount", "Positives", "Performance"]
 
     def test_findings_have_valid_severity(self, analysis):
         for f in analysis.findings():
@@ -357,8 +506,7 @@ class TestChannelChecks:
             ),
         )
         results, _, _ = dm.analysis._check_channels(pl.lit(True))
-        critical = [f for f in results if f.severity == "critical"]
-        assert any("zero responses" in f.title for f in critical)
+        assert any("zero responses" in f.title for f in results)
 
 
 class TestConfigurationChecks:
@@ -1173,21 +1321,23 @@ class TestHeadlineFinding:
         deterministic.
         """
         return patch.object(
-            dm.aggregates,
-            "summary_by_channel",
+            dm.analysis,
+            "_health_check_channel_summary",
             return_value=pl.DataFrame(
                 [
                     {
+                        "ChannelDirection": "Web/Inbound",
                         "Channel": "Web",
                         "Direction": "Inbound",
                         "Responses": 100000,
                         "Positives": 5000,
                         "Performance": 0.72,
+                        "CTR": 0.05,
+                        "Actions": 20,
                         "OmniChannel": 0.5,
-                        "Configuration": "WebConfig",
                     }
                 ]
-            ).lazy(),
+            ),
         )
 
     def test_clean_data_emits_healthy_headline(self):

--- a/python/tests/adm/test_Analysis.py
+++ b/python/tests/adm/test_Analysis.py
@@ -1185,7 +1185,7 @@ class TestCheckPredictionsEdgeCases:
                     "Direction": "Inbound",
                     "Lift": -0.05,
                     "Prediction": "WebPrediction",
-                    "ControlPercentage": 0.02,
+                    "ControlPercentage": 2.0,
                 }
             ]
         )
@@ -1200,7 +1200,7 @@ class TestCheckPredictionsEdgeCases:
                     "Direction": "Inbound",
                     "Lift": 0.03,
                     "Prediction": "WebPrediction",
-                    "ControlPercentage": 0.02,
+                    "ControlPercentage": 2.0,
                 }
             ]
         )
@@ -1215,7 +1215,7 @@ class TestCheckPredictionsEdgeCases:
                     "Direction": "Inbound",
                     "Lift": float("nan"),
                     "Prediction": "PredictInboundDefaultPropensity",
-                    "ControlPercentage": 0.02,
+                    "ControlPercentage": 2.0,
                 }
             ]
         )
@@ -1230,12 +1230,13 @@ class TestCheckPredictionsEdgeCases:
                     "Direction": "Inbound",
                     "Lift": float("nan"),
                     "Prediction": "WebPrediction",
-                    "ControlPercentage": 0.15,
+                    "ControlPercentage": 15.0,
                 }
             ]
         )
         results = analysis._check_predictions(pred)
         assert any("Large control group" in f.title for f in results)
+        assert any("15.0%" in f.title for f in results)
 
     def test_small_control_group_is_info(self, analysis):
         pred = self._make_prediction_mock(
@@ -1245,12 +1246,13 @@ class TestCheckPredictionsEdgeCases:
                     "Direction": "Inbound",
                     "Lift": float("nan"),
                     "Prediction": "WebPrediction",
-                    "ControlPercentage": 0.001,
+                    "ControlPercentage": 0.1,
                 }
             ]
         )
         results = analysis._check_predictions(pred)
         assert any("Very small control group" in f.title for f in results)
+        assert any("0.1%" in f.title for f in results)
 
 
 # ── Additional coverage: exception paths & IH predictor branches ─────────

--- a/python/tests/adm/test_Analysis.py
+++ b/python/tests/adm/test_Analysis.py
@@ -787,6 +787,15 @@ class TestCheckModelMaturityEdgeCases:
         results = analysis._check_model_maturity(last_data)
         assert any("AUC=50" in f.title for f in results)
 
+    def test_mature_low_performance_covers_values_just_above_auc50(self, analysis):
+        from pdstools.utils.metric_limits import MetricLimits
+
+        bp_min = int(MetricLimits.best_practice_min("TotalPositiveCount"))
+        rows = [{"Positives": bp_min + 100, "Performance": 0.51, "ResponseCount": 5000}]
+        last_data = _make_last_data(rows)
+        results = analysis._check_model_maturity(last_data)
+        assert any("low performance" in f.title for f in results)
+
     def test_suspiciously_high_performance(self, analysis):
         from pdstools.utils.metric_limits import MetricLimits
 

--- a/python/tests/adm/test_Analysis.py
+++ b/python/tests/adm/test_Analysis.py
@@ -1,0 +1,1254 @@
+"""Tests for the ADM Analysis module (automated health check findings)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import polars as pl
+import pytest
+from pdstools import ADMDatamart, datasets
+from pdstools.adm.Analysis import Analysis, Finding, _gini
+
+
+def _make_dm(rows: list[dict]) -> ADMDatamart:
+    """Build a minimal ADMDatamart from a list of row dicts."""
+    schema_casts = {
+        "Performance": pl.Float64,
+        "SuccessRate": pl.Float64,
+        "Positives": pl.Int64,
+        "ResponseCount": pl.Int64,
+    }
+    defaults = {
+        "ModelID": "m1",
+        "SnapshotTime": "20250101",
+        "Performance": 0.7,
+        "SuccessRate": 0.05,
+        "Positives": 500,
+        "ResponseCount": 10000,
+        "Channel": "Web",
+        "Direction": "Inbound",
+        "Configuration": "WebConfig",
+        "Name": "ActionA",
+        "Treatment": "T1",
+        "Issue": "Sales",
+        "Group": "Cards",
+    }
+    merged = [{**defaults, **r} for r in rows]
+    df = (
+        pl.DataFrame(merged)
+        .lazy()
+        .with_columns(
+            pl.col("SnapshotTime").str.to_datetime("%Y%m%d"),
+            *[pl.col(c).cast(t) for c, t in schema_casts.items() if c in pl.DataFrame(merged).columns],
+        )
+    )
+    return ADMDatamart(model_df=df)
+
+
+def _make_last_data(rows: list[dict]) -> pl.DataFrame:
+    """Build a last_data DataFrame for direct maturity/distribution checks."""
+    defaults = {
+        "ModelID": "m1",
+        "ResponseCount": 10000,
+        "Positives": 500,
+        "Performance": 0.7,
+        "SuccessRate": 0.05,
+        "Name": "ActionA",
+        "Configuration": "Config1",
+        "Channel": "Web",
+        "Direction": "Inbound",
+        "Issue": "Sales",
+        "Group": "Cards",
+    }
+    return pl.DataFrame([{**defaults, **r} for r in rows])
+
+
+@pytest.fixture
+def sample_dm():
+    """Fixture using CDH sample data."""
+    return datasets.cdh_sample()
+
+
+@pytest.fixture
+def analysis(sample_dm):
+    """Fixture providing the Analysis namespace."""
+    return sample_dm.analysis
+
+
+# ── Finding dataclass ───────────────────────────────────────────────────
+
+
+class TestFinding:
+    def test_creation(self):
+        f = Finding(
+            severity="warning",
+            category="model",
+            title="Test finding",
+            detail="Some detail here.",
+        )
+        assert f.severity == "warning"
+        assert f.category == "model"
+        assert f.data == {}
+
+    def test_creation_with_data(self):
+        f = Finding(
+            severity="critical",
+            category="channel",
+            title="Test",
+            detail="Detail",
+            data={"count": 42},
+        )
+        assert f.data["count"] == 42
+
+    def test_str_representation(self):
+        f = Finding(
+            severity="critical",
+            category="channel",
+            title="Bad channel",
+            detail="Detail",
+        )
+        result = str(f)
+        assert "❌" in result
+        assert "channel" in result
+        assert "Bad channel" in result
+
+    def test_frozen(self):
+        f = Finding(
+            severity="info",
+            category="model",
+            title="Test",
+            detail="Detail",
+        )
+        with pytest.raises(AttributeError):
+            f.severity = "critical"
+
+
+# ── Gini helper ─────────────────────────────────────────────────────────
+
+
+class TestGini:
+    def test_equal_distribution(self):
+        assert _gini([1, 1, 1, 1]) == pytest.approx(0.0, abs=0.01)
+
+    def test_perfect_inequality(self):
+        assert _gini([0, 0, 0, 100]) == pytest.approx(0.75, abs=0.01)
+
+    def test_empty(self):
+        assert _gini([]) == 0.0
+
+    def test_all_zeros(self):
+        assert _gini([0, 0, 0]) == 0.0
+
+    def test_with_nans(self):
+        result = _gini([1.0, float("nan"), 2.0, 3.0])
+        assert 0 < result < 1
+
+    def test_single_value(self):
+        assert _gini([42]) == 0.0
+
+
+# ── Analysis namespace ──────────────────────────────────────────────────
+
+
+class TestAnalysisNamespace:
+    def test_accessible_on_datamart(self, sample_dm):
+        assert hasattr(sample_dm, "analysis")
+        assert isinstance(sample_dm.analysis, Analysis)
+
+    def test_findings_returns_list(self, analysis):
+        results = analysis.findings()
+        assert isinstance(results, list)
+        assert all(isinstance(f, Finding) for f in results)
+
+    def test_findings_sorted_by_severity(self, analysis):
+        results = analysis.findings()
+        if len(results) > 1:
+            severity_order = {"critical": 0, "warning": 1, "info": 2, "success": 3}
+            orders = [severity_order[f.severity] for f in results]
+            assert orders == sorted(orders)
+
+    def test_findings_start_with_summary_headline(self, analysis):
+        results = analysis.findings()
+        assert results
+        assert results[0].category == "summary"
+        assert results[0].title.startswith("Health:")
+        assert "verdict" in results[0].data
+
+    def test_markdown_renders_summary_and_sections(self, analysis):
+        markdown = analysis.markdown(title="Custom Health Check", subtitle="Sample")
+        assert markdown.startswith("# Custom Health Check")
+        assert "## Sample" in markdown
+        assert "## Summary" in markdown
+        assert "## Key Metrics" in markdown
+        assert "## Estate Snapshot" in markdown
+        assert "## Findings Overview" in markdown
+        assert (
+            "## Critical Findings" in markdown
+            or "## Warning Findings" in markdown
+            or "## Informational Findings" in markdown
+        )
+
+    def test_markdown_renders_compact_tables(self, analysis):
+        markdown = analysis.markdown()
+        assert "| Metric | Value |" in markdown
+        assert "| Severity | Count |" in markdown
+        assert "| Category | Count |" in markdown
+        assert "### Top Channels by Responses" in markdown
+        assert "### Top Configurations by Responses" in markdown
+
+    def test_markdown_includes_disclaimer(self, analysis):
+        markdown = analysis.markdown(disclaimer="Use with caution")
+        assert "> **Disclaimer:** Use with caution" in markdown
+
+    def test_findings_have_valid_severity(self, analysis):
+        for f in analysis.findings():
+            assert f.severity in ("critical", "warning", "info", "success")
+
+    def test_findings_have_valid_category(self, analysis):
+        valid_categories = {
+            "channel",
+            "model",
+            "predictor",
+            "prediction",
+            "taxonomy",
+            "response_distribution",
+            "trend",
+            "configuration",
+            "data_quality",
+            "summary",
+        }
+        for f in analysis.findings():
+            assert f.category in valid_categories
+
+    def test_findings_have_nonempty_title_and_detail(self, analysis):
+        findings = analysis.findings()
+        assert findings, "Expected sample data to produce at least one finding"
+        for f in findings:
+            assert f.title, "Finding has empty title"
+            assert f.detail, "Finding has empty detail"
+
+
+# ── Individual check methods ────────────────────────────────────────────
+
+
+class TestChannelChecks:
+    def test_no_crash_with_sample_data(self, analysis):
+        active_filter = pl.lit(True)
+        results, _, _ = analysis._check_channels(active_filter)
+        assert isinstance(results, list)
+
+    def test_detects_zero_responses(self):
+        dm = ADMDatamart(
+            model_df=pl.DataFrame(
+                {
+                    "ModelID": ["m1"],
+                    "SnapshotTime": ["20250101"],
+                    "Performance": [0.5],
+                    "SuccessRate": [0.0],
+                    "Positives": [0],
+                    "ResponseCount": [0],
+                    "Channel": ["Web"],
+                    "Direction": ["Inbound"],
+                    "Configuration": ["TestConfig"],
+                    "Name": ["A"],
+                    "Treatment": ["T1"],
+                    "Issue": ["Sales"],
+                    "Group": ["Cards"],
+                }
+            )
+            .lazy()
+            .with_columns(
+                pl.col("SnapshotTime").str.to_datetime("%Y%m%d"),
+                pl.col("Performance").cast(pl.Float64),
+                pl.col("SuccessRate").cast(pl.Float64),
+                pl.col("Positives").cast(pl.Int64),
+                pl.col("ResponseCount").cast(pl.Int64),
+            ),
+        )
+        results, _, _ = dm.analysis._check_channels(pl.lit(True))
+        critical = [f for f in results if f.severity == "critical"]
+        assert any("zero responses" in f.title for f in critical)
+
+
+class TestConfigurationChecks:
+    def test_no_crash_with_sample_data(self, analysis, sample_dm):
+        last_data = analysis._get_last_data()
+        results = analysis._check_configurations(last_data)
+        assert isinstance(results, list)
+
+
+class TestModelMaturityChecks:
+    def test_no_crash_with_sample_data(self, analysis):
+        last_data = analysis._get_last_data()
+        results = analysis._check_model_maturity(last_data)
+        assert isinstance(results, list)
+        buckets = {f.data.get("bucket") for f in results if "bucket" in f.data}
+        assert "mature_decent" in buckets
+
+    def test_detects_model_categories(self, analysis):
+        last_data = analysis._get_last_data()
+        results = analysis._check_model_maturity(last_data)
+        titles = " ".join(f.title for f in results)
+        # Should report on mature models with decent performance
+        assert "mature" in titles.lower() or "performance" in titles.lower()
+
+
+class TestTaxonomyChecks:
+    def test_no_crash_with_sample_data(self, analysis):
+        results = analysis._check_taxonomy()
+        assert isinstance(results, list)
+
+
+class TestResponseDistributionChecks:
+    def test_no_crash_with_sample_data(self, analysis):
+        last_data = analysis._get_last_data()
+        results = analysis._check_response_distribution(last_data, pl.lit(True))
+        assert isinstance(results, list)
+
+
+class TestTrendChecks:
+    def test_no_crash_with_sample_data(self, analysis):
+        results = analysis._check_trends()
+        assert isinstance(results, list)
+
+
+class TestPredictorChecks:
+    def test_no_crash_with_sample_data(self, analysis, sample_dm):
+        if sample_dm.predictor_data is not None:
+            results = analysis._check_predictors()
+            assert isinstance(results, list)
+            assert results
+            assert all(f.category == "predictor" for f in results)
+
+
+class TestPredictionChecks:
+    def test_no_crash_without_prediction(self, analysis):
+        # When no prediction data, findings should be called without it
+        results = analysis.findings(prediction=None)
+        assert isinstance(results, list)
+
+    def test_findings_with_mock_prediction(self, analysis):
+        # Covers line 144: `results.extend(self._check_predictions(prediction))`
+        pred = MagicMock()
+        pred.summary_by_channel.return_value = pl.DataFrame(
+            [
+                {
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Lift": float("nan"),
+                    "Prediction": "WebPred",
+                    "ControlPercentage": 0.02,
+                }
+            ]
+        ).lazy()
+        results = analysis.findings(prediction=pred)
+        assert isinstance(results, list)
+
+
+# ── Integration test ────────────────────────────────────────────────────
+
+
+class TestFullAnalysis:
+    def test_full_findings_with_sample_data(self, sample_dm):
+        """End-to-end test: run all findings on sample data."""
+        results = sample_dm.analysis.findings()
+        categories = {f.category for f in results}
+        assert "summary" in categories
+        assert {"model", "taxonomy"}.issubset(categories)
+
+        # Every finding should be well-formed
+        for f in results:
+            assert f.title
+            assert f.detail
+            assert isinstance(f.data, dict)
+
+        # Headline summary should be first.
+        assert results[0].category == "summary"
+
+    def test_custom_active_filter(self, sample_dm):
+        results = sample_dm.analysis.findings(
+            active_filter=pl.col("ResponseCount") > 100,
+        )
+        assert isinstance(results, list)
+
+    def test_custom_threshold_days(self, sample_dm):
+        results = sample_dm.analysis.findings(active_threshold_days=7)
+        assert isinstance(results, list)
+
+
+# ── Edge case: _check_channels ──────────────────────────────────────────
+
+
+class TestCheckChannelsEdgeCases:
+    def test_exception_in_summary_returns_empty(self):
+        dm = _make_dm([{}])
+        with patch.object(dm.aggregates, "summary_by_channel", side_effect=RuntimeError("boom")):
+            results, dead_count, has_low_perf = dm.analysis._check_channels(pl.lit(True))
+        assert results == []
+        assert dead_count == 0
+        assert has_low_perf is False
+
+    def test_zero_positives_with_responses(self):
+        mock_row = {
+            "Channel": "Web",
+            "Direction": "Inbound",
+            "Responses": 1000,
+            "Positives": 0,
+            "Performance": 0.65,
+            "OmniChannel": 0.8,
+            "Configuration": "C1",
+        }
+        dm = _make_dm([{}])
+        with patch.object(dm.aggregates, "summary_by_channel", return_value=pl.DataFrame([mock_row]).lazy()):
+            results, _, _ = dm.analysis._check_channels(pl.lit(True))
+        critical = [f for f in results if f.severity == "critical"]
+        assert any("zero positives" in f.title for f in critical)
+
+    def test_low_performance_rag_red(self):
+        # Performance on 50-100 scale; below 52 triggers RAG=RED.
+        mock_row = {
+            "Channel": "Web",
+            "Direction": "Inbound",
+            "Responses": 5000,
+            "Positives": 200,
+            "Performance": 50.0,
+            "OmniChannel": 0.8,
+            "Configuration": "C1",
+        }
+        dm = _make_dm([{}])
+        with patch.object(dm.aggregates, "summary_by_channel", return_value=pl.DataFrame([mock_row]).lazy()):
+            results, _, has_low_perf = dm.analysis._check_channels(pl.lit(True))
+        warnings = [f for f in results if f.severity == "warning" and f.category == "channel"]
+        assert any("low average performance" in f.title for f in warnings)
+        assert has_low_perf is True
+
+    def test_low_omni_channel_overlap(self):
+        dm = _make_dm([{"ResponseCount": 5000, "Positives": 200}])
+        # Patch summary to return a row with low OmniChannel
+        mock_row = {
+            "Channel": "Web",
+            "Direction": "Inbound",
+            "Responses": 5000,
+            "Positives": 200,
+            "Performance": 0.65,
+            "OmniChannel": 0.1,
+            "Configuration": "C1",
+        }
+        mock_df = pl.DataFrame([mock_row])
+        with patch.object(dm.aggregates, "summary_by_channel", return_value=mock_df.lazy()):
+            results, _, _ = dm.analysis._check_channels(pl.lit(True))
+        assert any("low cross-channel overlap" in f.title for f in results)
+
+    def test_many_configurations_per_channel(self):
+        # Per-channel "has N model configurations" was removed as a finding —
+        # it was almost always emitted on dead channels and added no
+        # actionable information. The check should now produce *no* findings
+        # for an active channel that simply has many configurations.
+        mock_row = {
+            "Channel": "Web",
+            "Direction": "Inbound",
+            "Responses": 5000,
+            "Positives": 200,
+            "Performance": 0.65,
+            "OmniChannel": 0.8,
+            "Configuration": "C1, C2, C3",  # 3 configs → ≥2 commas
+        }
+        dm = _make_dm([{}])
+        mock_df = pl.DataFrame([mock_row])
+        with patch.object(dm.aggregates, "summary_by_channel", return_value=mock_df.lazy()):
+            results, _, _ = dm.analysis._check_channels(pl.lit(True))
+        assert not any("model configurations" in f.title for f in results)
+
+
+# ── Edge case: _check_configurations ────────────────────────────────────
+
+
+class TestCheckConfigurationsEdgeCases:
+    def test_default_config_name_flagged(self):
+        dm = _make_dm([{"Configuration": "Default_Inbound_Model"}])
+        last_data = _make_last_data(
+            [{"Configuration": "Default_Inbound_Model", "ResponseCount": 1000, "Positives": 50}]
+        )
+        results = dm.analysis._check_configurations(last_data)
+        assert any("Default configuration" in f.title for f in results)
+        assert any(f.severity == "warning" for f in results)
+
+    def test_config_with_responses_but_no_positives(self):
+        dm = _make_dm([{"Configuration": "MyConfig", "ResponseCount": 1000, "Positives": 0}])
+        last_data = _make_last_data([{"Configuration": "MyConfig", "ResponseCount": 1000, "Positives": 0}])
+        results = dm.analysis._check_configurations(last_data)
+        assert any("no positives" in f.title for f in results)
+        assert any(f.severity == "critical" for f in results)
+
+    def test_stale_historical_configuration_not_flagged(self):
+        dm = _make_dm(
+            [
+                {"Configuration": "Default_Inbound_Model", "SnapshotTime": "20240101"},
+                {"Configuration": "ActiveConfig", "SnapshotTime": "20250101"},
+            ]
+        )
+        last_data = _make_last_data([{"Configuration": "ActiveConfig", "ResponseCount": 1000, "Positives": 50}])
+        results = dm.analysis._check_configurations(last_data)
+        assert not any("Default configuration" in f.title for f in results)
+
+
+# ── Edge case: _check_model_maturity ────────────────────────────────────
+
+
+class TestCheckModelMaturityEdgeCases:
+    def test_empty_last_data_returns_empty(self, analysis):
+        empty = pl.DataFrame(
+            {
+                "ResponseCount": pl.Series([], dtype=pl.Int64),
+                "Positives": pl.Series([], dtype=pl.Int64),
+                "Performance": pl.Series([], dtype=pl.Float64),
+            }
+        )
+        results = analysis._check_model_maturity(empty)
+        assert results == []
+
+    def test_high_pct_unused_is_warning(self, analysis):
+        # >20% unused → warning
+        rows = [{"ResponseCount": 0}] * 25 + [{"ResponseCount": 1000, "Positives": 100}] * 75
+        last_data = _make_last_data(rows)
+        results = analysis._check_model_maturity(last_data)
+        unused_findings = [f for f in results if "never been used" in f.title]
+        assert any(f.severity == "warning" for f in unused_findings)
+
+    def test_low_pct_unused_is_info(self, analysis):
+        # <20% unused → info
+        rows = [{"ResponseCount": 0}] * 5 + [{"ResponseCount": 1000, "Positives": 100}] * 95
+        last_data = _make_last_data(rows)
+        results = analysis._check_model_maturity(last_data)
+        unused_findings = [f for f in results if "never been used" in f.title]
+        assert any(f.severity == "info" for f in unused_findings)
+
+    def test_high_pct_no_positives_is_warning(self, analysis):
+        # >10% have responses but zero positives → warning
+        rows = [{"ResponseCount": 1000, "Positives": 0}] * 15 + [{"ResponseCount": 1000, "Positives": 100}] * 85
+        last_data = _make_last_data(rows)
+        results = analysis._check_model_maturity(last_data)
+        findings = [f for f in results if "zero positives" in f.title]
+        assert any(f.severity == "warning" for f in findings)
+
+    def test_low_pct_no_positives_is_info(self, analysis):
+        # <10% have responses but zero positives → info
+        rows = [{"ResponseCount": 1000, "Positives": 0}] * 5 + [{"ResponseCount": 1000, "Positives": 100}] * 95
+        last_data = _make_last_data(rows)
+        results = analysis._check_model_maturity(last_data)
+        findings = [f for f in results if "zero positives" in f.title]
+        assert any(f.severity == "info" for f in findings)
+
+    def test_mature_stuck_at_auc50(self, analysis):
+        from pdstools.utils.metric_limits import MetricLimits
+
+        bp_min = int(MetricLimits.best_practice_min("TotalPositiveCount"))
+        rows = [{"Positives": bp_min + 100, "Performance": 0.5, "ResponseCount": 5000}]
+        last_data = _make_last_data(rows)
+        results = analysis._check_model_maturity(last_data)
+        assert any("AUC=50" in f.title for f in results)
+
+    def test_suspiciously_high_performance(self, analysis):
+        from pdstools.utils.metric_limits import MetricLimits
+
+        bp_min = int(MetricLimits.best_practice_min("TotalPositiveCount"))
+        rows = [{"Positives": bp_min + 100, "Performance": 0.99, "ResponseCount": 5000}]
+        last_data = _make_last_data(rows)
+        results = analysis._check_model_maturity(last_data)
+        assert any("suspiciously high" in f.title for f in results)
+
+
+# ── Edge case: _check_model_performance ─────────────────────────────────
+
+
+class TestCheckModelPerformanceEdgeCases:
+    def test_exception_in_active_filter_returns_empty(self, analysis):
+        last_data = _make_last_data([{}])
+        bad_filter = pl.col("nonexistent_column") > 0
+        results, avg = analysis._check_model_performance(last_data, bad_filter)
+        assert results == []
+        assert avg is None
+
+    def test_empty_active_data_returns_empty(self, analysis):
+        last_data = _make_last_data([{}])
+        results, avg = analysis._check_model_performance(last_data, pl.lit(False))
+        assert results == []
+        assert avg is None
+
+
+# ── Edge case: _check_taxonomy ───────────────────────────────────────────
+
+
+class TestCheckTaxonomyEdgeCases:
+    def test_rag_red_produces_warning(self):
+        # 1 action → almost certainly RED for ActionCount
+        dm = _make_dm([{"Name": "OnlyAction"}])
+        with patch("pdstools.adm.Analysis.MetricLimits.evaluate_metric_rag", return_value="RED"):
+            results = dm.analysis._check_taxonomy()
+        warnings = [f for f in results if f.severity == "warning" and f.category == "taxonomy"]
+        # One warning per evaluated taxonomy metric (actions, treatments,
+        # issues, channels) → 4 with the minimal 1-action dataset.
+        assert len(warnings) == 4
+        # Titles now state direction + the violated bound rather than a
+        # generic "outside recommended limits" string.
+        for f in warnings:
+            assert (
+                ("below minimum" in f.title)
+                or ("above maximum" in f.title)
+                or ("below recommended" in f.title)
+                or ("above typical range" in f.title)
+            )
+
+    def test_rag_amber_produces_info(self):
+        dm = _make_dm([{"Name": "OnlyAction"}])
+        with patch("pdstools.adm.Analysis.MetricLimits.evaluate_metric_rag", return_value="AMBER"):
+            results = dm.analysis._check_taxonomy()
+        infos = [f for f in results if f.severity == "info" and f.category == "taxonomy"]
+        assert len(infos) == 4
+        for f in infos:
+            assert ("below recommended" in f.title) or ("above typical range" in f.title)
+
+
+# ── Edge case: _check_response_distribution ─────────────────────────────
+
+
+class TestCheckResponseDistributionEdgeCases:
+    def test_exception_in_active_filter_returns_empty(self, analysis):
+        last_data = _make_last_data([{}])
+        results = analysis._check_response_distribution(last_data, pl.col("nonexistent") > 0)
+        assert results == []
+
+    def test_empty_active_data_returns_empty(self, analysis):
+        last_data = _make_last_data([{}])
+        results = analysis._check_response_distribution(last_data, pl.lit(False))
+        assert results == []
+
+    def test_high_gini_responses_warning(self, analysis):
+        # One model gets all responses → Gini near 1
+        rows = [{"ResponseCount": 1_000_000, "Positives": 50000, "Performance": 0.7}] + [
+            {"ResponseCount": 1, "Positives": 0, "Performance": 0.5}
+        ] * 20
+        last_data = _make_last_data(rows)
+        results = analysis._check_response_distribution(last_data, pl.lit(True))
+        assert any("highly skewed" in f.title and f.severity == "warning" for f in results)
+
+    def test_moderate_gini_responses_info(self, analysis):
+        # Moderate concentration (Gini ~0.75-0.89)
+        rows = [{"ResponseCount": 10000, "Positives": 500, "Performance": 0.7}] + [
+            {"ResponseCount": 100, "Positives": 5, "Performance": 0.7}
+        ] * 10
+        last_data = _make_last_data(rows)
+        results = analysis._check_response_distribution(last_data, pl.lit(True))
+        moderate = [f for f in results if "moderately skewed" in f.title]
+        # May or may not trigger depending on exact Gini — just verify no crash
+        assert isinstance(results, list)
+        for f in moderate:
+            assert f.severity == "info"
+
+    def test_zero_total_responses_skips_low_auc_check(self, analysis):
+        rows = [{"ResponseCount": 0, "Positives": 0, "Performance": 0.5}] * 5
+        last_data = _make_last_data(rows)
+        results = analysis._check_response_distribution(last_data, pl.lit(True))
+        # Must not crash; no low-auc-volume finding possible
+        assert not any("response volume" in f.title.lower() and "low-performance" in f.title.lower() for f in results)
+
+    def test_majority_volume_at_low_auc_warning(self, analysis):
+        # >50% responses from models with AUC < 0.55
+        rows = [{"ResponseCount": 10000, "Positives": 100, "Performance": 0.50}] * 6 + [
+            {"ResponseCount": 1000, "Positives": 200, "Performance": 0.75}
+        ] * 4
+        last_data = _make_last_data(rows)
+        results = analysis._check_response_distribution(last_data, pl.lit(True))
+        assert any("low-performance models" in f.title and f.severity == "warning" for f in results)
+
+    def test_notable_volume_at_low_auc_info(self, analysis):
+        # 30-50% responses from models with AUC < 0.55
+        rows = [{"ResponseCount": 4000, "Positives": 100, "Performance": 0.50}] * 1 + [
+            {"ResponseCount": 6000, "Positives": 500, "Performance": 0.75}
+        ] * 1
+        last_data = _make_last_data(rows)
+        results = analysis._check_response_distribution(last_data, pl.lit(True))
+        notable = [f for f in results if "low-performance models" in f.title]
+        assert isinstance(notable, list)  # may or may not trigger; must not crash
+
+
+# ── Edge case: _check_trends ─────────────────────────────────────────────
+
+
+class TestCheckTrendsEdgeCases:
+    def test_single_snapshot_returns_empty(self):
+        dm = _make_dm([{}])  # one row → one snapshot
+        results = dm.analysis._check_trends()
+        assert results == []
+
+    def test_exception_getting_snapshots_returns_empty(self):
+        dm = _make_dm([{}])
+        with patch.object(dm.model_data, "select", side_effect=RuntimeError("boom")):
+            results = dm.analysis._check_trends()
+        assert results == []
+
+    def test_performance_decline_triggers_warning(self):
+        # Build 6 weekly snapshots with AUC dropping sharply
+        rows = []
+        dates = ["20250101", "20250108", "20250115", "20250122", "20250129", "20250205"]
+        perfs = [0.75, 0.74, 0.73, 0.65, 0.63, 0.61]  # >3 AUC drop first→second half
+        for date, perf in zip(dates, perfs, strict=True):
+            rows.append({"SnapshotTime": date, "Performance": perf, "ResponseCount": 1000, "Positives": 50})
+        dm = _make_dm(rows)
+        results = dm.analysis._check_trends()
+        assert any("declining" in f.title and f.severity == "warning" for f in results)
+
+    def test_response_volume_drop_triggers_warning(self):
+        rows = []
+        dates = ["20250101", "20250108", "20250115", "20250122", "20250129", "20250205"]
+        resps = [10000, 10000, 10000, 1000, 1000, 1000]  # 90% drop
+        for date, resp in zip(dates, resps, strict=True):
+            rows.append({"SnapshotTime": date, "Performance": 0.70, "ResponseCount": resp, "Positives": 50})
+        dm = _make_dm(rows)
+        results = dm.analysis._check_trends()
+        assert any("Response volume dropped" in f.title for f in results)
+
+
+# ── Edge case: _check_predictions ────────────────────────────────────────
+
+
+class TestCheckPredictionsEdgeCases:
+    def _make_prediction_mock(self, rows: list[dict]):
+        """Build a mock Prediction with controlled summary_by_channel output."""
+        mock = MagicMock()
+        mock.summary_by_channel.return_value = pl.DataFrame(rows).lazy()
+        return mock
+
+    def test_no_lift_column_returns_empty(self, analysis):
+        pred = self._make_prediction_mock([{"Channel": "Web", "Direction": "Inbound"}])
+        results = analysis._check_predictions(pred)
+        assert results == []
+
+    def test_exception_in_summary_returns_empty(self, analysis):
+        pred = MagicMock()
+        pred.summary_by_channel.side_effect = RuntimeError("no data")
+        results = analysis._check_predictions(pred)
+        assert results == []
+
+    def test_negative_lift_is_critical(self, analysis):
+        pred = self._make_prediction_mock(
+            [
+                {
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Lift": -0.05,
+                    "Prediction": "WebPrediction",
+                    "ControlPercentage": 0.02,
+                }
+            ]
+        )
+        results = analysis._check_predictions(pred)
+        assert any(f.severity == "critical" and "Negative" in f.title for f in results)
+
+    def test_very_low_lift_is_warning(self, analysis):
+        pred = self._make_prediction_mock(
+            [
+                {
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Lift": 0.03,
+                    "Prediction": "WebPrediction",
+                    "ControlPercentage": 0.02,
+                }
+            ]
+        )
+        results = analysis._check_predictions(pred)
+        assert any(f.severity == "warning" and "low engagement lift" in f.title for f in results)
+
+    def test_default_prediction_name_is_warning(self, analysis):
+        pred = self._make_prediction_mock(
+            [
+                {
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Lift": float("nan"),
+                    "Prediction": "PredictInboundDefaultPropensity",
+                    "ControlPercentage": 0.02,
+                }
+            ]
+        )
+        results = analysis._check_predictions(pred)
+        assert any("Default prediction name" in f.title for f in results)
+
+    def test_large_control_group_is_warning(self, analysis):
+        pred = self._make_prediction_mock(
+            [
+                {
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Lift": float("nan"),
+                    "Prediction": "WebPrediction",
+                    "ControlPercentage": 0.15,
+                }
+            ]
+        )
+        results = analysis._check_predictions(pred)
+        assert any("Large control group" in f.title for f in results)
+
+    def test_small_control_group_is_info(self, analysis):
+        pred = self._make_prediction_mock(
+            [
+                {
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Lift": float("nan"),
+                    "Prediction": "WebPrediction",
+                    "ControlPercentage": 0.001,
+                }
+            ]
+        )
+        results = analysis._check_predictions(pred)
+        assert any("Very small control group" in f.title for f in results)
+
+
+# ── Additional coverage: exception paths & IH predictor branches ─────────
+
+
+class TestCheckTaxonomyExceptionPaths:
+    def test_n_unique_values_exception_continues(self):
+        """Lines 544-545: exception in n_unique_values loop is swallowed."""
+        dm = _make_dm([{}])
+        with patch("pdstools.adm.Analysis.report_utils.n_unique_values", side_effect=RuntimeError("boom")):
+            results = dm.analysis._check_taxonomy()
+        assert isinstance(results, list)  # must not crash
+
+    def test_predictor_count_exception_is_swallowed(self):
+        """Lines 619-620: exception in predictor-count block is swallowed."""
+        dm = datasets.cdh_sample()
+        assert dm.predictor_data is not None
+        # combined_data must work for schema check (line 529) but fail on .filter() (line 594)
+        mock_cd = MagicMock()
+        mock_cd.collect_schema.return_value.names.return_value = ["Configuration", "EntryType", "PredictorName"]
+        mock_cd.filter.side_effect = RuntimeError("boom")
+        dm.combined_data = mock_cd
+        results = dm.analysis._check_taxonomy()
+        assert isinstance(results, list)
+
+
+class TestCheckTrendsMoreEdgeCases:
+    def test_exception_in_trend_collection_returns_empty(self):
+        """Lines 755-756: exception during trend aggregation returns empty."""
+        rows = [
+            {"SnapshotTime": d, "Performance": 0.70, "ResponseCount": 1000, "Positives": 50}
+            for d in ["20250101", "20250108", "20250115", "20250122"]
+        ]
+        dm = _make_dm(rows)
+        with patch("pdstools.adm.Analysis.cdh_utils.weighted_average_polars", side_effect=RuntimeError("boom")):
+            results = dm.analysis._check_trends()
+        assert results == []
+
+    def test_channel_with_fewer_than_3_snapshots_is_skipped(self):
+        """Line 761: per-channel trend with < 3 rows is skipped gracefully."""
+        rows = []
+        for date in ["20250101", "20250108", "20250115", "20250122"]:
+            rows.append(
+                {
+                    "SnapshotTime": date,
+                    "Channel": "Web",
+                    "Direction": "Inbound",
+                    "Performance": 0.70,
+                    "ResponseCount": 1000,
+                    "Positives": 50,
+                }
+            )
+        for date in ["20250101", "20250108"]:
+            rows.append(
+                {
+                    "SnapshotTime": date,
+                    "Channel": "Email",
+                    "Direction": "Outbound",
+                    "Performance": 0.70,
+                    "ResponseCount": 1000,
+                    "Positives": 50,
+                }
+            )
+        dm = _make_dm(rows)
+        results = dm.analysis._check_trends()
+        assert isinstance(results, list)
+
+
+class TestCheckPredictorsExceptionPaths:
+    def test_poor_predictor_exception_is_swallowed(self, analysis):
+        """Lines 861-862: exception in poor-predictor block is swallowed."""
+        with patch.object(analysis.datamart, "combined_data", new=None):
+            results = analysis._check_predictors()
+        assert isinstance(results, list)
+
+
+class TestCheckPredictorsIHBranches:
+    def _make_dm_with_ih(self, ih_count: int, non_ih_count: int) -> ADMDatamart:
+        """ADMDatamart with controlled IH predictor counts in combined_data."""
+        dm = _make_dm([{}])
+        rows = [
+            {
+                "Configuration": "C1",
+                "EntryType": "Predictor",
+                "PredictorCategory": "IH",
+                "PredictorName": f"IH_{i}",
+                "Performance": 0.55,
+                "ResponseCount": 1000,
+                "MissingPct": 0.0,
+            }
+            for i in range(ih_count)
+        ] + [
+            {
+                "Configuration": "C1",
+                "EntryType": "Predictor",
+                "PredictorCategory": "Customer",
+                "PredictorName": f"C_{i}",
+                "Performance": 0.55,
+                "ResponseCount": 1000,
+                "MissingPct": 0.0,
+            }
+            for i in range(non_ih_count)
+        ]
+        dm.combined_data = pl.DataFrame(rows).lazy()
+        return dm
+
+    def test_more_than_100_ih_predictors_is_info(self):
+        """Line 919: IH_count > 100 produces an info finding."""
+        dm = self._make_dm_with_ih(ih_count=110, non_ih_count=10)
+        results = dm.analysis._check_predictors()
+        assert any("IH predictors" in f.title and f.severity == "info" for f in results)
+
+    def test_zero_ih_predictors_is_info(self):
+        """Lines 937-955: IH_count == 0 produces an info finding."""
+        dm = self._make_dm_with_ih(ih_count=0, non_ih_count=10)
+        results = dm.analysis._check_predictors()
+        assert any("no IH predictors" in f.title and f.severity == "info" for f in results)
+
+
+# ── New behaviour: data-quality, collapsed dead channels, headline,
+#     tiered AUC, mature-low-perf bucket, taxonomy-direction titles,
+#     configuration channel hint. ─────────────────────────────────────────
+
+
+class TestDataQualityCheck:
+    """Detect malformed Channel/Direction values (e.g. "/", "/Inbound")."""
+
+    def test_invalid_channel_predicate(self):
+        for v in [None, "", " ", "/", "/Inbound", "Web/", "  /  "]:
+            assert Analysis._is_invalid_channel_name(v), v
+        for v in ["Web", "Email", "VZW-MFA-IOS"]:
+            assert not Analysis._is_invalid_channel_name(v), v
+
+    def test_invalid_pair_emits_finding_with_exact_count(self):
+        # Three garbage rows + one good row. Data-quality finding should
+        # report a model count of exactly 3, not 4.
+        rows = [
+            {"ModelID": "m1", "Channel": "", "Direction": ""},
+            {"ModelID": "m2", "Channel": "", "Direction": "Inbound"},
+            {"ModelID": "m3", "Channel": "/", "Direction": "Inbound"},
+            {"ModelID": "m4", "Channel": "Web", "Direction": "Inbound"},
+        ]
+        dm = _make_dm(rows)
+        findings, invalid = dm.analysis._check_data_quality()
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.severity == "critical"
+        assert f.category == "data_quality"
+        assert f.data["model_count"] == 3
+        assert f.data["invalid_count"] == 3
+        # The good "Web/Inbound" pair is not in the invalid set.
+        assert "Web/Inbound" not in invalid
+        assert "/Inbound" in invalid
+
+    def test_clean_data_emits_no_finding(self):
+        rows = [{"ModelID": "m1", "Channel": "Web", "Direction": "Inbound"}]
+        dm = _make_dm(rows)
+        findings, invalid = dm.analysis._check_data_quality()
+        assert findings == []
+        assert invalid == set()
+
+    def test_invalid_channels_excluded_from_channel_check(self):
+        # Mix: one valid dead channel + one invalid dead channel. The
+        # invalid pair should not show up in the collapsed dead-channel
+        # finding.
+        rows = [
+            {"ModelID": "m1", "Channel": "", "Direction": "", "ResponseCount": 0, "Positives": 0},
+            {"ModelID": "m2", "Channel": "Web", "Direction": "Inbound", "ResponseCount": 0, "Positives": 0},
+        ]
+        dm = _make_dm(rows)
+        findings, dead_count, _ = dm.analysis._check_channels(pl.lit(True), invalid_channels={"/"})
+        # Dead-channel finding should mention only Web/Inbound.
+        dead = [f for f in findings if "zero responses" in f.title]
+        assert len(dead) == 1
+        assert dead[0].data["channels"] == ["Web/Inbound"]
+        assert dead_count == 1
+
+
+class TestCollapsedDeadChannels:
+    """Multiple dead channels are aggregated into one finding per direction."""
+
+    def test_multiple_dead_channels_collapse_per_direction(self):
+        # Mock summary_by_channel directly: 3 dead Inbound, 1 dead Outbound,
+        # 1 live channel. Should yield 2 collapsed findings.
+        summary_rows = [
+            {
+                "Channel": "A",
+                "Direction": "Inbound",
+                "Responses": 0,
+                "Positives": 0,
+                "Performance": None,
+                "OmniChannel": None,
+                "Configuration": "C1",
+            },
+            {
+                "Channel": "B",
+                "Direction": "Inbound",
+                "Responses": 0,
+                "Positives": 0,
+                "Performance": None,
+                "OmniChannel": None,
+                "Configuration": "C2",
+            },
+            {
+                "Channel": "C",
+                "Direction": "Inbound",
+                "Responses": 0,
+                "Positives": 0,
+                "Performance": None,
+                "OmniChannel": None,
+                "Configuration": "C3",
+            },
+            {
+                "Channel": "X",
+                "Direction": "Outbound",
+                "Responses": 0,
+                "Positives": 0,
+                "Performance": None,
+                "OmniChannel": None,
+                "Configuration": "C4",
+            },
+            {
+                "Channel": "Live",
+                "Direction": "Inbound",
+                "Responses": 5000,
+                "Positives": 200,
+                "Performance": 0.65,
+                "OmniChannel": 0.5,
+                "Configuration": "C5",
+            },
+        ]
+        dm = _make_dm([{}])
+        with patch.object(dm.aggregates, "summary_by_channel", return_value=pl.DataFrame(summary_rows).lazy()):
+            findings, dead_count, _ = dm.analysis._check_channels(pl.lit(True))
+        dead = [f for f in findings if "zero responses" in f.title]
+        assert len(dead) == 2
+        assert dead_count == 4
+        by_dir = {f.data["direction"]: f for f in dead}
+        assert by_dir["Inbound"].data["dead_channel_count"] == 3
+        assert by_dir["Outbound"].data["dead_channel_count"] == 1
+        assert "1 Outbound channel has" in by_dir["Outbound"].title
+        assert "3 Inbound channels have" in by_dir["Inbound"].title
+
+    def test_truncates_long_channel_list_with_more_suffix(self):
+        summary_rows = [
+            {
+                "Channel": f"Ch{i}",
+                "Direction": "Inbound",
+                "Responses": 0,
+                "Positives": 0,
+                "Performance": None,
+                "OmniChannel": None,
+                "Configuration": f"C{i}",
+            }
+            for i in range(8)
+        ]
+        dm = _make_dm([{}])
+        with patch.object(dm.aggregates, "summary_by_channel", return_value=pl.DataFrame(summary_rows).lazy()):
+            findings, dead_count, _ = dm.analysis._check_channels(pl.lit(True))
+        dead = next(f for f in findings if "zero responses" in f.title)
+        assert "+3 more" in dead.title
+        # All 8 channel names are kept on the finding's data payload.
+        assert len(dead.data["channels"]) == 8
+        assert dead_count == 8
+
+
+class TestHeadlineFinding:
+    """findings() prepends a single 🩺 [summary] headline."""
+
+    def _stub_clean_summary(self, dm: ADMDatamart):
+        """Patch summary_by_channel to one healthy channel.
+
+        Synthetic ADMDatamart input doesn't always populate the
+        Inbound/Outbound response split that summary_by_channel relies on,
+        so we feed a known-good summary directly to keep these tests
+        deterministic.
+        """
+        return patch.object(
+            dm.aggregates,
+            "summary_by_channel",
+            return_value=pl.DataFrame(
+                [
+                    {
+                        "Channel": "Web",
+                        "Direction": "Inbound",
+                        "Responses": 100000,
+                        "Positives": 5000,
+                        "Performance": 0.72,
+                        "OmniChannel": 0.5,
+                        "Configuration": "WebConfig",
+                    }
+                ]
+            ).lazy(),
+        )
+
+    def test_clean_data_emits_healthy_headline(self):
+        rows = [{"ResponseCount": 5000, "Positives": 500, "Performance": 0.72, "ModelID": f"m{i}"} for i in range(20)]
+        dm = _make_dm(rows)
+        with (
+            self._stub_clean_summary(dm),
+            patch.object(dm.analysis, "_check_configurations", return_value=[]),
+            patch.object(dm.analysis, "_check_model_maturity", return_value=[]),
+            patch.object(dm.analysis, "_check_taxonomy", return_value=[]),
+            patch.object(dm.analysis, "_check_response_distribution", return_value=[]),
+            patch.object(dm.analysis, "_check_trends", return_value=[]),
+        ):
+            all_findings = dm.analysis.findings()
+        head = all_findings[0]
+        assert head.category == "summary"
+        assert head.severity == "success"
+        assert "HEALTHY" in head.title
+        assert head.data["pct_never_used"] == 0.0
+        assert head.data["dead_channel_count"] == 0
+
+    def test_high_unused_triggers_mixed_headline(self):
+        rows = [{"ResponseCount": 0, "Positives": 0, "Performance": 0.5, "ModelID": f"u{i}"} for i in range(30)]
+        rows += [{"ResponseCount": 5000, "Positives": 500, "Performance": 0.72, "ModelID": f"m{i}"} for i in range(70)]
+        dm = _make_dm(rows)
+        with self._stub_clean_summary(dm):
+            head = dm.analysis.findings()[0]
+        assert head.category == "summary"
+        assert head.severity == "warning"
+        assert "MIXED" in head.title
+        assert "30% of models never used" in head.title
+
+    def test_headline_severity_matches_body_findings(self):
+        rows = [{"ResponseCount": 0, "Positives": 0, "Performance": 0.5, "ModelID": f"u{i}"} for i in range(30)]
+        rows += [{"ResponseCount": 5000, "Positives": 500, "Performance": 0.72, "ModelID": f"m{i}"} for i in range(70)]
+        dm = _make_dm(rows)
+        with self._stub_clean_summary(dm):
+            findings = dm.analysis.findings()
+        head, body = findings[0], findings[1:]
+        assert head.severity == max(
+            (f.severity for f in body),
+            key=lambda severity: {"critical": 3, "warning": 2, "info": 1, "success": 0}[severity],
+        )
+
+    def test_summary_uses_stethoscope_icon(self):
+        rows = [{"ResponseCount": 5000, "Positives": 500, "Performance": 0.72}]
+        dm = _make_dm(rows)
+        with self._stub_clean_summary(dm):
+            head = dm.analysis.findings()[0]
+        assert str(head).startswith("🩺 [summary]")
+
+
+class TestTieredAUCFinding:
+    """Overall-AUC finding scales severity with the tier."""
+
+    def _avg_finding(self, perf):
+        rows = [{"ResponseCount": 5000, "Positives": 500, "Performance": perf, "ModelID": "m1"}]
+        dm = _make_dm(rows)
+        ld = dm.analysis._get_last_data()
+        results, avg = dm.analysis._check_model_performance(ld, pl.lit(True))
+        assert len(results) == 1
+        return results[0], avg
+
+    def test_low_auc_is_critical(self):
+        f, _ = self._avg_finding(0.55)
+        assert f.severity == "critical"
+        assert "low" in f.title
+
+    def test_borderline_auc_is_warning(self):
+        f, _ = self._avg_finding(0.60)
+        assert f.severity == "warning"
+        assert "borderline" in f.title
+
+    def test_healthy_auc_is_info(self):
+        f, _ = self._avg_finding(0.65)
+        assert f.severity == "info"
+        assert "healthy" in f.title
+
+    def test_strong_auc_is_success(self):
+        f, _ = self._avg_finding(0.78)
+        assert f.severity == "success"
+        assert "strong" in f.title
+
+
+class TestMaturityBuckets:
+    """Visible maturity buckets are mutually exclusive but intentionally
+    not exhaustive — mature low-performance models are surfaced through
+    dedicated count findings (low_performance, stuck_at_50) rather than
+    a percentage bucket, so the visible totals can sum to less than 100 %."""
+
+    def test_buckets_are_disjoint(self):
+        rows = (
+            [{"ModelID": f"u{i}", "ResponseCount": 0, "Positives": 0, "Performance": 0.5} for i in range(10)]
+            + [{"ModelID": f"z{i}", "ResponseCount": 100, "Positives": 0, "Performance": 0.5} for i in range(7)]
+            + [{"ModelID": f"i{i}", "ResponseCount": 1000, "Positives": 50, "Performance": 0.6} for i in range(13)]
+            + [{"ModelID": f"l{i}", "ResponseCount": 5000, "Positives": 500, "Performance": 0.50} for i in range(11)]
+            + [{"ModelID": f"d{i}", "ResponseCount": 5000, "Positives": 500, "Performance": 0.72} for i in range(19)]
+        )
+        dm = _make_dm(rows)
+        ld = dm.analysis._get_last_data()
+        results = dm.analysis._check_model_maturity(ld)
+        counts = {f.data["bucket"]: f.data["count"] for f in results if "bucket" in f.data}
+        # Four visible buckets — `mature_low_perf` is intentionally not a
+        # bucket; those models are reported via low-performance / stuck
+        # warnings instead.
+        assert counts == {
+            "never_used": 10,
+            "responses_no_positives": 7,
+            "immature": 13,
+            "mature_decent": 19,
+        }
+        # Total visible coverage is 49 of 60 — the 11 mature low-perf
+        # models are deliberately excluded from the percentage view.
+        assert sum(counts.values()) == 49
+
+
+class TestTaxonomyThresholdInTitle:
+    """Taxonomy findings now state the violated bound and direction."""
+
+    def test_below_minimum_title(self):
+        dm = _make_dm([{"Treatment": "T1"}])  # 1 treatment → < hard min 2
+        results = dm.analysis._check_taxonomy()
+        treatment = [f for f in results if "treatment" in f.title.lower()]
+        assert any("below minimum" in f.title for f in treatment)
+
+
+class TestConfigurationHasNoPositivesIncludesChannel:
+    def test_channel_hint_appended(self):
+        dm = _make_dm(
+            [
+                {
+                    "Configuration": "Push_Click_Through_Rate",
+                    "Channel": "Push",
+                    "Direction": "Outbound",
+                    "ResponseCount": 1000,
+                    "Positives": 0,
+                }
+            ]
+        )
+        last_data = _make_last_data(
+            [
+                {
+                    "Configuration": "Push_Click_Through_Rate",
+                    "Channel": "Push",
+                    "Direction": "Outbound",
+                    "ResponseCount": 1000,
+                    "Positives": 0,
+                }
+            ]
+        )
+        results = dm.analysis._check_configurations(last_data)
+        f = next(f for f in results if "no positives" in f.title)
+        assert "(Push/Outbound)" in f.title
+        assert f.data["channel"] == "Push"
+        assert f.data["direction"] == "Outbound"

--- a/python/tests/adm/test_Analysis.py
+++ b/python/tests/adm/test_Analysis.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import polars as pl
 import pytest
 from pdstools import ADMDatamart, datasets
-from pdstools.adm.Analysis import Analysis, Finding, _gini
+from pdstools.adm.Analysis import Analysis, Finding, _format_markdown_value, _gini
 
 
 def _make_dm(rows: list[dict]) -> ADMDatamart:
@@ -147,6 +147,22 @@ class TestGini:
         assert _gini([42]) == 0.0
 
 
+class TestMarkdownFormattingHelpers:
+    def test_format_markdown_value_handles_common_types(self):
+        assert _format_markdown_value(None) == "N/A"
+        assert _format_markdown_value(True) == "Yes"
+        assert _format_markdown_value(False) == "No"
+        assert _format_markdown_value(0.0) == "0"
+        assert _format_markdown_value(12.3456) == "12.35"
+        assert _format_markdown_value(0.123456) == "0.1235"
+        assert _format_markdown_value("a|b\nc") == "a\\|b c"
+
+    def test_format_markdown_value_handles_lists(self):
+        value = _format_markdown_value([1, 2, 3, 4, 5, 6])
+        assert value.startswith("1, 2, 3")
+        assert "(+1 more)" in value
+
+
 # ── Analysis namespace ──────────────────────────────────────────────────
 
 
@@ -199,6 +215,81 @@ class TestAnalysisNamespace:
     def test_markdown_includes_disclaimer(self, analysis):
         markdown = analysis.markdown(disclaimer="Use with caution")
         assert "> **Disclaimer:** Use with caution" in markdown
+
+    def test_markdown_handles_summary_only(self, analysis):
+        summary = Finding(
+            severity="success",
+            category="summary",
+            title="Health: HEALTHY - no issues detected",
+            detail="Everything looks good.",
+            data={"avg_auc": 0.71},
+        )
+        last_data = _make_last_data([{}])
+        with (
+            patch.object(analysis, "findings", return_value=[summary]),
+            patch.object(analysis, "_get_last_data", return_value=last_data),
+            patch.object(analysis, "_estate_snapshot_sections", return_value=[]),
+        ):
+            markdown = analysis.markdown()
+        assert "## Findings" in markdown
+        assert "No findings were generated." in markdown
+
+    def test_key_metrics_table_handles_active_filter_and_predictor_errors(self, sample_dm):
+        findings = [
+            Finding(
+                severity="success",
+                category="summary",
+                title="Health: HEALTHY - AUC 71.0",
+                detail="Everything looks good.",
+                data={"avg_auc": 0.71},
+            )
+        ]
+        last_data = sample_dm.analysis._get_last_data()
+        with patch.object(
+            sample_dm.aggregates,
+            "predictors_global_overview",
+            side_effect=RuntimeError("boom"),
+        ):
+            table = sample_dm.analysis._key_metrics_table(
+                last_data,
+                findings,
+                pl.col("does_not_exist") > 0,
+            )
+        values = dict(table.iter_rows())
+        assert values["Active models"] == "N/A"
+        assert values["Predictors"] == "N/A"
+
+    def test_estate_snapshot_sections_handle_aggregate_failures(self, sample_dm):
+        with (
+            patch.object(sample_dm.aggregates, "summary_by_channel", side_effect=RuntimeError("boom")),
+            patch.object(sample_dm.aggregates, "summary_by_configuration", side_effect=RuntimeError("boom")),
+            patch.object(sample_dm.aggregates, "predictors_global_overview", side_effect=RuntimeError("boom")),
+        ):
+            sections = sample_dm.analysis._estate_snapshot_sections(pl.lit(True))
+        assert sections == []
+
+    def test_estate_snapshot_sections_include_predictor_categories(self, sample_dm):
+        with patch.object(
+            sample_dm.aggregates,
+            "summary_by_configuration",
+            return_value=pl.DataFrame(
+                [
+                    {
+                        "Configuration": "Cfg1",
+                        "Channel": "Web",
+                        "Direction": "Inbound",
+                        "ResponseCount": 1000,
+                        "Positives": 50,
+                        "Performance": 0.65,
+                    }
+                ]
+            ).lazy(),
+        ):
+            sections = sample_dm.analysis._estate_snapshot_sections(pl.lit(True))
+        titles = [title for title, _ in sections]
+        assert "Top Channels by Responses" in titles
+        assert "Top Configurations by Responses" in titles
+        assert "Predictor Categories" in titles
 
     def test_findings_have_valid_severity(self, analysis):
         for f in analysis.findings():

--- a/python/tests/adm/test_Prediction.py
+++ b/python/tests/adm/test_Prediction.py
@@ -2,6 +2,7 @@
 
 import datetime
 import shutil
+from unittest.mock import patch
 
 import polars as pl
 import pytest
@@ -518,6 +519,15 @@ def test_from_databricks_view_applies_query():
     result = pred.predictions.collect()
     assert result.height == 4
     assert result["ModelName"].unique().to_list() == ["PREDICTWEBPROPENSITY"]
+
+
+def test_from_databricks_view_preserves_lazy_validation():
+    databricks_data = _make_databricks_prediction_data(["MYCUSTOMPREDICTION"])
+
+    with patch.object(Prediction, "__init__", return_value=None) as init_mock:
+        Prediction.from_databricks_view(databricks_data)
+
+    assert init_mock.call_args.kwargs["_materialize_validated"] is False
 
 
 def test_prediction_plots_internal_method(preds_singleday):

--- a/python/tests/adm/test_Prediction_validators.py
+++ b/python/tests/adm/test_Prediction_validators.py
@@ -9,6 +9,7 @@ traceable back to the inputs — no structural-only checks.
 from __future__ import annotations
 
 import datetime
+from unittest.mock import patch
 
 import polars as pl
 import pytest
@@ -43,6 +44,14 @@ def test_normalize_performance_scale_all_null():
     df = pl.LazyFrame({"Performance": [None, None]}, schema={"Performance": pl.Float64})
     out = Prediction._normalize_performance_scale(df).collect()
     assert out["Performance"].to_list() == [None, None]
+
+
+def test_normalize_performance_scale_is_lazy():
+    """Performance normalization should not eagerly collect the LazyFrame."""
+    df = pl.LazyFrame({"Performance": [55.0, 70.0, 100.0]})
+    with patch.object(pl.LazyFrame, "collect", side_effect=RuntimeError("should stay lazy")):
+        out = Prediction._normalize_performance_scale(df)
+    assert isinstance(out, pl.LazyFrame)
 
 
 def test_parse_snapshot_time_from_pega_string():

--- a/python/tests/healthcheck/test_Reports.py
+++ b/python/tests/healthcheck/test_Reports.py
@@ -149,11 +149,11 @@ def test_full_embed_integration():
         assert results["cdn"]["size"] < results["embedded"]["size"], "CDN should be smaller than embedded"
 
 
-def test_health_check_agent_writes_markdown(tmp_path):
+def test_health_check_markdown_writes_markdown(tmp_path):
     datamart = datasets.cdh_sample()
     reports = Reports(datamart)
 
-    output_path = reports.health_check_agent(
+    output_path = reports.health_check_markdown(
         name="agent_health_check",
         output_dir=tmp_path,
     )
@@ -169,11 +169,11 @@ def test_health_check_agent_writes_markdown(tmp_path):
     assert "Health:" in content
 
 
-def test_health_check_agent_respects_title_subtitle_and_disclaimer(tmp_path):
+def test_health_check_markdown_respects_title_subtitle_and_disclaimer(tmp_path):
     datamart = datasets.cdh_sample()
     reports = Reports(datamart)
 
-    output_path = reports.health_check_agent(
+    output_path = reports.health_check_markdown(
         output_dir=tmp_path,
         title="Custom Title",
         subtitle="Custom Subtitle",

--- a/python/tests/healthcheck/test_Reports.py
+++ b/python/tests/healthcheck/test_Reports.py
@@ -184,3 +184,17 @@ def test_health_check_markdown_respects_title_subtitle_and_disclaimer(tmp_path):
     assert "# Custom Title" in content
     assert "## Custom Subtitle" in content
     assert "> **Disclaimer:** Review before sharing." in content
+
+
+def test_health_check_markdown_accepts_preaggregates(tmp_path):
+    datamart = datasets.cdh_sample()
+    reports = Reports(datamart)
+    preaggregates = datamart.analysis.compute_health_check_preaggregates()
+
+    output_path = reports.health_check_markdown(
+        output_dir=tmp_path,
+        preaggregates=preaggregates,
+    )
+
+    assert output_path.exists()
+    assert output_path.read_text(encoding="utf-8").startswith("# ADM Health Check")

--- a/python/tests/healthcheck/test_Reports.py
+++ b/python/tests/healthcheck/test_Reports.py
@@ -2,6 +2,7 @@
 
 import zipfile
 
+import polars as pl
 import pytest
 
 from pdstools import datasets
@@ -198,3 +199,16 @@ def test_health_check_markdown_accepts_preaggregates(tmp_path):
 
     assert output_path.exists()
     assert output_path.read_text(encoding="utf-8").startswith("# ADM Health Check")
+
+
+def test_health_check_markdown_rejects_query_with_preaggregates(tmp_path):
+    datamart = datasets.cdh_sample()
+    reports = Reports(datamart)
+    preaggregates = datamart.analysis.compute_health_check_preaggregates()
+
+    with pytest.raises(ValueError, match="query and preaggregates"):
+        reports.health_check_markdown(
+            output_dir=tmp_path,
+            query=pl.col("Channel") == "Web",
+            preaggregates=preaggregates,
+        )

--- a/python/tests/healthcheck/test_Reports.py
+++ b/python/tests/healthcheck/test_Reports.py
@@ -4,6 +4,9 @@ import zipfile
 
 import pytest
 
+from pdstools import datasets
+from pdstools.adm.Reports import Reports
+
 from pdstools.utils.report_utils import check_report_for_errors
 
 
@@ -144,3 +147,40 @@ def test_full_embed_integration():
 
         # CDN should be smallest (no embedded resources)
         assert results["cdn"]["size"] < results["embedded"]["size"], "CDN should be smaller than embedded"
+
+
+def test_health_check_agent_writes_markdown(tmp_path):
+    datamart = datasets.cdh_sample()
+    reports = Reports(datamart)
+
+    output_path = reports.health_check_agent(
+        name="agent_health_check",
+        output_dir=tmp_path,
+    )
+
+    assert output_path.exists()
+    assert output_path.suffix == ".md"
+    content = output_path.read_text(encoding="utf-8")
+    assert content.startswith("# ADM Health Check")
+    assert "## Summary" in content
+    assert "## Key Metrics" in content
+    assert "## Estate Snapshot" in content
+    assert "## Findings Overview" in content
+    assert "Health:" in content
+
+
+def test_health_check_agent_respects_title_subtitle_and_disclaimer(tmp_path):
+    datamart = datasets.cdh_sample()
+    reports = Reports(datamart)
+
+    output_path = reports.health_check_agent(
+        output_dir=tmp_path,
+        title="Custom Title",
+        subtitle="Custom Subtitle",
+        disclaimer="Review before sharing.",
+    )
+
+    content = output_path.read_text(encoding="utf-8")
+    assert "# Custom Title" in content
+    assert "## Custom Subtitle" in content
+    assert "> **Disclaimer:** Review before sharing." in content


### PR DESCRIPTION
- add the dm.analysis findings namespace to ADMDatamart
- centralize compact health diagnostics and markdown rendering in Analysis
- add a direct markdown-based health_check_agent wrapper without Quarto

Supersedes #623