### PR TITLE
Speed up latest-snapshot aggregations

### DIFF
--- a/python/pdstools/adm/Aggregates.py
+++ b/python/pdstools/adm/Aggregates.py
@@ -57,12 +57,15 @@ class Aggregates:
         if df.collect_schema()["SnapshotTime"] == pl.Null:
             return df
 
+        latest_snapshot_time = (
+            df.select(pl.col("SnapshotTime").fill_null(strategy="zero").max()).collect(engine="streaming").item()
+        )
+
         return df.filter(
             # For safety consider to .over("ModelID"), if product improves so snapshots
             # get written not in bulk but per model? Downside is that
             # very old model IDs that never got used anymore would still show up.
-            pl.col("SnapshotTime").fill_null(strategy="zero")
-            == pl.col("SnapshotTime").fill_null(strategy="zero").max(),
+            pl.col("SnapshotTime").fill_null(strategy="zero") == pl.lit(latest_snapshot_time),
         )
 
     def _combine_data(

--- a/python/pdstools/utils/report_utils/_polars_helpers.py
+++ b/python/pdstools/utils/report_utils/_polars_helpers.py
@@ -19,7 +19,7 @@ def n_unique_values(dm, all_dm_cols, fld):
     fld = polars_subset_to_existing_cols(all_dm_cols, fld)
     if len(fld) == 0:
         return 0
-    return dm.model_data.select(pl.col(fld)).drop_nulls().collect().n_unique()
+    return dm.model_data.select(pl.col(fld)).drop_nulls().unique().select(pl.len()).collect().item()
 
 
 def max_by_hierarchy(dm, all_dm_cols, fld, grouping):
@@ -73,11 +73,12 @@ def sample_values(dm, all_dm_cols, fld, n=6):
             pl.concat_str(fld, separator="/").alias("__SampleValues__"),
         )
         .drop_nulls()
+        .unique()
+        .sort("__SampleValues__")
+        .head(n)
         .collect()
         .to_series()
-        .unique()
-        .sort()
-        .to_list()[:n]
+        .to_list()
     )
 
 

--- a/python/tests/adm/test_Aggregates.py
+++ b/python/tests/adm/test_Aggregates.py
@@ -101,6 +101,13 @@ def test_model_summary(dm_aggregates):
     assert dm_aggregates.model_summary().collect().shape[1] == 20
 
 
+def test_last_uses_global_latest_snapshot(dm_minimal):
+    last_snapshot = dm_minimal.aggregates.last().collect()
+
+    assert last_snapshot["SnapshotTime"].unique().to_list() == [datetime(2033, 3, 31)]
+    assert last_snapshot["Name"].sort().to_list() == ["C", "F", "G"]
+
+
 def test_predictors_overview(dm_aggregates):
     assert dm_aggregates.predictors_overview().collect().height == 1800
     assert dm_aggregates.predictors_overview().collect().width == 13


### PR DESCRIPTION
## Summary

- speed up `Aggregates.last()` by computing the global latest `SnapshotTime` once and then filtering with a literal timestamp
- keep `report_utils.n_unique_values()` lazy instead of materializing rows before counting unique values
- keep `report_utils.sample_values()` lazy through `unique()`, `sort()`, and `head()` before collecting results
- add a targeted regression test to lock in the current global-latest snapshot semantics

## Why

The ADM health-check path spends a lot of time building latest-snapshot and reporting summaries on very large datasets. These changes keep the current behavior the same, but avoid expensive query shapes that force unnecessary work.

## Benchmarks

Based on a very large real-world dataset:

| Query | Before | After |
| --- | ---: | ---: |
| `Aggregates.last()` | ~87.5s | ~7.9s |
| `Aggregates.last()` with Polars streaming | ~83.3s | ~6.7s |
| `n_unique_values(Name)` | ~3.2s | ~0.7s |
| `n_unique_values(Issue)` | ~3.3s | ~0.6s |
| `n_unique_values(Channel + Direction)` | ~5.3s | ~0.9s |
| `sample_values()` | ~3.4s | ~1.3s |

The `Aggregates.last()` rewrite was also checked against the previous implementation and produced identical results for the tested dataset.

## Behavior

- no intended user-facing behavior change
- `Aggregates.last()` still returns the rows from the global latest snapshot, not per-model latest rows
- helper outputs for `n_unique_values()` and `sample_values()` remain unchanged

## Testing

- `uv run pytest python/tests/adm/test_Aggregates.py python/tests/utils/test_report_utils.py -q`
- `uv run pytest python/tests/adm/test_end_to_end.py -q`
- `uv run ruff check python/pdstools/adm/Aggregates.py python/pdstools/utils/report_utils/_polars_helpers.py python/tests/adm/test_Aggregates.py python/tests/utils/test_report_utils.py`
