### PR TITLE
fix(valuefinder): avoid coverage import crash

### DIFF
--- a/python/pdstools/valuefinder/Schema.py
+++ b/python/pdstools/valuefinder/Schema.py
@@ -12,14 +12,7 @@ class pyValueFinder:
     pyGroup = pl.Categorical
     pyPropensity = pl.Float64
     FinalPropensity = pl.Float64
-    pyStage = pl.Enum(
-        [
-            "Eligibility",
-            "Applicability",
-            "Suitability",
-            "Arbitration",
-        ],
-    )
+    pyStage = pl.Categorical
     pxRank = pl.UInt16
     pxPriority = pl.Float64
     pyModelPropensity = pl.Float64


### PR DESCRIPTION
- change ValueFinder pyStage schema from Polars Enum to Categorical
- restore compatibility with pytest-cov collection for modules that import pdstools