### PR TITLE
Da pen portrait cohort apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,8 @@ test_consolidation.py
 # Local healthcheck batch outputs (may contain customer names)
 /healthcheck_reports/
 
+# Local data exports (may contain customer names or customer data)
+/export_*.json
+
 # Claude / Copilot local settings (machine-specific, may contain tokens)
 .claude/settings.json

--- a/docs/decision-analyzer-architecture.md
+++ b/docs/decision-analyzer-architecture.md
@@ -147,7 +147,7 @@ methods for every summary.
 The generic handoff APIs live on `DecisionAnalyzer`:
 
 ```python
-ids = da.get_interaction_ids("aggregates.filtered_at_stage", "Eligibility")
+ids = da.get_interaction_ids("aggregates.filtered_at_stage", "Engagement Policies")
 count = ids.height
 ```
 

--- a/docs/decision-analyzer-architecture.md
+++ b/docs/decision-analyzer-architecture.md
@@ -148,19 +148,20 @@ The generic handoff APIs live on `DecisionAnalyzer`:
 
 ```python
 ids = da.get_interaction_ids("aggregates.filtered_at_stage", "Eligibility")
-count = da.get_interaction_count("aggregates.filtered_at_stage", "Eligibility")
+count = ids.height
 ```
 
-They accept a public dotted method path, call that row-producing method with the
-remaining arguments, and project unique `Interaction ID` values or their count.
-`Interaction ID` is the boundary: Decision Analyzer must not resolve it to
-customer IDs, subject IDs, decision dates, accounts, households, or profile
-attributes. That join belongs in the downstream application that owns the
-identity model and retention rules.
+`get_interaction_ids` accepts a public dotted method path, calls that
+row-producing method with the remaining arguments, and projects unique
+`Interaction ID` values. Call `.height` (or `len(...)`) on the returned frame
+when you need the cohort size. `Interaction ID` is the boundary: Decision
+Analyzer must not resolve it to customer IDs, subject IDs, decision dates,
+accounts, households, or profile attributes. That join belongs in the downstream
+application that owns the identity model and retention rules.
 
 Canonical aggregate-to-row mappings:
 
-| Summary question | Aggregate method | Row-producing method for IDs/counts |
+| Summary question | Aggregate method | Row-producing method for IDs |
 | --- | --- | --- |
 | Distribution at a stage | `da.aggregates.get_distribution_data(...)` | `aggregates.remaining_at_stage` with the same stage and cell filters |
 | Funnel available actions | `da.aggregates.get_funnel_data(...)[0]` | `aggregates.available_at_stage` |
@@ -217,8 +218,8 @@ Rules of thumb:
    for explicitly sample-backed methods.
 4. If a summary identifies a cohort that downstream may need, add or reuse a
    row-producing method that returns rows with `Interaction ID`, then let callers
-   use `get_interaction_ids("aggregates.method_name", ...)` or
-   `get_interaction_count("aggregates.method_name", ...)`.
+   use `get_interaction_ids("aggregates.method_name", ...)` and call `.height` on
+   the result for the cohort size.
 5. If it needs stage filtering, reuse the aggregate namespace stage helpers such
    as `remaining_at_stage(...)`, `available_at_stage(...)`, or
    `filtered_at_stage(...)`.

--- a/docs/decision-analyzer-architecture.md
+++ b/docs/decision-analyzer-architecture.md
@@ -172,8 +172,7 @@ Canonical aggregate-to-row mappings:
 Rules of thumb:
 
 - Put aggregate and row-cohort methods in `_aggregates.py` under
-   `da.aggregates`, not directly on `DecisionAnalyzer`, unless a compatibility
-   wrapper is required.
+   `da.aggregates`, not directly on `DecisionAnalyzer`.
 - Use full `decision_data` for exact row cohorts. Sample-backed scoring methods
    can stay sample-backed for performance, but they should not pretend to provide
    exact downstream cohorts.

--- a/docs/decision-analyzer-architecture.md
+++ b/docs/decision-analyzer-architecture.md
@@ -1,6 +1,6 @@
 # Decision Analyzer Architecture
 
-**Updated:** April 1, 2026 — Guide for making changes to the Decision Analysis Tool.
+**Updated:** July 8, 2026 — Guide for making changes to the Decision Analysis Tool.
 
 For method signatures, column definitions, and page docstrings, read the source
 directly. This document captures the non-obvious design decisions and patterns.
@@ -124,6 +124,65 @@ level pages analyze. `get_possible_scope_values()` returns available levels base
 on what columns exist. Page 6 (Win/Loss) uses this hierarchy for comparison group
 definition.
 
+### Aggregate Summaries and Row Cohorts
+
+Decision Analyzer exposes two related but distinct API shapes:
+
+- **Aggregate summary methods** answer chart/table questions compactly. Examples:
+   `da.aggregates.get_funnel_data(...)`,
+   `da.aggregates.get_decisions_without_actions_data(...)`, and
+   `da.aggregates.get_filter_component_data(...)`.
+- **Row-producing cohort methods** return the decision rows behind a cohort and
+   must include `Interaction ID`. Examples:
+   `da.aggregates.remaining_at_stage(...)`,
+   `da.aggregates.filtered_at_stage(...)`, and
+   `da.aggregates.filtered_by_component(...)`.
+
+When a user-facing aggregate may need downstream handoff, keep the cohort logic
+in a row-producing method first, then build the summary from that row set or add
+an explicit row counterpart. Do not make downstream consumers reconstruct a
+cohort from an aggregate table, and do not add one-off `*_interactions()` wrapper
+methods for every summary.
+
+The generic handoff APIs live on `DecisionAnalyzer`:
+
+```python
+ids = da.get_interaction_ids("aggregates.filtered_at_stage", "Eligibility")
+count = da.get_interaction_count("aggregates.filtered_at_stage", "Eligibility")
+```
+
+They accept a public dotted method path, call that row-producing method with the
+remaining arguments, and project unique `Interaction ID` values or their count.
+`Interaction ID` is the boundary: Decision Analyzer must not resolve it to
+customer IDs, subject IDs, decision dates, accounts, households, or profile
+attributes. That join belongs in the downstream application that owns the
+identity model and retention rules.
+
+Canonical aggregate-to-row mappings:
+
+| Summary question | Aggregate method | Row-producing method for IDs/counts |
+| --- | --- | --- |
+| Distribution at a stage | `da.aggregates.get_distribution_data(...)` | `aggregates.remaining_at_stage` with the same stage and cell filters |
+| Funnel available actions | `da.aggregates.get_funnel_data(...)[0]` | `aggregates.available_at_stage` |
+| Funnel passing actions | `da.aggregates.get_funnel_data(...)[1]` | `aggregates.passing_at_stage` |
+| Funnel filtered actions | `da.aggregates.get_funnel_data(...)[2]` | `aggregates.filtered_at_stage` |
+| Decisions left without actions | `da.aggregates.get_decisions_without_actions_data(...)` | `aggregates.without_actions_at_stage` |
+| Top filter components | `da.aggregates.get_filter_component_data(...)` | `aggregates.filtered_by_component` |
+
+Rules of thumb:
+
+- Put aggregate and row-cohort methods in `_aggregates.py` under
+   `da.aggregates`, not directly on `DecisionAnalyzer`, unless a compatibility
+   wrapper is required.
+- Use full `decision_data` for exact row cohorts. Sample-backed scoring methods
+   can stay sample-backed for performance, but they should not pretend to provide
+   exact downstream cohorts.
+- If an aggregate method collapses away row identity, document or add its
+   row-producing counterpart before exposing it as a downstream handoff path.
+- Keep aggregate outputs compact. They should not carry subject/customer/date
+   details or embedded interaction-ID lists unless the method is explicitly a row
+   cohort.
+
 ---
 
 ## Patterns to Follow When Adding/Modifying Pages
@@ -149,12 +208,24 @@ definition.
 
 ### Adding a New DA Method
 
-1. Add method to `DecisionAnalyzer` class with `additional_filters` parameter
-2. Use `apply_filter(self.sample, additional_filters)` for filtered sample access
-3. If expensive, consider adding to one of the cache layers
-4. If it needs stage filtering, use `_remaining_at_stage(stage, additional_filters)`
-5. Add corresponding plot function in `plots.py` if visualization needed
-6. Wrap in `da_streamlit_utils.py` with `@st.cache_data` if called from Streamlit
+1. Choose the right namespace first: `da.aggregates` for summary and row-cohort
+   queries, `da.scoring` for sample-backed scoring/reranking questions,
+   `da.plot` for figures, and top-level `DecisionAnalyzer` only for shared
+   lifecycle or compatibility surface.
+2. Add an `additional_filters` parameter when callers need reusable filtering.
+3. Use `apply_filter(self.da.decision_data, additional_filters)` for exact
+   full-data row cohorts and `apply_filter(self.da.sample, additional_filters)`
+   for explicitly sample-backed methods.
+4. If a summary identifies a cohort that downstream may need, add or reuse a
+   row-producing method that returns rows with `Interaction ID`, then let callers
+   use `get_interaction_ids("aggregates.method_name", ...)` or
+   `get_interaction_count("aggregates.method_name", ...)`.
+5. If it needs stage filtering, reuse the aggregate namespace stage helpers such
+   as `remaining_at_stage(...)`, `available_at_stage(...)`, or
+   `filtered_at_stage(...)`.
+6. If expensive, consider adding to one of the cache layers.
+7. Add corresponding plot function in `plots.py` if visualization is needed.
+8. Wrap in `da_streamlit_utils.py` with `@st.cache_data` if called from Streamlit.
 
 ---
 

--- a/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
+++ b/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
@@ -1,0 +1,89 @@
+# Interaction ID cohort guide for downstream users
+
+**Priority:** P2
+**Touches:** `python/pdstools/decision_analyzer/DecisionAnalyzer.py`, downstream pen-portrait workflows.
+
+## Purpose
+
+Decision Analyzer exposes two kinds of answers:
+
+1. Aggregate methods that summarize behavior, counts, distributions, or comparisons.
+2. Interaction ID methods that return the exact decision cohort behind a question.
+
+Downstream applications should use `Interaction ID` as the handoff key. Decision Analyzer should not resolve those IDs to customer, subject, or date attributes. The upstream application owns that mapping because it knows which customer identity, time window, and data-retention rules apply.
+
+## Aggregate-first workflow
+
+Use aggregate methods to decide where to investigate. These methods answer questions such as:
+
+- How many actions were filtered at each stage?
+- Which actions win or lose arbitration?
+- Which two cohorts overlap in a head-to-head comparison?
+- Which priority component or stage explains a shift?
+
+Examples:
+
+```python
+stage_summary = da.filtered_actions_per_stage()
+head_to_head = da.head_to_head_at_stage(
+    pl.col("Group") == "Retention",
+    pl.col("Group") == "Sales",
+    stage="Arbitration",
+)
+```
+
+Aggregate results are intentionally compact. They should not carry customer or subject details.
+
+## Interaction ID workflow
+
+When a downstream workflow needs the exact decisions behind an aggregate, ask for interaction IDs from the row-producing method that defines that cohort.
+
+```python
+output_ids = da.get_interaction_ids("remaining_at_stage", "Output")
+```
+
+`get_interaction_ids()` forwards all positional and keyword arguments to the named public method, then projects unique `Interaction ID` values from the returned Polars frame.
+
+```python
+web_output_ids = da.get_interaction_ids(
+    "remaining_at_stage",
+    "Output",
+    pl.col("Channel") == "Web",
+)
+```
+
+Use this pattern for public row-producing methods that return `Interaction ID`. If a method returns an aggregate summary without `Interaction ID`, `get_interaction_ids()` raises an error instead of guessing.
+
+## Set-derived cohorts
+
+Some cohorts are not a direct projection from one row-producing method. Those can have specific interaction-ID methods.
+
+`dropped_at_stage_interactions()` is one example: it returns interactions that were present at one stage and absent at the next stage. That is a set difference, not a plain projection.
+
+```python
+dropped_ids = da.dropped_at_stage_interactions(
+    "Contact Policies and final Action processing"
+)
+```
+
+Use specific cohort methods only when the cohort logic is distinct. Do not add one convenience wrapper per aggregate method.
+
+## Downstream resolution boundary
+
+Decision Analyzer returns only `Interaction ID` for cohort handoff. A downstream application can join those IDs to its own data model to resolve:
+
+- customer ID
+- subject ID
+- decision date or date range
+- account or household keys
+- application-specific profile attributes
+
+That join should happen outside pdstools.
+
+## Design rules
+
+- Prefer aggregate methods for summary analysis.
+- Prefer `get_interaction_ids("method_name", ...)` for direct row-cohort handoff.
+- Add a named `*_interactions()` method only for set logic that cannot be represented as a direct projection.
+- Do not add `include_subject_id`, `include_customer_id`, or date-resolution arguments to Decision Analyzer cohort APIs.
+- Do not expose `source` switches for exact cohort APIs; interaction cohorts use the full normalized decision data.

--- a/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
+++ b/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
@@ -79,7 +79,7 @@ For example, after identifying a funnel stage with many filtered actions:
 ```python
 filtered_ids = da.get_interaction_ids(
     "aggregates.filtered_at_stage",
-    "Eligibility",
+    "Engagement Policies",
     pl.col("Issue") == "Sales",
 )
 filtered_count = filtered_ids.height
@@ -91,7 +91,7 @@ After identifying a high-impact filter component:
 component_ids = da.get_interaction_ids(
     "aggregates.filtered_by_component",
     "EligibilityRule",
-    stage="Eligibility",
+    stage="Engagement Policies",
 )
 ```
 

--- a/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
+++ b/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
@@ -24,7 +24,7 @@ Use aggregate methods to decide where to investigate. These methods answer quest
 Examples:
 
 ```python
-stage_summary = da.filtered_actions_per_stage()
+stage_summary = da.aggregates.filtered_actions_per_stage()
 head_to_head = da.head_to_head_at_stage(
     pl.col("Group") == "Retention",
     pl.col("Group") == "Sales",
@@ -39,15 +39,15 @@ Aggregate results are intentionally compact. They should not carry customer or s
 When a downstream workflow needs the exact decisions behind an aggregate, define the cohort as rows first. From that same row-producing method, ask for either the interaction IDs or the interaction count.
 
 ```python
-output_ids = da.get_interaction_ids("remaining_at_stage", "Output")
-output_count = da.get_interaction_count("remaining_at_stage", "Output")
+output_ids = da.get_interaction_ids("aggregates.remaining_at_stage", "Output")
+output_count = da.get_interaction_count("aggregates.remaining_at_stage", "Output")
 ```
 
 `get_interaction_ids()` and `get_interaction_count()` forward all positional and keyword arguments to the named public method. The first projects unique `Interaction ID` values from the returned Polars frame; the second counts them.
 
 ```python
 web_output_ids = da.get_interaction_ids(
-    "remaining_at_stage",
+    "aggregates.remaining_at_stage",
     "Output",
     pl.col("Channel") == "Web",
 )
@@ -64,16 +64,16 @@ Some cohorts require set logic before they become rows. Those should still be ex
 `dropped_at_stage()` is one example: it returns rows for interactions that were present at one stage and absent at the next stage. The interaction IDs are still requested through the generic projector.
 
 ```python
-dropped_rows = da.dropped_at_stage(
+dropped_rows = da.aggregates.dropped_at_stage(
     "Contact Policies and final Action processing"
 )
 
 dropped_ids = da.get_interaction_ids(
-    "dropped_at_stage",
+    "aggregates.dropped_at_stage",
     "Contact Policies and final Action processing",
 )
 dropped_count = da.get_interaction_count(
-    "dropped_at_stage",
+    "aggregates.dropped_at_stage",
     "Contact Policies and final Action processing",
 )
 ```
@@ -95,8 +95,8 @@ That join should happen outside pdstools.
 ## Design rules
 
 - Prefer aggregate methods for summary analysis.
-- Prefer `get_interaction_ids("method_name", ...)` for direct row-cohort handoff.
-- Prefer `get_interaction_count("method_name", ...)` when an aggregate needs the count for the same cohort.
+- Prefer `get_interaction_ids("aggregates.method_name", ...)` for direct row-cohort handoff.
+- Prefer `get_interaction_count("aggregates.method_name", ...)` when an aggregate needs the count for the same cohort.
 - Add named row-producing methods for distinct set logic, then use `get_interaction_ids()` to project their IDs.
 - Do not add convenience `*_interactions()` wrappers.
 - Do not add `include_subject_id`, `include_customer_id`, or date-resolution arguments to Decision Analyzer cohort APIs.

--- a/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
+++ b/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
@@ -134,6 +134,57 @@ Decision Analyzer returns only `Interaction ID` for cohort handoff. A downstream
 
 That join should happen outside pdstools.
 
+## What the downstream pen-portrait app should do
+
+The pen-portrait app should treat Decision Analyzer as the owner of decision
+cohort definitions, not as the owner of customer identity or profile enrichment.
+The clean contract is:
+
+1. Use aggregate methods to let the user find an interesting cohort, such as a
+    high-filtering component, a funnel stage with heavy drop-off, or a sparse
+    action distribution cell.
+2. Convert that selected summary cell into the matching public row-producing
+    method path under `aggregates.*`, passing the same stage, scope, component,
+    and filter arguments that define the selected cohort.
+3. Call `get_interaction_ids(...)` when the downstream app needs the handoff
+    key, and `get_interaction_count(...)` when it needs the exact cohort size for
+    display or validation.
+4. Store the cohort recipe with the output: method path, positional arguments,
+    keyword arguments, user-selected filters, generated count, and generation
+    timestamp. That makes the pen portrait auditable and reproducible.
+5. Join the returned `Interaction ID` values to downstream-owned identity,
+    profile, and time-window data outside pdstools.
+
+The pen-portrait app should not reconstruct cohorts by reversing aggregate
+tables. Aggregate tables are summaries and may collapse away row identity. It
+should also not ask Decision Analyzer for subject IDs, customer IDs, dates,
+accounts, households, or profile attributes. Those fields depend on the
+downstream data model, retention policy, and enrichment rules, so they belong in
+the downstream app.
+
+For example, a selected filter component can be represented as a stable cohort
+recipe:
+
+```python
+cohort_method = "aggregates.filtered_by_component"
+cohort_args = (component_name,)
+cohort_kwargs = {"stage": stage, "additional_filters": selected_filters}
+
+interaction_ids = da.get_interaction_ids(
+     cohort_method,
+     *cohort_args,
+     **cohort_kwargs,
+)
+interaction_count = da.get_interaction_count(
+     cohort_method,
+     *cohort_args,
+     **cohort_kwargs,
+)
+```
+
+The downstream app can then enrich `interaction_ids` using its own data and
+render the pen portrait from that enriched dataset.
+
 ## Design rules
 
 - Prefer aggregate methods for summary analysis.

--- a/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
+++ b/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
@@ -57,6 +57,42 @@ Use this pattern for public row-producing methods that return `Interaction ID`. 
 
 Aggregate methods can still exist for user-facing summaries, but they should not be the only place where a cohort is defined. If downstream users need both the summary and the exact decisions behind it, keep the cohort logic in a row-producing method and build the summary from that row set.
 
+Common aggregate-to-row mappings:
+
+| Summary question | Aggregate method | Row-producing method for IDs/counts |
+| --- | --- | --- |
+| Distribution at a stage | `da.aggregates.get_distribution_data(...)` | `aggregates.remaining_at_stage` with the same stage and cell filters |
+| Funnel available actions | `da.aggregates.get_funnel_data(...)[0]` | `aggregates.available_at_stage` |
+| Funnel passing actions | `da.aggregates.get_funnel_data(...)[1]` | `aggregates.passing_at_stage` |
+| Funnel filtered actions | `da.aggregates.get_funnel_data(...)[2]` | `aggregates.filtered_at_stage` |
+| Decisions left without actions | `da.aggregates.get_decisions_without_actions_data(...)` | `aggregates.without_actions_at_stage` |
+| Top filter components | `da.aggregates.get_filter_component_data(...)` | `aggregates.filtered_by_component` |
+
+For example, after identifying a funnel stage with many filtered actions:
+
+```python
+filtered_ids = da.get_interaction_ids(
+    "aggregates.filtered_at_stage",
+    "Eligibility",
+    pl.col("Issue") == "Sales",
+)
+filtered_count = da.get_interaction_count(
+    "aggregates.filtered_at_stage",
+    "Eligibility",
+    pl.col("Issue") == "Sales",
+)
+```
+
+After identifying a high-impact filter component:
+
+```python
+component_ids = da.get_interaction_ids(
+    "aggregates.filtered_by_component",
+    "EligibilityRule",
+    stage="Eligibility",
+)
+```
+
 ## Set-derived row cohorts
 
 Some cohorts require set logic before they become rows. Those should still be exposed as row-producing methods first, and then projected with `get_interaction_ids()`.

--- a/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
+++ b/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
@@ -12,6 +12,12 @@ Decision Analyzer exposes two kinds of answers:
 
 Downstream applications should use `Interaction ID` as the handoff key. Decision Analyzer should not resolve those IDs to customer, subject, or date attributes. The upstream application owns that mapping because it knows which customer identity, time window, and data-retention rules apply.
 
+The generic API architecture for aggregate summaries, row-producing cohorts,
+and interaction-ID/count projection is documented in
+[`docs/decision-analyzer-architecture.md`](../../decision-analyzer-architecture.md).
+This guide applies that pattern to downstream cohort analysis and pen-portrait
+workflows.
+
 ## Aggregate-first workflow
 
 Use aggregate methods to decide where to investigate. These methods answer questions such as:

--- a/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
+++ b/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
@@ -13,7 +13,7 @@ Decision Analyzer exposes two kinds of answers:
 Downstream applications should use `Interaction ID` as the handoff key. Decision Analyzer should not resolve those IDs to customer, subject, or date attributes. The upstream application owns that mapping because it knows which customer identity, time window, and data-retention rules apply.
 
 The generic API architecture for aggregate summaries, row-producing cohorts,
-and interaction-ID/count projection is documented in
+and interaction-ID projection is documented in
 [`docs/decision-analyzer-architecture.md`](../../decision-analyzer-architecture.md).
 This guide applies that pattern to downstream cohort analysis and pen-portrait
 workflows.
@@ -31,7 +31,7 @@ Examples:
 
 ```python
 stage_summary = da.aggregates.filtered_actions_per_stage()
-head_to_head = da.head_to_head_at_stage(
+head_to_head = da.aggregates.head_to_head_at_stage(
     pl.col("Group") == "Retention",
     pl.col("Group") == "Sales",
     stage="Arbitration",
@@ -42,14 +42,14 @@ Aggregate results are intentionally compact. They should not carry customer or s
 
 ## Interaction ID workflow
 
-When a downstream workflow needs the exact decisions behind an aggregate, define the cohort as rows first. From that same row-producing method, ask for either the interaction IDs or the interaction count.
+When a downstream workflow needs the exact decisions behind an aggregate, define the cohort as rows first. From that same row-producing method, ask for the interaction IDs, and call `.height` on the returned frame when you need the cohort size.
 
 ```python
 output_ids = da.get_interaction_ids("aggregates.remaining_at_stage", "Output")
-output_count = da.get_interaction_count("aggregates.remaining_at_stage", "Output")
+output_count = output_ids.height
 ```
 
-`get_interaction_ids()` and `get_interaction_count()` forward all positional and keyword arguments to the named public method. The first projects unique `Interaction ID` values from the returned Polars frame; the second counts them.
+`get_interaction_ids()` forwards all positional and keyword arguments to the named public method and projects unique `Interaction ID` values from the returned Polars frame. For a cohort size, call `.height` (or `len(...)`) on that frame.
 
 ```python
 web_output_ids = da.get_interaction_ids(
@@ -65,7 +65,7 @@ Aggregate methods can still exist for user-facing summaries, but they should not
 
 Common aggregate-to-row mappings:
 
-| Summary question | Aggregate method | Row-producing method for IDs/counts |
+| Summary question | Aggregate method | Row-producing method for IDs |
 | --- | --- | --- |
 | Distribution at a stage | `da.aggregates.get_distribution_data(...)` | `aggregates.remaining_at_stage` with the same stage and cell filters |
 | Funnel available actions | `da.aggregates.get_funnel_data(...)[0]` | `aggregates.available_at_stage` |
@@ -82,11 +82,7 @@ filtered_ids = da.get_interaction_ids(
     "Eligibility",
     pl.col("Issue") == "Sales",
 )
-filtered_count = da.get_interaction_count(
-    "aggregates.filtered_at_stage",
-    "Eligibility",
-    pl.col("Issue") == "Sales",
-)
+filtered_count = filtered_ids.height
 ```
 
 After identifying a high-impact filter component:
@@ -114,10 +110,7 @@ dropped_ids = da.get_interaction_ids(
     "aggregates.dropped_at_stage",
     "Contact Policies and final Action processing",
 )
-dropped_count = da.get_interaction_count(
-    "aggregates.dropped_at_stage",
-    "Contact Policies and final Action processing",
-)
+dropped_count = dropped_ids.height
 ```
 
 Use specific row-producing methods only when the cohort logic is distinct. Do not add convenience `*_interactions()` wrappers.
@@ -147,8 +140,8 @@ The clean contract is:
     method path under `aggregates.*`, passing the same stage, scope, component,
     and filter arguments that define the selected cohort.
 3. Call `get_interaction_ids(...)` when the downstream app needs the handoff
-    key, and `get_interaction_count(...)` when it needs the exact cohort size for
-    display or validation.
+    key, and call `.height` on the returned frame when it needs the exact cohort
+    size for display or validation.
 4. Store the cohort recipe with the output: method path, positional arguments,
     keyword arguments, user-selected filters, generated count, and generation
     timestamp. That makes the pen portrait auditable and reproducible.
@@ -175,11 +168,7 @@ interaction_ids = da.get_interaction_ids(
      *cohort_args,
      **cohort_kwargs,
 )
-interaction_count = da.get_interaction_count(
-     cohort_method,
-     *cohort_args,
-     **cohort_kwargs,
-)
+interaction_count = interaction_ids.height
 ```
 
 The downstream app can then enrich `interaction_ids` using its own data and
@@ -189,7 +178,7 @@ render the pen portrait from that enriched dataset.
 
 - Prefer aggregate methods for summary analysis.
 - Prefer `get_interaction_ids("aggregates.method_name", ...)` for direct row-cohort handoff.
-- Prefer `get_interaction_count("aggregates.method_name", ...)` when an aggregate needs the count for the same cohort.
+- Call `.height` on the returned frame when an aggregate needs the count for the same cohort.
 - Add named row-producing methods for distinct set logic, then use `get_interaction_ids()` to project their IDs.
 - Do not add convenience `*_interactions()` wrappers.
 - Do not add `include_subject_id`, `include_customer_id`, or date-resolution arguments to Decision Analyzer cohort APIs.

--- a/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
+++ b/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
@@ -54,19 +54,24 @@ web_output_ids = da.get_interaction_ids(
 
 Use this pattern for public row-producing methods that return `Interaction ID`. If a method returns an aggregate summary without `Interaction ID`, `get_interaction_ids()` raises an error instead of guessing.
 
-## Set-derived cohorts
+## Set-derived row cohorts
 
-Some cohorts are not a direct projection from one row-producing method. Those can have specific interaction-ID methods.
+Some cohorts require set logic before they become rows. Those should still be exposed as row-producing methods first, and then projected with `get_interaction_ids()`.
 
-`dropped_at_stage_interactions()` is one example: it returns interactions that were present at one stage and absent at the next stage. That is a set difference, not a plain projection.
+`dropped_at_stage()` is one example: it returns rows for interactions that were present at one stage and absent at the next stage. The interaction IDs are still requested through the generic projector.
 
 ```python
-dropped_ids = da.dropped_at_stage_interactions(
+dropped_rows = da.dropped_at_stage(
     "Contact Policies and final Action processing"
+)
+
+dropped_ids = da.get_interaction_ids(
+    "dropped_at_stage",
+    "Contact Policies and final Action processing",
 )
 ```
 
-Use specific cohort methods only when the cohort logic is distinct. Do not add one convenience wrapper per aggregate method.
+Use specific row-producing methods only when the cohort logic is distinct. Do not add convenience `*_interactions()` wrappers.
 
 ## Downstream resolution boundary
 
@@ -84,6 +89,7 @@ That join should happen outside pdstools.
 
 - Prefer aggregate methods for summary analysis.
 - Prefer `get_interaction_ids("method_name", ...)` for direct row-cohort handoff.
-- Add a named `*_interactions()` method only for set logic that cannot be represented as a direct projection.
+- Add named row-producing methods for distinct set logic, then use `get_interaction_ids()` to project their IDs.
+- Do not add convenience `*_interactions()` wrappers.
 - Do not add `include_subject_id`, `include_customer_id`, or date-resolution arguments to Decision Analyzer cohort APIs.
 - Do not expose `source` switches for exact cohort APIs; interaction cohorts use the full normalized decision data.

--- a/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
+++ b/docs/plans/decision-analyzer/interaction-id-cohort-guide.md
@@ -36,13 +36,14 @@ Aggregate results are intentionally compact. They should not carry customer or s
 
 ## Interaction ID workflow
 
-When a downstream workflow needs the exact decisions behind an aggregate, ask for interaction IDs from the row-producing method that defines that cohort.
+When a downstream workflow needs the exact decisions behind an aggregate, define the cohort as rows first. From that same row-producing method, ask for either the interaction IDs or the interaction count.
 
 ```python
 output_ids = da.get_interaction_ids("remaining_at_stage", "Output")
+output_count = da.get_interaction_count("remaining_at_stage", "Output")
 ```
 
-`get_interaction_ids()` forwards all positional and keyword arguments to the named public method, then projects unique `Interaction ID` values from the returned Polars frame.
+`get_interaction_ids()` and `get_interaction_count()` forward all positional and keyword arguments to the named public method. The first projects unique `Interaction ID` values from the returned Polars frame; the second counts them.
 
 ```python
 web_output_ids = da.get_interaction_ids(
@@ -53,6 +54,8 @@ web_output_ids = da.get_interaction_ids(
 ```
 
 Use this pattern for public row-producing methods that return `Interaction ID`. If a method returns an aggregate summary without `Interaction ID`, `get_interaction_ids()` raises an error instead of guessing.
+
+Aggregate methods can still exist for user-facing summaries, but they should not be the only place where a cohort is defined. If downstream users need both the summary and the exact decisions behind it, keep the cohort logic in a row-producing method and build the summary from that row set.
 
 ## Set-derived row cohorts
 
@@ -66,6 +69,10 @@ dropped_rows = da.dropped_at_stage(
 )
 
 dropped_ids = da.get_interaction_ids(
+    "dropped_at_stage",
+    "Contact Policies and final Action processing",
+)
+dropped_count = da.get_interaction_count(
     "dropped_at_stage",
     "Contact Policies and final Action processing",
 )
@@ -89,6 +96,7 @@ That join should happen outside pdstools.
 
 - Prefer aggregate methods for summary analysis.
 - Prefer `get_interaction_ids("method_name", ...)` for direct row-cohort handoff.
+- Prefer `get_interaction_count("method_name", ...)` when an aggregate needs the count for the same cohort.
 - Add named row-producing methods for distinct set logic, then use `get_interaction_ids()` to project their IDs.
 - Do not add convenience `*_interactions()` wrappers.
 - Do not add `include_subject_id`, `include_customer_id`, or date-resolution arguments to Decision Analyzer cohort APIs.

--- a/examples/decision_analyzer/decision_analyzer.ipynb
+++ b/examples/decision_analyzer/decision_analyzer.ipynb
@@ -208,7 +208,7 @@
    "source": [
     "#### Row cohorts for downstream handoff\n",
     "\n",
-    "Aggregate charts and tables are compact summaries. When another application needs the exact decisions behind a summary, use a row-producing cohort method under `decision_data.aggregates`, then project the `Interaction ID` values or count from that same method."
+    "Aggregate charts and tables are compact summaries. When another application needs the exact decisions behind a summary, use a row-producing cohort method under `decision_data.aggregates`, then project the `Interaction ID` values from that same method (call `.height` on the result for the cohort size)."
    ]
   },
   {
@@ -221,10 +221,7 @@
     "    \"aggregates.filtered_at_stage\",\n",
     "    \"Eligibility\",\n",
     ")\n",
-    "filtered_count = decision_data.get_interaction_count(\n",
-    "    \"aggregates.filtered_at_stage\",\n",
-    "    \"Eligibility\",\n",
-    ")\n",
+    "filtered_count = filtered_ids.height\n",
     "\n",
     "component_ids = decision_data.get_interaction_ids(\n",
     "    \"aggregates.filtered_by_component\",\n",

--- a/examples/decision_analyzer/decision_analyzer.ipynb
+++ b/examples/decision_analyzer/decision_analyzer.ipynb
@@ -219,7 +219,7 @@
    "source": [
     "filtered_ids = decision_data.get_interaction_ids(\n",
     "    \"aggregates.filtered_at_stage\",\n",
-    "    \"Eligibility\",\n",
+    "    \"Engagement Policies\",\n",
     ")\n",
     "filtered_count = filtered_ids.height\n",
     "\n",
@@ -230,8 +230,8 @@
     ")\n",
     "\n",
     "{\n",
-    "    \"filtered_at_eligibility\": filtered_count,\n",
-    "    \"filtered_at_eligibility_ids_preview\": filtered_ids.head(5),\n",
+    "    \"filtered_at_engagement_policies\": filtered_count,\n",
+    "    \"filtered_at_engagement_policies_ids_preview\": filtered_ids.head(5),\n",
     "    \"top_component_ids_preview\": component_ids.head(5),\n",
     "}"
    ]

--- a/examples/decision_analyzer/decision_analyzer.ipynb
+++ b/examples/decision_analyzer/decision_analyzer.ipynb
@@ -206,6 +206,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Row cohorts for downstream handoff\n",
+    "\n",
+    "Aggregate charts and tables are compact summaries. When another application needs the exact decisions behind a summary, use a row-producing cohort method under `decision_data.aggregates`, then project the `Interaction ID` values or count from that same method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_ids = decision_data.get_interaction_ids(\n",
+    "    \"aggregates.filtered_at_stage\",\n",
+    "    \"Eligibility\",\n",
+    ")\n",
+    "filtered_count = decision_data.get_interaction_count(\n",
+    "    \"aggregates.filtered_at_stage\",\n",
+    "    \"Eligibility\",\n",
+    ")\n",
+    "\n",
+    "component_ids = decision_data.get_interaction_ids(\n",
+    "    \"aggregates.filtered_by_component\",\n",
+    "    filter_table[\"Component Name\"][0],\n",
+    "    stage=filter_table[\"Stage Group\"][0],\n",
+    ")\n",
+    "\n",
+    "{\n",
+    "    \"filtered_at_eligibility\": filtered_count,\n",
+    "    \"filtered_at_eligibility_ids_preview\": filtered_ids.head(5),\n",
+    "    \"top_component_ids_preview\": component_ids.head(5),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Action Distribution\n",
     "\n",
     "Distribution of actions at the Arbitration stage. Helps identify action groups that rarely survive to Arbitration."

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -993,35 +993,6 @@ class DecisionAnalyzer:
             return self.sample
         return apply_filter(self.sample, filters)
 
-    def remaining_at_stage(
-        self,
-        stage: str | None = None,
-        additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
-    ) -> pl.LazyFrame:
-        """Return action rows remaining at a stage.
-
-        Prefer :meth:`aggregates.remaining_at_stage`; this top-level method is
-        retained as a compatibility wrapper.
-        """
-        return self.aggregates.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
-
-    def _remaining_rows_at_stage(
-        self,
-        data: pl.LazyFrame,
-        stage: str | None = None,
-        additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
-    ) -> pl.LazyFrame:
-        return self.aggregates._remaining_rows_at_stage(
-            data,
-            stage,
-            additional_filters,
-            strict_stage=strict_stage,
-        )
-
     def get_interaction_ids(self, method_name: str, *args: object, **kwargs: object) -> pl.DataFrame:
         """Project unique interaction IDs from a row-producing method.
 
@@ -1174,41 +1145,9 @@ class DecisionAnalyzer:
                 break
         return target
 
-    def dropped_at_stage(
-        self,
-        stage: str,
-        additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
-    ) -> pl.LazyFrame:
-        """Return rows for interactions that lose their final action at ``stage``.
-
-        Prefer :meth:`aggregates.dropped_at_stage`; this top-level method is
-        retained as a compatibility wrapper.
-        """
-        return self.aggregates.dropped_at_stage(stage, additional_filters, strict_stage=strict_stage)
-
     def get_overview_stats(self) -> dict[str, object]:
         """Return overview statistics as a concrete dictionary."""
         return dict(self.overview_stats)
-
-    def filtered_actions_per_stage(
-        self,
-        additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        include_zero_stages: bool = True,
-        sort_by: str = "actions_filtered",
-    ) -> pl.DataFrame:
-        """Return per-stage action filtering counts.
-
-        Prefer :meth:`aggregates.filtered_actions_per_stage`; this top-level
-        method is retained as a compatibility wrapper.
-        """
-        return self.aggregates.filtered_actions_per_stage(
-            additional_filters,
-            include_zero_stages=include_zero_stages,
-            sort_by=sort_by,
-        )
 
     def head_to_head_at_stage(
         self,

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -32,7 +32,6 @@ from ..pega_io.File import read_data
 from ..utils.namespaces import LazyNamespace
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
     import os
     from .plots import Plot
 
@@ -1040,7 +1039,6 @@ class DecisionAnalyzer:
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
         *,
         source: str = "full",
-        include_subject_id: bool = True,
         strict_stage: bool = True,
     ) -> pl.DataFrame:
         """Return exact interaction IDs with at least one action remaining at a stage.
@@ -1050,11 +1048,11 @@ class DecisionAnalyzer:
         are acceptable.
         """
         if self._stage_index(stage, strict_stage=strict_stage) is None:
-            return self._empty_interaction_frame(source, include_subject_id)
+            return self._empty_interaction_frame(source)
 
         return (
             self.remaining_at_stage(stage, additional_filters, source=source, strict_stage=strict_stage)
-            .select(self._interaction_detail_columns(source, include_subject_id))
+            .select("Interaction ID")
             .unique()
             .collect()
         )
@@ -1065,7 +1063,6 @@ class DecisionAnalyzer:
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
         *,
         source: str = "full",
-        include_subject_id: bool = True,
         strict_stage: bool = True,
     ) -> pl.DataFrame:
         """Return exact interactions that lose their final action at ``stage``.
@@ -1076,12 +1073,11 @@ class DecisionAnalyzer:
         """
         stage_idx = self._stage_index(stage, strict_stage=strict_stage)
         if stage_idx is None or stage_idx >= len(self.AvailableNBADStages) - 1:
-            return self._empty_interaction_frame(source, include_subject_id)
+            return self._empty_interaction_frame(source)
 
-        id_columns = self._interaction_detail_columns(source, include_subject_id)
         current = (
             self.remaining_at_stage(stage, additional_filters, source=source, strict_stage=strict_stage)
-            .select(id_columns)
+            .select("Interaction ID")
             .unique()
         )
         next_stage = self.AvailableNBADStages[stage_idx + 1]
@@ -1091,38 +1087,6 @@ class DecisionAnalyzer:
             .unique()
         )
         return current.join(next_ids, on="Interaction ID", how="anti").collect()
-
-    def get_interaction_details(
-        self,
-        interaction_ids: str | Iterable[str],
-        columns: list[str] | None = None,
-    ) -> pl.DataFrame:
-        """Resolve interaction IDs to subject IDs and optional detail columns.
-
-        Parameters
-        ----------
-        interaction_ids : iterable or str
-            Interaction IDs to resolve. Empty input returns an empty DataFrame
-            with the selected output schema.
-        columns : list[str], optional
-            Extra columns to include when present in the data, such as
-            ``Issue``, ``Group``, ``Action``, ``Channel``, ``Direction``, or
-            ``Treatment``.
-        """
-        selected_columns = self._interaction_detail_columns("full", include_subject_id=True)
-        if columns is not None:
-            available = set(self.decision_data.collect_schema().names())
-            selected_columns.extend(col for col in columns if col in available and col not in selected_columns)
-
-        ids = [interaction_ids] if isinstance(interaction_ids, str) else list(interaction_ids)
-
-        if not ids:
-            schema = self.decision_data.collect_schema()
-            return pl.DataFrame(schema={col: schema[col] for col in selected_columns})
-
-        return (
-            self.decision_data.filter(pl.col("Interaction ID").is_in(ids)).select(selected_columns).unique().collect()
-        )
 
     def get_overview_stats(self) -> dict[str, object]:
         """Return overview statistics as a concrete dictionary."""
@@ -1286,27 +1250,22 @@ class DecisionAnalyzer:
         if include_interaction_ids:
             outcome_ids = overlap.select("Interaction ID", "outcome")
             result["cohorts"] = {
-                "x_wins": self._details_for_interaction_frame(
+                "x_wins": self._interaction_id_frame(
                     outcome_ids.filter(pl.col("outcome") == "x_wins").select("Interaction ID")
                 ),
-                "y_wins": self._details_for_interaction_frame(
+                "y_wins": self._interaction_id_frame(
                     outcome_ids.filter(pl.col("outcome") == "y_wins").select("Interaction ID")
                 ),
-                "other": self._details_for_interaction_frame(
+                "other": self._interaction_id_frame(
                     outcome_ids.filter(pl.col("outcome") == "other").select("Interaction ID")
                 ),
-                "x_only": self._details_for_interaction_frame(x_only),
-                "y_only": self._details_for_interaction_frame(y_only),
+                "x_only": self._interaction_id_frame(x_only),
+                "y_only": self._interaction_id_frame(y_only),
             }
         return result
 
-    def _details_for_interaction_frame(self, interaction_ids: pl.LazyFrame) -> pl.DataFrame:
-        return (
-            self.decision_data.join(interaction_ids.unique(), on="Interaction ID", how="inner")
-            .select(self._interaction_detail_columns("full", include_subject_id=True))
-            .unique()
-            .collect()
-        )
+    def _interaction_id_frame(self, interaction_ids: pl.LazyFrame) -> pl.DataFrame:
+        return interaction_ids.select("Interaction ID").unique().collect()
 
     def _stage_source(self, source: str) -> pl.LazyFrame:
         if source == "sample":
@@ -1322,18 +1281,9 @@ class DecisionAnalyzer:
             raise ValueError(f"Unknown stage {stage!r}. Expected one of: {self.AvailableNBADStages}")
         return None
 
-    def _interaction_detail_columns(self, source: str, include_subject_id: bool) -> list[str]:
-        available = set(self._stage_source(source).collect_schema().names())
-        columns = ["Interaction ID"]
-        if include_subject_id and "Subject ID" in available:
-            columns.append("Subject ID")
-        return columns
-
-    def _empty_interaction_frame(self, source: str, include_subject_id: bool) -> pl.DataFrame:
+    def _empty_interaction_frame(self, source: str) -> pl.DataFrame:
         schema = self._stage_source(source).collect_schema()
-        return pl.DataFrame(
-            schema={col: schema[col] for col in self._interaction_detail_columns(source, include_subject_id)}
-        )
+        return pl.DataFrame(schema={"Interaction ID": schema["Interaction ID"]})
 
     def get_available_fields_for_filtering(self, *, categorical_only: bool = False) -> list[str]:
         """Return column names available for data filtering.

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1062,12 +1062,12 @@ class DecisionAnalyzer:
         Pass only public methods that still return decision rows containing
         ``Interaction ID``. This works for methods such as
         ``remaining_at_stage`` because their results still contain the rows
-        behind the cohort. It does not work for aggregate summaries such as
-        counts, distributions, or comparison tables: those methods may say how
-        many interactions were affected, but they no longer contain the actual
-        interaction IDs. If a cohort needs custom logic, add that logic as a
-        row-producing method first (for example, ``dropped_at_stage``), then
-        project IDs through this method.
+        behind the cohort. Aggregate summaries should be built from the same
+        row-producing cohort method whenever downstream applications also need
+        the exact IDs. For counts, use :meth:`get_interaction_count` on that
+        same row-producing method. If a cohort needs custom logic, add that
+        logic as a row-producing method first (for example,
+        ``dropped_at_stage``), then project IDs or counts from it.
 
         Parameters
         ----------
@@ -1112,6 +1112,61 @@ class DecisionAnalyzer:
         ...     "Contact Policies and final Action processing",
         ... )
         """
+        result = self._row_result_for_interaction_projection(method_name, *args, **kwargs)
+        if isinstance(result, pl.LazyFrame):
+            return result.select("Interaction ID").unique().collect()
+
+        return result.select("Interaction ID").unique()
+
+    def get_interaction_count(self, method_name: str, *args: object, **kwargs: object) -> int:
+        """Count unique interaction IDs from a row-producing method.
+
+        This is the count companion to :meth:`get_interaction_ids`. Use it
+        when an aggregate view needs the number of interactions in a cohort,
+        but downstream applications may also need the exact IDs for that same
+        cohort. Both methods accept the same ``method_name``, ``*args``, and
+        ``**kwargs`` so the cohort definition stays in one row-producing
+        method.
+
+        Parameters
+        ----------
+        method_name : str
+            Name of a public ``DecisionAnalyzer`` method that returns a
+            Polars DataFrame or LazyFrame containing ``Interaction ID``.
+        *args, **kwargs
+            Arguments forwarded to the selected method.
+
+        Returns
+        -------
+        int
+            Number of unique ``Interaction ID`` values returned by the selected
+            row-producing method.
+
+        Examples
+        --------
+        Count decisions that still have at least one action at Output:
+
+        >>> da.get_interaction_count("remaining_at_stage", "Output")
+
+        Count a set-derived row cohort:
+
+        >>> da.get_interaction_count(
+        ...     "dropped_at_stage",
+        ...     "Contact Policies and final Action processing",
+        ... )
+        """
+        result = self._row_result_for_interaction_projection(method_name, *args, **kwargs)
+        if isinstance(result, pl.LazyFrame):
+            return result.select(pl.n_unique("Interaction ID")).collect().item()
+
+        return result.select(pl.n_unique("Interaction ID")).item()
+
+    def _row_result_for_interaction_projection(
+        self,
+        method_name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> pl.LazyFrame | pl.DataFrame:
         if method_name.startswith("_"):
             raise ValueError("method_name must refer to a public DecisionAnalyzer method.")
 
@@ -1123,12 +1178,12 @@ class DecisionAnalyzer:
         if isinstance(result, pl.LazyFrame):
             if "Interaction ID" not in result.collect_schema().names():
                 raise ValueError(f"{method_name!r} does not return an 'Interaction ID' column.")
-            return result.select("Interaction ID").unique().collect()
+            return result
 
         if isinstance(result, pl.DataFrame):
             if "Interaction ID" not in result.columns:
                 raise ValueError(f"{method_name!r} does not return an 'Interaction ID' column.")
-            return result.select("Interaction ID").unique()
+            return result
 
         raise TypeError(f"{method_name!r} must return a Polars DataFrame or LazyFrame.")
 

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -993,6 +993,131 @@ class DecisionAnalyzer:
             return self.sample
         return apply_filter(self.sample, filters)
 
+    def remaining_at_stage(
+        self,
+        stage: str | None = None,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        source: str = "sample",
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        """Return action rows remaining at a stage.
+
+        Rows are considered remaining at ``stage`` when their current stage is
+        the requested stage or any later stage in ``AvailableNBADStages``.
+        ``source="sample"`` uses the deterministic sampled data used by
+        exploratory analyses; ``source="full"`` uses the full normalized
+        decision data for exact cohort work.
+
+        Parameters
+        ----------
+        stage : str, optional
+            Stage to evaluate. When omitted, returns rows with non-null
+            ``Priority`` after applying filters.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before selecting remaining rows.
+        source : {"sample", "full"}, default "sample"
+            Data source to query.
+        strict_stage : bool, default True
+            Raise ``ValueError`` for unknown stages. When False, unknown stages
+            return an empty frame.
+        """
+        base = apply_filter(self._stage_source(source), additional_filters)
+        if stage is None:
+            return base.filter(pl.col("Priority").is_not_null())
+
+        stage_idx = self._stage_index(stage, strict_stage=strict_stage)
+        if stage_idx is None:
+            return base.limit(0)
+
+        remaining_stages = self.AvailableNBADStages[stage_idx:]
+        return base.filter(pl.col(self.level).is_in(remaining_stages))
+
+    def remaining_at_stage_interactions(
+        self,
+        stage: str,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        source: str = "full",
+        include_subject_id: bool = True,
+        strict_stage: bool = True,
+    ) -> pl.DataFrame:
+        """Return exact interaction IDs with at least one action remaining at a stage.
+
+        Exact cohort APIs default to ``source="full"``. Use
+        ``source="sample"`` only for exploratory workflows where sampled IDs
+        are acceptable.
+        """
+        if self._stage_index(stage, strict_stage=strict_stage) is None:
+            return self._empty_interaction_frame(source, include_subject_id)
+
+        return (
+            self.remaining_at_stage(stage, additional_filters, source=source, strict_stage=strict_stage)
+            .select(self._interaction_detail_columns(source, include_subject_id))
+            .unique()
+            .collect()
+        )
+
+    def dropped_at_stage_interactions(
+        self,
+        stage: str,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        source: str = "full",
+        include_subject_id: bool = True,
+        strict_stage: bool = True,
+    ) -> pl.DataFrame:
+        """Return exact interactions that lose their final action at ``stage``.
+
+        The cohort is computed as interactions remaining at ``stage`` minus
+        interactions remaining at the next stage, using the same filters and
+        source on both sides. Terminal stages return an empty frame.
+        """
+        stage_idx = self._stage_index(stage, strict_stage=strict_stage)
+        if stage_idx is None or stage_idx >= len(self.AvailableNBADStages) - 1:
+            return self._empty_interaction_frame(source, include_subject_id)
+
+        id_columns = self._interaction_detail_columns(source, include_subject_id)
+        current = (
+            self.remaining_at_stage(stage, additional_filters, source=source, strict_stage=strict_stage)
+            .select(id_columns)
+            .unique()
+        )
+        next_stage = self.AvailableNBADStages[stage_idx + 1]
+        next_ids = (
+            self.remaining_at_stage(next_stage, additional_filters, source=source, strict_stage=strict_stage)
+            .select("Interaction ID")
+            .unique()
+        )
+        return current.join(next_ids, on="Interaction ID", how="anti").collect()
+
+    def _stage_source(self, source: str) -> pl.LazyFrame:
+        if source == "sample":
+            return self.sample
+        if source == "full":
+            return self.decision_data
+        raise ValueError("source must be either 'sample' or 'full'.")
+
+    def _stage_index(self, stage: str, *, strict_stage: bool) -> int | None:
+        if stage in self.AvailableNBADStages:
+            return self.AvailableNBADStages.index(stage)
+        if strict_stage:
+            raise ValueError(f"Unknown stage {stage!r}. Expected one of: {self.AvailableNBADStages}")
+        return None
+
+    def _interaction_detail_columns(self, source: str, include_subject_id: bool) -> list[str]:
+        available = set(self._stage_source(source).collect_schema().names())
+        columns = ["Interaction ID"]
+        if include_subject_id and "Subject ID" in available:
+            columns.append("Subject ID")
+        return columns
+
+    def _empty_interaction_frame(self, source: str, include_subject_id: bool) -> pl.DataFrame:
+        schema = self._stage_source(source).collect_schema()
+        return pl.DataFrame(
+            schema={col: schema[col] for col in self._interaction_detail_columns(source, include_subject_id)}
+        )
+
     def get_available_fields_for_filtering(self, *, categorical_only: bool = False) -> list[str]:
         """Return column names available for data filtering.
 

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1105,7 +1105,15 @@ class DecisionAnalyzer:
         return target
 
     def get_overview_stats(self) -> dict[str, object]:
-        """Return overview statistics as a concrete dictionary."""
+        """Return overview statistics as a concrete dictionary.
+
+        Returns
+        -------
+        dict[str, object]
+            A shallow copy of the analyzer overview statistics, suitable for
+            downstream serialization or display without exposing the internal
+            cached mapping.
+        """
         return dict(self.overview_stats)
 
     def get_available_fields_for_filtering(self, *, categorical_only: bool = False) -> list[str]:

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1042,27 +1042,6 @@ class DecisionAnalyzer:
         remaining_stages = self.AvailableNBADStages[stage_idx:]
         return base.filter(pl.col(self.level).is_in(remaining_stages))
 
-    def remaining_at_stage_interactions(
-        self,
-        stage: str,
-        additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
-    ) -> pl.DataFrame:
-        """Return exact interaction IDs with at least one action remaining at a stage.
-
-        Exact cohort APIs use the full normalized decision data.
-        """
-        if self._stage_index(stage, strict_stage=strict_stage) is None:
-            return self._empty_interaction_frame()
-
-        return self.get_interaction_ids(
-            "remaining_at_stage",
-            stage,
-            additional_filters,
-            strict_stage=strict_stage,
-        )
-
     def get_interaction_ids(self, method_name: str, *args: object, **kwargs: object) -> pl.DataFrame:
         """Return unique interaction IDs from a public row-producing method.
 

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1073,14 +1073,14 @@ class DecisionAnalyzer:
 
         raise TypeError(f"{method_name!r} must return a Polars DataFrame or LazyFrame.")
 
-    def dropped_at_stage_interactions(
+    def dropped_at_stage(
         self,
         stage: str,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
         *,
         strict_stage: bool = True,
-    ) -> pl.DataFrame:
-        """Return exact interactions that lose their final action at ``stage``.
+    ) -> pl.LazyFrame:
+        """Return rows for interactions that lose their final action at ``stage``.
 
         The cohort is computed as interactions remaining at ``stage`` minus
         interactions remaining at the next stage, using the same filters on
@@ -1088,20 +1088,16 @@ class DecisionAnalyzer:
         """
         stage_idx = self._stage_index(stage, strict_stage=strict_stage)
         if stage_idx is None or stage_idx >= len(self.AvailableNBADStages) - 1:
-            return self._empty_interaction_frame()
+            return self.remaining_at_stage(stage, additional_filters, strict_stage=False).limit(0)
 
-        current = (
-            self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
-            .select("Interaction ID")
-            .unique()
-        )
+        current = self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
         next_stage = self.AvailableNBADStages[stage_idx + 1]
         next_ids = (
             self.remaining_at_stage(next_stage, additional_filters, strict_stage=strict_stage)
             .select("Interaction ID")
             .unique()
         )
-        return current.join(next_ids, on="Interaction ID", how="anti").collect()
+        return current.join(next_ids, on="Interaction ID", how="anti")
 
     def get_overview_stats(self) -> dict[str, object]:
         """Return overview statistics as a concrete dictionary."""
@@ -1287,10 +1283,6 @@ class DecisionAnalyzer:
         if strict_stage:
             raise ValueError(f"Unknown stage {stage!r}. Expected one of: {self.AvailableNBADStages}")
         return None
-
-    def _empty_interaction_frame(self) -> pl.DataFrame:
-        schema = self.decision_data.collect_schema()
-        return pl.DataFrame(schema={"Interaction ID": schema["Interaction ID"]})
 
     def get_available_fields_for_filtering(self, *, categorical_only: bool = False) -> list[str]:
         """Return column names available for data filtering.

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -32,6 +32,7 @@ from ..pega_io.File import read_data
 from ..utils.namespaces import LazyNamespace
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     import os
     from .plots import Plot
 
@@ -1090,6 +1091,42 @@ class DecisionAnalyzer:
             .unique()
         )
         return current.join(next_ids, on="Interaction ID", how="anti").collect()
+
+    def get_interaction_details(
+        self,
+        interaction_ids: str | Iterable[str],
+        columns: list[str] | None = None,
+    ) -> pl.DataFrame:
+        """Resolve interaction IDs to subject IDs and optional detail columns.
+
+        Parameters
+        ----------
+        interaction_ids : iterable or str
+            Interaction IDs to resolve. Empty input returns an empty DataFrame
+            with the selected output schema.
+        columns : list[str], optional
+            Extra columns to include when present in the data, such as
+            ``Issue``, ``Group``, ``Action``, ``Channel``, ``Direction``, or
+            ``Treatment``.
+        """
+        selected_columns = self._interaction_detail_columns("full", include_subject_id=True)
+        if columns is not None:
+            available = set(self.decision_data.collect_schema().names())
+            selected_columns.extend(col for col in columns if col in available and col not in selected_columns)
+
+        ids = [interaction_ids] if isinstance(interaction_ids, str) else list(interaction_ids)
+
+        if not ids:
+            schema = self.decision_data.collect_schema()
+            return pl.DataFrame(schema={col: schema[col] for col in selected_columns})
+
+        return (
+            self.decision_data.filter(pl.col("Interaction ID").is_in(ids)).select(selected_columns).unique().collect()
+        )
+
+    def get_overview_stats(self) -> dict[str, object]:
+        """Return overview statistics as a concrete dictionary."""
+        return dict(self.overview_stats)
 
     def _stage_source(self, source: str) -> pl.LazyFrame:
         if source == "sample":

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1128,6 +1128,71 @@ class DecisionAnalyzer:
         """Return overview statistics as a concrete dictionary."""
         return dict(self.overview_stats)
 
+    def filtered_actions_per_stage(
+        self,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        include_zero_stages: bool = True,
+        sort_by: str = "actions_filtered",
+    ) -> pl.DataFrame:
+        """Return per-stage action filtering counts.
+
+        Parameters
+        ----------
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before aggregation.
+        include_zero_stages : bool, default True
+            Include all available stages except ``Output``, filling missing
+            stages with zero counts.
+        sort_by : {"actions_filtered", "interactions_affected", "stage"}, default "actions_filtered"
+            Output ordering. Count-based sorts are descending; ``"stage"``
+            preserves pipeline order.
+        """
+        valid_sorts = {"actions_filtered", "interactions_affected", "stage"}
+        if sort_by not in valid_sorts:
+            raise ValueError(f"sort_by must be one of {sorted(valid_sorts)}")
+
+        stage_order = [stage for stage in self.AvailableNBADStages if stage != "Output"]
+        filtered_view = apply_filter(self.preaggregated_filter_view, additional_filters).filter(
+            pl.col("Record Type") == "FILTERED_OUT"
+        )
+        result = (
+            filtered_view.with_columns(pl.col(self.level).cast(pl.Utf8))
+            .group_by(self.level)
+            .agg(
+                actions_filtered=pl.sum("Decisions"),
+                interactions_affected=pl.col("Interaction_IDs")
+                .list.explode(keep_nulls=False, empty_as_null=False)
+                .unique()
+                .count(),
+            )
+        )
+
+        if include_zero_stages:
+            result = (
+                pl.LazyFrame({self.level: stage_order})
+                .join(result, on=self.level, how="left")
+                .with_columns(pl.col("actions_filtered", "interactions_affected").fill_null(0))
+            )
+
+        result_df = result.with_columns(
+            pl.col("actions_filtered").cast(pl.Int64),
+            pl.col("interactions_affected").cast(pl.Int64),
+            pl.col(self.level)
+            .replace_strict(
+                {stage: idx for idx, stage in enumerate(stage_order)},
+                default=len(stage_order),
+                return_dtype=pl.Int64,
+            )
+            .alias("_stage_order"),
+        ).collect()
+
+        if sort_by == "stage":
+            result_df = result_df.sort("_stage_order")
+        else:
+            result_df = result_df.sort([sort_by, "_stage_order"], descending=[True, False])
+        return result_df.drop("_stage_order")
+
     def _stage_source(self, source: str) -> pl.LazyFrame:
         if source == "sample":
             return self.sample

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1043,7 +1043,31 @@ class DecisionAnalyzer:
         return base.filter(pl.col(self.level).is_in(remaining_stages))
 
     def get_interaction_ids(self, method_name: str, *args: object, **kwargs: object) -> pl.DataFrame:
-        """Return unique interaction IDs from a public row-producing method.
+        """Project unique interaction IDs from a row-producing method.
+
+        This is the main handoff interface for downstream applications that
+        need the exact decision cohort behind a Decision Analyzer question.
+        Use aggregate methods first to decide what needs investigation, then
+        call this method with the public row-producing method that defines the
+        cohort. The selected method is called with ``*args`` and ``**kwargs``;
+        its Polars result is reduced to a one-column DataFrame of unique
+        ``Interaction ID`` values.
+
+        ``Interaction ID`` is the only identity returned by this interface.
+        Decision Analyzer does not resolve interaction IDs to subject IDs,
+        customer IDs, dates, accounts, households, or profile attributes. That
+        resolution belongs in the downstream application, which owns the
+        customer identity model, time-window rules, and data-retention context.
+
+        Pass only public methods that still return decision rows containing
+        ``Interaction ID``. This works for methods such as
+        ``remaining_at_stage`` because their results still contain the rows
+        behind the cohort. It does not work for aggregate summaries such as
+        counts, distributions, or comparison tables: those methods may say how
+        many interactions were affected, but they no longer contain the actual
+        interaction IDs. If a cohort needs custom logic, add that logic as a
+        row-producing method first (for example, ``dropped_at_stage``), then
+        project IDs through this method.
 
         Parameters
         ----------
@@ -1052,6 +1076,41 @@ class DecisionAnalyzer:
             Polars DataFrame or LazyFrame containing ``Interaction ID``.
         *args, **kwargs
             Arguments forwarded to the selected method.
+
+        Returns
+        -------
+        pl.DataFrame
+            A one-column DataFrame containing unique ``Interaction ID`` values.
+
+        Raises
+        ------
+        ValueError
+            If ``method_name`` is private, unknown, or returns row data without
+            an ``Interaction ID`` column.
+        TypeError
+            If the selected method does not return a Polars DataFrame or
+            LazyFrame.
+
+        Examples
+        --------
+        Get the decisions that still have at least one action at Output:
+
+        >>> da.get_interaction_ids("remaining_at_stage", "Output")
+
+        Forward filters to the row-producing method:
+
+        >>> da.get_interaction_ids(
+        ...     "remaining_at_stage",
+        ...     "Output",
+        ...     pl.col("Channel") == "Web",
+        ... )
+
+        Project IDs from a set-derived row cohort:
+
+        >>> da.get_interaction_ids(
+        ...     "dropped_at_stage",
+        ...     "Contact Policies and final Action processing",
+        ... )
         """
         if method_name.startswith("_"):
             raise ValueError("method_name must refer to a public DecisionAnalyzer method.")

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1056,12 +1056,43 @@ class DecisionAnalyzer:
         if self._stage_index(stage, strict_stage=strict_stage) is None:
             return self._empty_interaction_frame()
 
-        return (
-            self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
-            .select("Interaction ID")
-            .unique()
-            .collect()
+        return self.get_interaction_ids(
+            "remaining_at_stage",
+            stage,
+            additional_filters,
+            strict_stage=strict_stage,
         )
+
+    def get_interaction_ids(self, method_name: str, *args: object, **kwargs: object) -> pl.DataFrame:
+        """Return unique interaction IDs from a public row-producing method.
+
+        Parameters
+        ----------
+        method_name : str
+            Name of a public ``DecisionAnalyzer`` method that returns a
+            Polars DataFrame or LazyFrame containing ``Interaction ID``.
+        *args, **kwargs
+            Arguments forwarded to the selected method.
+        """
+        if method_name.startswith("_"):
+            raise ValueError("method_name must refer to a public DecisionAnalyzer method.")
+
+        method = getattr(self, method_name, None)
+        if not callable(method):
+            raise ValueError(f"Unknown DecisionAnalyzer method: {method_name!r}.")
+
+        result = method(*args, **kwargs)
+        if isinstance(result, pl.LazyFrame):
+            if "Interaction ID" not in result.collect_schema().names():
+                raise ValueError(f"{method_name!r} does not return an 'Interaction ID' column.")
+            return result.select("Interaction ID").unique().collect()
+
+        if isinstance(result, pl.DataFrame):
+            if "Interaction ID" not in result.columns:
+                raise ValueError(f"{method_name!r} does not return an 'Interaction ID' column.")
+            return result.select("Interaction ID").unique()
+
+        raise TypeError(f"{method_name!r} must return a Polars DataFrame or LazyFrame.")
 
     def dropped_at_stage_interactions(
         self,

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 # python/pdstools/decision_analyzer/DecisionAnalyzer.py
 from pathlib import Path
-from typing import ClassVar, TYPE_CHECKING
+from typing import ClassVar, TYPE_CHECKING, cast
 from functools import cached_property
 import logging
 import os
@@ -33,6 +33,8 @@ from ..utils.namespaces import LazyNamespace
 
 if TYPE_CHECKING:
     import os
+    from collections.abc import Callable
+
     from .plots import Plot
 
 logger = logging.getLogger(__name__)
@@ -1015,10 +1017,10 @@ class DecisionAnalyzer:
         ``aggregates.remaining_at_stage`` because their results still contain the rows
         behind the cohort. Aggregate summaries should be built from the same
         row-producing cohort method whenever downstream applications also need
-        the exact IDs. For counts, use :meth:`get_interaction_count` on that
-        same row-producing method. If a cohort needs custom logic, add that
-        logic as a row-producing method first (for example,
-        ``aggregates.dropped_at_stage``), then project IDs or counts from it.
+        the exact IDs. For a cohort size, call ``.height`` (or ``len(...)``) on
+        the returned frame. If a cohort needs custom logic, add that logic as a
+        row-producing method first (for example, ``aggregates.dropped_at_stage``),
+        then project its IDs here.
 
         Parameters
         ----------
@@ -1069,49 +1071,6 @@ class DecisionAnalyzer:
 
         return result.select("Interaction ID").unique()
 
-    def get_interaction_count(self, method_name: str, *args: object, **kwargs: object) -> int:
-        """Count unique interaction IDs from a row-producing method.
-
-        This is the count companion to :meth:`get_interaction_ids`. Use it
-        when an aggregate view needs the number of interactions in a cohort,
-        but downstream applications may also need the exact IDs for that same
-        cohort. Both methods accept the same ``method_name``, ``*args``, and
-        ``**kwargs`` so the cohort definition stays in one row-producing
-        method.
-
-        Parameters
-        ----------
-        method_name : str
-            Name or dotted path of a public method on ``DecisionAnalyzer`` that
-            returns a Polars DataFrame or LazyFrame containing ``Interaction ID``.
-        *args, **kwargs
-            Arguments forwarded to the selected method.
-
-        Returns
-        -------
-        int
-            Number of unique ``Interaction ID`` values returned by the selected
-            row-producing method.
-
-        Examples
-        --------
-        Count decisions that still have at least one action at Output:
-
-        >>> da.get_interaction_count("aggregates.remaining_at_stage", "Output")
-
-        Count a set-derived row cohort:
-
-        >>> da.get_interaction_count(
-        ...     "aggregates.dropped_at_stage",
-        ...     "Contact Policies and final Action processing",
-        ... )
-        """
-        result = self._row_result_for_interaction_projection(method_name, *args, **kwargs)
-        if isinstance(result, pl.LazyFrame):
-            return result.select(pl.n_unique("Interaction ID")).collect().item()
-
-        return result.select(pl.n_unique("Interaction ID")).item()
-
     def _row_result_for_interaction_projection(
         self,
         method_name: str,
@@ -1122,7 +1081,7 @@ class DecisionAnalyzer:
         if not callable(method):
             raise ValueError(f"Unknown DecisionAnalyzer method: {method_name!r}.")
 
-        result = method(*args, **kwargs)
+        result = cast("Callable[..., object]", method)(*args, **kwargs)
         if isinstance(result, pl.LazyFrame):
             if "Interaction ID" not in result.collect_schema().names():
                 raise ValueError(f"{method_name!r} does not return an 'Interaction ID' column.")
@@ -1148,122 +1107,6 @@ class DecisionAnalyzer:
     def get_overview_stats(self) -> dict[str, object]:
         """Return overview statistics as a concrete dictionary."""
         return dict(self.overview_stats)
-
-    def head_to_head_at_stage(
-        self,
-        filter_x: pl.Expr | list[pl.Expr],
-        filter_y: pl.Expr | list[pl.Expr],
-        *,
-        stage: str = "Arbitration",
-        breakdown: str = "Group",
-        min_cell: int = 20,
-        additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        include_interaction_ids: bool = True,
-    ) -> dict[str, object]:
-        """Compare two cohorts head-to-head among interactions where both participate.
-
-        The comparison uses full normalized decision data rows remaining at
-        ``stage`` and later stages. Within overlapping interactions, a side
-        wins when its best row is rank 1 and ranked above the other side;
-        overlaps won by a third action or tied on best rank are counted as
-        ``other``. Breakdown cells are paired as ``x_<breakdown>`` and
-        ``y_<breakdown>`` values so they represent true overlap cells, not only
-        the winning side.
-        """
-        if breakdown not in self.decision_data.collect_schema().names():
-            raise ValueError(f"breakdown must be an available column. {breakdown!r} was not found.")
-
-        stage_rows = self.aggregates.remaining_at_stage(stage, additional_filters)
-        x_rows = apply_filter(stage_rows, filter_x)
-        y_rows = apply_filter(stage_rows, filter_y)
-
-        x_boundaries = x_rows.group_by("Interaction ID").agg(
-            x_best_rank=pl.col("Rank").min(),
-            x_worst_rank=pl.col("Rank").max(),
-            x_row_count=pl.len(),
-        )
-        y_boundaries = y_rows.group_by("Interaction ID").agg(
-            y_best_rank=pl.col("Rank").min(),
-            y_worst_rank=pl.col("Rank").max(),
-            y_row_count=pl.len(),
-        )
-
-        overlap = x_boundaries.join(y_boundaries, on="Interaction ID", how="inner").with_columns(
-            pl.when((pl.col("x_best_rank") == 1) & (pl.col("x_best_rank") < pl.col("y_best_rank")))
-            .then(pl.lit("x_wins"))
-            .when((pl.col("y_best_rank") == 1) & (pl.col("y_best_rank") < pl.col("x_best_rank")))
-            .then(pl.lit("y_wins"))
-            .otherwise(pl.lit("other"))
-            .alias("outcome")
-        )
-
-        x_ids = x_boundaries.select("Interaction ID")
-        y_ids = y_boundaries.select("Interaction ID")
-        x_only = x_ids.join(y_ids, on="Interaction ID", how="anti")
-        y_only = y_ids.join(x_ids, on="Interaction ID", how="anti")
-
-        counts = overlap.select(
-            x_wins=(pl.col("outcome") == "x_wins").sum(),
-            y_wins=(pl.col("outcome") == "y_wins").sum(),
-            other=(pl.col("outcome") == "other").sum(),
-            total_overlap=pl.len(),
-        ).collect()
-        overall = counts.row(0, named=True)
-        overall["x_only"] = x_only.select(pl.len()).collect().item()
-        overall["y_only"] = y_only.select(pl.len()).collect().item()
-
-        x_breakdown_col = f"x_{breakdown}"
-        y_breakdown_col = f"y_{breakdown}"
-        x_breakdown = x_rows.select("Interaction ID", pl.col(breakdown).alias(x_breakdown_col)).unique()
-        y_breakdown = y_rows.select("Interaction ID", pl.col(breakdown).alias(y_breakdown_col)).unique()
-        cells = (
-            x_breakdown.join(y_breakdown, on="Interaction ID", how="inner")
-            .join(overlap.select("Interaction ID", "outcome"), on="Interaction ID", how="inner")
-            .group_by([x_breakdown_col, y_breakdown_col])
-            .agg(
-                x_wins=pl.col("Interaction ID").filter(pl.col("outcome") == "x_wins").n_unique(),
-                y_wins=pl.col("Interaction ID").filter(pl.col("outcome") == "y_wins").n_unique(),
-                other=pl.col("Interaction ID").filter(pl.col("outcome") == "other").n_unique(),
-                total_overlap=pl.col("Interaction ID").n_unique(),
-            )
-            .filter(pl.col("total_overlap") >= min_cell)
-            .sort("total_overlap", descending=True)
-            .collect()
-        )
-
-        result: dict[str, object] = {
-            "overall": overall,
-            "cells": cells,
-            "breakdown": breakdown,
-            "stage": stage,
-            "stage_semantics": "rows remaining at the requested stage and later stages",
-        }
-        if include_interaction_ids:
-            outcome_ids = overlap.select("Interaction ID", "outcome")
-            result["cohorts"] = {
-                "x_wins": self._interaction_id_frame(
-                    outcome_ids.filter(pl.col("outcome") == "x_wins").select("Interaction ID")
-                ),
-                "y_wins": self._interaction_id_frame(
-                    outcome_ids.filter(pl.col("outcome") == "y_wins").select("Interaction ID")
-                ),
-                "other": self._interaction_id_frame(
-                    outcome_ids.filter(pl.col("outcome") == "other").select("Interaction ID")
-                ),
-                "x_only": self._interaction_id_frame(x_only),
-                "y_only": self._interaction_id_frame(y_only),
-            }
-        return result
-
-    def _interaction_id_frame(self, interaction_ids: pl.LazyFrame) -> pl.DataFrame:
-        return interaction_ids.select("Interaction ID").unique().collect()
-
-    def _stage_index(self, stage: str, *, strict_stage: bool) -> int | None:
-        if stage in self.AvailableNBADStages:
-            return self.AvailableNBADStages.index(stage)
-        if strict_stage:
-            raise ValueError(f"Unknown stage {stage!r}. Expected one of: {self.AvailableNBADStages}")
-        return None
 
     def get_available_fields_for_filtering(self, *, categorical_only: bool = False) -> list[str]:
         """Return column names available for data filtering.

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1002,26 +1002,10 @@ class DecisionAnalyzer:
     ) -> pl.LazyFrame:
         """Return action rows remaining at a stage.
 
-        Rows are considered remaining at ``stage`` when their current stage is
-        the requested stage or any later stage in ``AvailableNBADStages``.
-
-        Parameters
-        ----------
-        stage : str, optional
-            Stage to evaluate. When omitted, returns rows with non-null
-            ``Priority`` after applying filters.
-        additional_filters : pl.Expr or list[pl.Expr], optional
-            Filters applied before selecting remaining rows.
-        strict_stage : bool, default True
-            Raise ``ValueError`` for unknown stages. When False, unknown stages
-            return an empty frame.
+        Prefer :meth:`aggregates.remaining_at_stage`; this top-level method is
+        retained as a compatibility wrapper.
         """
-        return self._remaining_rows_at_stage(
-            self.decision_data,
-            stage,
-            additional_filters,
-            strict_stage=strict_stage,
-        )
+        return self.aggregates.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
 
     def _remaining_rows_at_stage(
         self,
@@ -1031,16 +1015,12 @@ class DecisionAnalyzer:
         *,
         strict_stage: bool = True,
     ) -> pl.LazyFrame:
-        base = apply_filter(data, additional_filters)
-        if stage is None:
-            return base.filter(pl.col("Priority").is_not_null())
-
-        stage_idx = self._stage_index(stage, strict_stage=strict_stage)
-        if stage_idx is None:
-            return base.limit(0)
-
-        remaining_stages = self.AvailableNBADStages[stage_idx:]
-        return base.filter(pl.col(self.level).is_in(remaining_stages))
+        return self.aggregates._remaining_rows_at_stage(
+            data,
+            stage,
+            additional_filters,
+            strict_stage=strict_stage,
+        )
 
     def get_interaction_ids(self, method_name: str, *args: object, **kwargs: object) -> pl.DataFrame:
         """Project unique interaction IDs from a row-producing method.
@@ -1048,8 +1028,8 @@ class DecisionAnalyzer:
         This is the main handoff interface for downstream applications that
         need the exact decision cohort behind a Decision Analyzer question.
         Use aggregate methods first to decide what needs investigation, then
-        call this method with the public row-producing method that defines the
-        cohort. The selected method is called with ``*args`` and ``**kwargs``;
+        call this method with the public row-producing method path that
+        defines the cohort. The selected method is called with ``*args`` and ``**kwargs``;
         its Polars result is reduced to a one-column DataFrame of unique
         ``Interaction ID`` values.
 
@@ -1061,19 +1041,19 @@ class DecisionAnalyzer:
 
         Pass only public methods that still return decision rows containing
         ``Interaction ID``. This works for methods such as
-        ``remaining_at_stage`` because their results still contain the rows
+        ``aggregates.remaining_at_stage`` because their results still contain the rows
         behind the cohort. Aggregate summaries should be built from the same
         row-producing cohort method whenever downstream applications also need
         the exact IDs. For counts, use :meth:`get_interaction_count` on that
         same row-producing method. If a cohort needs custom logic, add that
         logic as a row-producing method first (for example,
-        ``dropped_at_stage``), then project IDs or counts from it.
+        ``aggregates.dropped_at_stage``), then project IDs or counts from it.
 
         Parameters
         ----------
         method_name : str
-            Name of a public ``DecisionAnalyzer`` method that returns a
-            Polars DataFrame or LazyFrame containing ``Interaction ID``.
+            Name or dotted path of a public method on ``DecisionAnalyzer`` that
+            returns a Polars DataFrame or LazyFrame containing ``Interaction ID``.
         *args, **kwargs
             Arguments forwarded to the selected method.
 
@@ -1095,12 +1075,12 @@ class DecisionAnalyzer:
         --------
         Get the decisions that still have at least one action at Output:
 
-        >>> da.get_interaction_ids("remaining_at_stage", "Output")
+        >>> da.get_interaction_ids("aggregates.remaining_at_stage", "Output")
 
         Forward filters to the row-producing method:
 
         >>> da.get_interaction_ids(
-        ...     "remaining_at_stage",
+        ...     "aggregates.remaining_at_stage",
         ...     "Output",
         ...     pl.col("Channel") == "Web",
         ... )
@@ -1108,7 +1088,7 @@ class DecisionAnalyzer:
         Project IDs from a set-derived row cohort:
 
         >>> da.get_interaction_ids(
-        ...     "dropped_at_stage",
+        ...     "aggregates.dropped_at_stage",
         ...     "Contact Policies and final Action processing",
         ... )
         """
@@ -1131,8 +1111,8 @@ class DecisionAnalyzer:
         Parameters
         ----------
         method_name : str
-            Name of a public ``DecisionAnalyzer`` method that returns a
-            Polars DataFrame or LazyFrame containing ``Interaction ID``.
+            Name or dotted path of a public method on ``DecisionAnalyzer`` that
+            returns a Polars DataFrame or LazyFrame containing ``Interaction ID``.
         *args, **kwargs
             Arguments forwarded to the selected method.
 
@@ -1146,12 +1126,12 @@ class DecisionAnalyzer:
         --------
         Count decisions that still have at least one action at Output:
 
-        >>> da.get_interaction_count("remaining_at_stage", "Output")
+        >>> da.get_interaction_count("aggregates.remaining_at_stage", "Output")
 
         Count a set-derived row cohort:
 
         >>> da.get_interaction_count(
-        ...     "dropped_at_stage",
+        ...     "aggregates.dropped_at_stage",
         ...     "Contact Policies and final Action processing",
         ... )
         """
@@ -1167,10 +1147,7 @@ class DecisionAnalyzer:
         *args: object,
         **kwargs: object,
     ) -> pl.LazyFrame | pl.DataFrame:
-        if method_name.startswith("_"):
-            raise ValueError("method_name must refer to a public DecisionAnalyzer method.")
-
-        method = getattr(self, method_name, None)
+        method = self._resolve_public_method(method_name)
         if not callable(method):
             raise ValueError(f"Unknown DecisionAnalyzer method: {method_name!r}.")
 
@@ -1187,6 +1164,16 @@ class DecisionAnalyzer:
 
         raise TypeError(f"{method_name!r} must return a Polars DataFrame or LazyFrame.")
 
+    def _resolve_public_method(self, method_name: str) -> object:
+        target: object = self
+        for part in method_name.split("."):
+            if not part or part.startswith("_"):
+                raise ValueError("method_name must refer to a public DecisionAnalyzer method.")
+            target = getattr(target, part, None)
+            if target is None:
+                break
+        return target
+
     def dropped_at_stage(
         self,
         stage: str,
@@ -1196,22 +1183,10 @@ class DecisionAnalyzer:
     ) -> pl.LazyFrame:
         """Return rows for interactions that lose their final action at ``stage``.
 
-        The cohort is computed as interactions remaining at ``stage`` minus
-        interactions remaining at the next stage, using the same filters on
-        both sides. Terminal stages return an empty frame.
+        Prefer :meth:`aggregates.dropped_at_stage`; this top-level method is
+        retained as a compatibility wrapper.
         """
-        stage_idx = self._stage_index(stage, strict_stage=strict_stage)
-        if stage_idx is None or stage_idx >= len(self.AvailableNBADStages) - 1:
-            return self.remaining_at_stage(stage, additional_filters, strict_stage=False).limit(0)
-
-        current = self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
-        next_stage = self.AvailableNBADStages[stage_idx + 1]
-        next_ids = (
-            self.remaining_at_stage(next_stage, additional_filters, strict_stage=strict_stage)
-            .select("Interaction ID")
-            .unique()
-        )
-        return current.join(next_ids, on="Interaction ID", how="anti")
+        return self.aggregates.dropped_at_stage(stage, additional_filters, strict_stage=strict_stage)
 
     def get_overview_stats(self) -> dict[str, object]:
         """Return overview statistics as a concrete dictionary."""
@@ -1226,61 +1201,14 @@ class DecisionAnalyzer:
     ) -> pl.DataFrame:
         """Return per-stage action filtering counts.
 
-        Parameters
-        ----------
-        additional_filters : pl.Expr or list[pl.Expr], optional
-            Filters applied before aggregation.
-        include_zero_stages : bool, default True
-            Include all available stages except ``Output``, filling missing
-            stages with zero counts.
-        sort_by : {"actions_filtered", "interactions_affected", "stage"}, default "actions_filtered"
-            Output ordering. Count-based sorts are descending; ``"stage"``
-            preserves pipeline order.
+        Prefer :meth:`aggregates.filtered_actions_per_stage`; this top-level
+        method is retained as a compatibility wrapper.
         """
-        valid_sorts = {"actions_filtered", "interactions_affected", "stage"}
-        if sort_by not in valid_sorts:
-            raise ValueError(f"sort_by must be one of {sorted(valid_sorts)}")
-
-        stage_order = [stage for stage in self.AvailableNBADStages if stage != "Output"]
-        filtered_view = apply_filter(self.preaggregated_filter_view, additional_filters).filter(
-            pl.col("Record Type") == "FILTERED_OUT"
+        return self.aggregates.filtered_actions_per_stage(
+            additional_filters,
+            include_zero_stages=include_zero_stages,
+            sort_by=sort_by,
         )
-        result = (
-            filtered_view.with_columns(pl.col(self.level).cast(pl.Utf8))
-            .group_by(self.level)
-            .agg(
-                actions_filtered=pl.sum("Decisions"),
-                interactions_affected=pl.col("Interaction_IDs")
-                .list.explode(keep_nulls=False, empty_as_null=False)
-                .unique()
-                .count(),
-            )
-        )
-
-        if include_zero_stages:
-            result = (
-                pl.LazyFrame({self.level: stage_order})
-                .join(result, on=self.level, how="left")
-                .with_columns(pl.col("actions_filtered", "interactions_affected").fill_null(0))
-            )
-
-        result_df = result.with_columns(
-            pl.col("actions_filtered").cast(pl.Int64),
-            pl.col("interactions_affected").cast(pl.Int64),
-            pl.col(self.level)
-            .replace_strict(
-                {stage: idx for idx, stage in enumerate(stage_order)},
-                default=len(stage_order),
-                return_dtype=pl.Int64,
-            )
-            .alias("_stage_order"),
-        ).collect()
-
-        if sort_by == "stage":
-            result_df = result_df.sort("_stage_order")
-        else:
-            result_df = result_df.sort([sort_by, "_stage_order"], descending=[True, False])
-        return result_df.drop("_stage_order")
 
     def head_to_head_at_stage(
         self,
@@ -1306,7 +1234,7 @@ class DecisionAnalyzer:
         if breakdown not in self.decision_data.collect_schema().names():
             raise ValueError(f"breakdown must be an available column. {breakdown!r} was not found.")
 
-        stage_rows = self.remaining_at_stage(stage, additional_filters)
+        stage_rows = self.aggregates.remaining_at_stage(stage, additional_filters)
         x_rows = apply_filter(stage_rows, filter_x)
         y_rows = apply_filter(stage_rows, filter_y)
 

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -1193,6 +1193,121 @@ class DecisionAnalyzer:
             result_df = result_df.sort([sort_by, "_stage_order"], descending=[True, False])
         return result_df.drop("_stage_order")
 
+    def head_to_head_at_stage(
+        self,
+        filter_x: pl.Expr | list[pl.Expr],
+        filter_y: pl.Expr | list[pl.Expr],
+        *,
+        stage: str = "Arbitration",
+        breakdown: str = "Group",
+        min_cell: int = 20,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        source: str = "full",
+        include_interaction_ids: bool = True,
+    ) -> dict[str, object]:
+        """Compare two cohorts head-to-head among interactions where both participate.
+
+        The comparison uses rows remaining at ``stage`` and later stages for
+        the selected ``source``. Within overlapping interactions, a side wins
+        when its best row is rank 1 and ranked above the other side; overlaps
+        won by a third action or tied on best rank are counted as ``other``.
+        Breakdown cells are paired as ``x_<breakdown>`` and ``y_<breakdown>``
+        values so they represent true overlap cells, not only the winning side.
+        """
+        if breakdown not in self._stage_source(source).collect_schema().names():
+            raise ValueError(f"breakdown must be an available column. {breakdown!r} was not found.")
+
+        stage_rows = self.remaining_at_stage(stage, additional_filters, source=source)
+        x_rows = apply_filter(stage_rows, filter_x)
+        y_rows = apply_filter(stage_rows, filter_y)
+
+        x_boundaries = x_rows.group_by("Interaction ID").agg(
+            x_best_rank=pl.col("Rank").min(),
+            x_worst_rank=pl.col("Rank").max(),
+            x_row_count=pl.len(),
+        )
+        y_boundaries = y_rows.group_by("Interaction ID").agg(
+            y_best_rank=pl.col("Rank").min(),
+            y_worst_rank=pl.col("Rank").max(),
+            y_row_count=pl.len(),
+        )
+
+        overlap = x_boundaries.join(y_boundaries, on="Interaction ID", how="inner").with_columns(
+            pl.when((pl.col("x_best_rank") == 1) & (pl.col("x_best_rank") < pl.col("y_best_rank")))
+            .then(pl.lit("x_wins"))
+            .when((pl.col("y_best_rank") == 1) & (pl.col("y_best_rank") < pl.col("x_best_rank")))
+            .then(pl.lit("y_wins"))
+            .otherwise(pl.lit("other"))
+            .alias("outcome")
+        )
+
+        x_ids = x_boundaries.select("Interaction ID")
+        y_ids = y_boundaries.select("Interaction ID")
+        x_only = x_ids.join(y_ids, on="Interaction ID", how="anti")
+        y_only = y_ids.join(x_ids, on="Interaction ID", how="anti")
+
+        counts = overlap.select(
+            x_wins=(pl.col("outcome") == "x_wins").sum(),
+            y_wins=(pl.col("outcome") == "y_wins").sum(),
+            other=(pl.col("outcome") == "other").sum(),
+            total_overlap=pl.len(),
+        ).collect()
+        overall = counts.row(0, named=True)
+        overall["x_only"] = x_only.select(pl.len()).collect().item()
+        overall["y_only"] = y_only.select(pl.len()).collect().item()
+
+        x_breakdown_col = f"x_{breakdown}"
+        y_breakdown_col = f"y_{breakdown}"
+        x_breakdown = x_rows.select("Interaction ID", pl.col(breakdown).alias(x_breakdown_col)).unique()
+        y_breakdown = y_rows.select("Interaction ID", pl.col(breakdown).alias(y_breakdown_col)).unique()
+        cells = (
+            x_breakdown.join(y_breakdown, on="Interaction ID", how="inner")
+            .join(overlap.select("Interaction ID", "outcome"), on="Interaction ID", how="inner")
+            .group_by([x_breakdown_col, y_breakdown_col])
+            .agg(
+                x_wins=pl.col("Interaction ID").filter(pl.col("outcome") == "x_wins").n_unique(),
+                y_wins=pl.col("Interaction ID").filter(pl.col("outcome") == "y_wins").n_unique(),
+                other=pl.col("Interaction ID").filter(pl.col("outcome") == "other").n_unique(),
+                total_overlap=pl.col("Interaction ID").n_unique(),
+            )
+            .filter(pl.col("total_overlap") >= min_cell)
+            .sort("total_overlap", descending=True)
+            .collect()
+        )
+
+        result: dict[str, object] = {
+            "overall": overall,
+            "cells": cells,
+            "breakdown": breakdown,
+            "stage": stage,
+            "source": source,
+            "stage_semantics": "rows remaining at the requested stage and later stages",
+        }
+        if include_interaction_ids:
+            outcome_ids = overlap.select("Interaction ID", "outcome")
+            result["cohorts"] = {
+                "x_wins": self._details_for_interaction_frame(
+                    outcome_ids.filter(pl.col("outcome") == "x_wins").select("Interaction ID")
+                ),
+                "y_wins": self._details_for_interaction_frame(
+                    outcome_ids.filter(pl.col("outcome") == "y_wins").select("Interaction ID")
+                ),
+                "other": self._details_for_interaction_frame(
+                    outcome_ids.filter(pl.col("outcome") == "other").select("Interaction ID")
+                ),
+                "x_only": self._details_for_interaction_frame(x_only),
+                "y_only": self._details_for_interaction_frame(y_only),
+            }
+        return result
+
+    def _details_for_interaction_frame(self, interaction_ids: pl.LazyFrame) -> pl.DataFrame:
+        return (
+            self.decision_data.join(interaction_ids.unique(), on="Interaction ID", how="inner")
+            .select(self._interaction_detail_columns("full", include_subject_id=True))
+            .unique()
+            .collect()
+        )
+
     def _stage_source(self, source: str) -> pl.LazyFrame:
         if source == "sample":
             return self.sample

--- a/python/pdstools/decision_analyzer/DecisionAnalyzer.py
+++ b/python/pdstools/decision_analyzer/DecisionAnalyzer.py
@@ -998,16 +998,12 @@ class DecisionAnalyzer:
         stage: str | None = None,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
         *,
-        source: str = "sample",
         strict_stage: bool = True,
     ) -> pl.LazyFrame:
         """Return action rows remaining at a stage.
 
         Rows are considered remaining at ``stage`` when their current stage is
         the requested stage or any later stage in ``AvailableNBADStages``.
-        ``source="sample"`` uses the deterministic sampled data used by
-        exploratory analyses; ``source="full"`` uses the full normalized
-        decision data for exact cohort work.
 
         Parameters
         ----------
@@ -1016,13 +1012,26 @@ class DecisionAnalyzer:
             ``Priority`` after applying filters.
         additional_filters : pl.Expr or list[pl.Expr], optional
             Filters applied before selecting remaining rows.
-        source : {"sample", "full"}, default "sample"
-            Data source to query.
         strict_stage : bool, default True
             Raise ``ValueError`` for unknown stages. When False, unknown stages
             return an empty frame.
         """
-        base = apply_filter(self._stage_source(source), additional_filters)
+        return self._remaining_rows_at_stage(
+            self.decision_data,
+            stage,
+            additional_filters,
+            strict_stage=strict_stage,
+        )
+
+    def _remaining_rows_at_stage(
+        self,
+        data: pl.LazyFrame,
+        stage: str | None = None,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        base = apply_filter(data, additional_filters)
         if stage is None:
             return base.filter(pl.col("Priority").is_not_null())
 
@@ -1038,20 +1047,17 @@ class DecisionAnalyzer:
         stage: str,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
         *,
-        source: str = "full",
         strict_stage: bool = True,
     ) -> pl.DataFrame:
         """Return exact interaction IDs with at least one action remaining at a stage.
 
-        Exact cohort APIs default to ``source="full"``. Use
-        ``source="sample"`` only for exploratory workflows where sampled IDs
-        are acceptable.
+        Exact cohort APIs use the full normalized decision data.
         """
         if self._stage_index(stage, strict_stage=strict_stage) is None:
-            return self._empty_interaction_frame(source)
+            return self._empty_interaction_frame()
 
         return (
-            self.remaining_at_stage(stage, additional_filters, source=source, strict_stage=strict_stage)
+            self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
             .select("Interaction ID")
             .unique()
             .collect()
@@ -1062,27 +1068,26 @@ class DecisionAnalyzer:
         stage: str,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
         *,
-        source: str = "full",
         strict_stage: bool = True,
     ) -> pl.DataFrame:
         """Return exact interactions that lose their final action at ``stage``.
 
         The cohort is computed as interactions remaining at ``stage`` minus
-        interactions remaining at the next stage, using the same filters and
-        source on both sides. Terminal stages return an empty frame.
+        interactions remaining at the next stage, using the same filters on
+        both sides. Terminal stages return an empty frame.
         """
         stage_idx = self._stage_index(stage, strict_stage=strict_stage)
         if stage_idx is None or stage_idx >= len(self.AvailableNBADStages) - 1:
-            return self._empty_interaction_frame(source)
+            return self._empty_interaction_frame()
 
         current = (
-            self.remaining_at_stage(stage, additional_filters, source=source, strict_stage=strict_stage)
+            self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
             .select("Interaction ID")
             .unique()
         )
         next_stage = self.AvailableNBADStages[stage_idx + 1]
         next_ids = (
-            self.remaining_at_stage(next_stage, additional_filters, source=source, strict_stage=strict_stage)
+            self.remaining_at_stage(next_stage, additional_filters, strict_stage=strict_stage)
             .select("Interaction ID")
             .unique()
         )
@@ -1166,22 +1171,22 @@ class DecisionAnalyzer:
         breakdown: str = "Group",
         min_cell: int = 20,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        source: str = "full",
         include_interaction_ids: bool = True,
     ) -> dict[str, object]:
         """Compare two cohorts head-to-head among interactions where both participate.
 
-        The comparison uses rows remaining at ``stage`` and later stages for
-        the selected ``source``. Within overlapping interactions, a side wins
-        when its best row is rank 1 and ranked above the other side; overlaps
-        won by a third action or tied on best rank are counted as ``other``.
-        Breakdown cells are paired as ``x_<breakdown>`` and ``y_<breakdown>``
-        values so they represent true overlap cells, not only the winning side.
+        The comparison uses full normalized decision data rows remaining at
+        ``stage`` and later stages. Within overlapping interactions, a side
+        wins when its best row is rank 1 and ranked above the other side;
+        overlaps won by a third action or tied on best rank are counted as
+        ``other``. Breakdown cells are paired as ``x_<breakdown>`` and
+        ``y_<breakdown>`` values so they represent true overlap cells, not only
+        the winning side.
         """
-        if breakdown not in self._stage_source(source).collect_schema().names():
+        if breakdown not in self.decision_data.collect_schema().names():
             raise ValueError(f"breakdown must be an available column. {breakdown!r} was not found.")
 
-        stage_rows = self.remaining_at_stage(stage, additional_filters, source=source)
+        stage_rows = self.remaining_at_stage(stage, additional_filters)
         x_rows = apply_filter(stage_rows, filter_x)
         y_rows = apply_filter(stage_rows, filter_y)
 
@@ -1244,7 +1249,6 @@ class DecisionAnalyzer:
             "cells": cells,
             "breakdown": breakdown,
             "stage": stage,
-            "source": source,
             "stage_semantics": "rows remaining at the requested stage and later stages",
         }
         if include_interaction_ids:
@@ -1267,13 +1271,6 @@ class DecisionAnalyzer:
     def _interaction_id_frame(self, interaction_ids: pl.LazyFrame) -> pl.DataFrame:
         return interaction_ids.select("Interaction ID").unique().collect()
 
-    def _stage_source(self, source: str) -> pl.LazyFrame:
-        if source == "sample":
-            return self.sample
-        if source == "full":
-            return self.decision_data
-        raise ValueError("source must be either 'sample' or 'full'.")
-
     def _stage_index(self, stage: str, *, strict_stage: bool) -> int | None:
         if stage in self.AvailableNBADStages:
             return self.AvailableNBADStages.index(stage)
@@ -1281,8 +1278,8 @@ class DecisionAnalyzer:
             raise ValueError(f"Unknown stage {stage!r}. Expected one of: {self.AvailableNBADStages}")
         return None
 
-    def _empty_interaction_frame(self, source: str) -> pl.DataFrame:
-        schema = self._stage_source(source).collect_schema()
+    def _empty_interaction_frame(self) -> pl.DataFrame:
+        schema = self.decision_data.collect_schema()
         return pl.DataFrame(schema={"Interaction ID": schema["Interaction ID"]})
 
     def get_available_fields_for_filtering(self, *, categorical_only: bool = False) -> list[str]:

--- a/python/pdstools/decision_analyzer/_aggregates.py
+++ b/python/pdstools/decision_analyzer/_aggregates.py
@@ -104,6 +104,108 @@ class Aggregates:
         )
         return current.join(next_ids, on="Interaction ID", how="anti")
 
+    def available_at_stage(
+        self,
+        stage: str,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        """Return action rows available when entering ``stage``.
+
+        This is the row-producing counterpart to the ``available`` frame
+        returned by :meth:`get_funnel_data`.
+        """
+        return self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
+
+    def passing_at_stage(
+        self,
+        stage: str,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        """Return action rows that pass ``stage`` and remain afterward.
+
+        This is the row-producing counterpart to the ``passing`` frame returned
+        by :meth:`get_funnel_data`. For a pipeline stage, passing rows are the
+        rows available at the next stage. Terminal stages return an empty
+        frame.
+        """
+        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
+        if stage_idx is None or stage_idx >= len(self.da.AvailableNBADStages) - 1:
+            return self.remaining_at_stage(stage, additional_filters, strict_stage=False).limit(0)
+
+        next_stage = self.da.AvailableNBADStages[stage_idx + 1]
+        return self.remaining_at_stage(next_stage, additional_filters, strict_stage=strict_stage)
+
+    def filtered_at_stage(
+        self,
+        stage: str,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        """Return action rows filtered out at ``stage``.
+
+        This is the row-producing counterpart to the ``filtered`` frame
+        returned by :meth:`get_funnel_data` and the per-stage summary returned
+        by :meth:`filtered_actions_per_stage`.
+        """
+        base = apply_filter(self.da.decision_data, additional_filters)
+        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
+        if stage_idx is None:
+            return base.limit(0)
+
+        return base.filter((pl.col(self.da.level) == stage) & (pl.col("Record Type") == "FILTERED_OUT"))
+
+    def filtered_by_component(
+        self,
+        component_name: str,
+        stage: str | None = None,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        """Return action rows filtered by a named component.
+
+        This is the row-producing counterpart to
+        :meth:`get_filter_component_data` and component impact summaries.
+        Pass ``stage`` to narrow the component cohort to a single pipeline
+        stage.
+        """
+        available = self.da.decision_data.collect_schema().names()
+        if "Component Name" not in available:
+            raise ValueError("Component Name is not available in this Decision Analyzer export.")
+
+        base = apply_filter(self.da.decision_data, additional_filters).filter(
+            (pl.col("Record Type") == "FILTERED_OUT") & (pl.col("Component Name") == component_name)
+        )
+        if stage is None:
+            return base
+
+        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
+        if stage_idx is None:
+            return base.limit(0)
+
+        return base.filter(pl.col(self.da.level) == stage)
+
+    def without_actions_at_stage(
+        self,
+        stage: str,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        """Return rows for interactions newly left without actions at ``stage``.
+
+        This is the row-producing counterpart to
+        :meth:`get_decisions_without_actions_data`. It returns the last rows
+        present before an interaction loses all remaining actions, so callers
+        can project the affected ``Interaction ID`` values.
+        """
+        return self.dropped_at_stage(stage, additional_filters, strict_stage=strict_stage)
+
     def filtered_actions_per_stage(
         self,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,

--- a/python/pdstools/decision_analyzer/_aggregates.py
+++ b/python/pdstools/decision_analyzer/_aggregates.py
@@ -72,6 +72,17 @@ class Aggregates:
             ``ValueError``.
         additional_filters : pl.Expr or list[pl.Expr], optional
             Filters applied before selecting remaining rows.
+
+        Returns
+        -------
+        pl.LazyFrame
+            Decision rows that still have an action at the requested stage.
+
+        Raises
+        ------
+        ValueError
+            If ``stage`` is not one of the available Decision Analyzer stage
+            names.
         """
         return self._remaining_rows_at_stage(self.da.decision_data, stage, additional_filters)
 
@@ -99,6 +110,26 @@ class Aggregates:
         interactions remaining at the next stage, using the same filters on
         both sides. Terminal stages return an empty frame. An unknown stage
         raises ``ValueError``.
+
+        Parameters
+        ----------
+        stage : str
+            Stage where the interaction drop-off is evaluated.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before computing the current-stage and next-stage
+            cohorts.
+
+        Returns
+        -------
+        pl.LazyFrame
+            Decision rows for interactions present at ``stage`` but absent at
+            the next pipeline stage.
+
+        Raises
+        ------
+        ValueError
+            If ``stage`` is not one of the available Decision Analyzer stage
+            names.
         """
         stage_idx = self._stage_index(stage)
         if stage_idx >= len(self.da.AvailableNBADStages) - 1:
@@ -119,6 +150,24 @@ class Aggregates:
         This is the row-producing counterpart to the ``available`` frame
         returned by :meth:`get_funnel_data`. An unknown stage raises
         ``ValueError``.
+
+        Parameters
+        ----------
+        stage : str
+            Stage whose entering action rows are returned.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before selecting available rows.
+
+        Returns
+        -------
+        pl.LazyFrame
+            Decision rows available at the requested stage.
+
+        Raises
+        ------
+        ValueError
+            If ``stage`` is not one of the available Decision Analyzer stage
+            names.
         """
         return self.remaining_at_stage(stage, additional_filters)
 
@@ -133,6 +182,25 @@ class Aggregates:
         by :meth:`get_funnel_data`. For a pipeline stage, passing rows are the
         rows available at the next stage. Terminal stages return an empty
         frame. An unknown stage raises ``ValueError``.
+
+        Parameters
+        ----------
+        stage : str
+            Stage whose passing action rows are returned.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before selecting passing rows.
+
+        Returns
+        -------
+        pl.LazyFrame
+            Decision rows available at the next pipeline stage. Terminal
+            stages return an empty frame with the same schema.
+
+        Raises
+        ------
+        ValueError
+            If ``stage`` is not one of the available Decision Analyzer stage
+            names.
         """
         stage_idx = self._stage_index(stage)
         if stage_idx >= len(self.da.AvailableNBADStages) - 1:
@@ -152,6 +220,25 @@ class Aggregates:
         returned by :meth:`get_funnel_data` and the per-stage summary returned
         by :meth:`filtered_actions_per_stage`. An unknown stage raises
         ``ValueError``.
+
+        Parameters
+        ----------
+        stage : str
+            Stage whose filtered action rows are returned.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before selecting filtered rows.
+
+        Returns
+        -------
+        pl.LazyFrame
+            Decision rows with ``Record Type == "FILTERED_OUT"`` at the
+            requested stage.
+
+        Raises
+        ------
+        ValueError
+            If ``stage`` is not one of the available Decision Analyzer stage
+            names.
         """
         self._stage_index(stage)
         base = apply_filter(self.da.decision_data, additional_filters)
@@ -169,6 +256,29 @@ class Aggregates:
         :meth:`get_filter_component_data` and component impact summaries.
         Pass ``stage`` to narrow the component cohort to a single pipeline
         stage; an unknown stage raises ``ValueError``.
+
+        Parameters
+        ----------
+        component_name : str
+            Component name from the ``Component Name`` column.
+        stage : str, optional
+            Stage to restrict the component cohort to. When omitted, rows from
+            all stages are returned.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before selecting component rows.
+
+        Returns
+        -------
+        pl.LazyFrame
+            Filtered-out decision rows matching ``component_name`` and,
+            optionally, ``stage``.
+
+        Raises
+        ------
+        ValueError
+            If the export does not include ``Component Name`` or if ``stage``
+            is provided but is not one of the available Decision Analyzer stage
+            names.
         """
         available = self.da.decision_data.collect_schema().names()
         if "Component Name" not in available:
@@ -194,6 +304,25 @@ class Aggregates:
         :meth:`get_decisions_without_actions_data`. It returns the last rows
         present before an interaction loses all remaining actions, so callers
         can project the affected ``Interaction ID`` values.
+
+        Parameters
+        ----------
+        stage : str
+            Stage where interactions are evaluated for losing all actions.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before computing the drop-off cohort.
+
+        Returns
+        -------
+        pl.LazyFrame
+            Decision rows for interactions that are present at ``stage`` and no
+            longer present at the next pipeline stage.
+
+        Raises
+        ------
+        ValueError
+            If ``stage`` is not one of the available Decision Analyzer stage
+            names.
         """
         return self.dropped_at_stage(stage, additional_filters)
 
@@ -217,6 +346,50 @@ class Aggregates:
         ``other``. Breakdown cells are paired as ``x_<breakdown>`` and
         ``y_<breakdown>`` values so they represent true overlap cells, not only
         the winning side.
+
+        Parameters
+        ----------
+        filter_x : pl.Expr or list[pl.Expr]
+            Filter expression defining the first comparison cohort.
+        filter_y : pl.Expr or list[pl.Expr]
+            Filter expression defining the second comparison cohort.
+        stage : str, default "Arbitration"
+            Stage at which to evaluate the comparison. Rows at this stage and
+            later stages are considered remaining in the cohort.
+        breakdown : str, default "Group"
+            Column used to pair overlap cells. The result contains
+            ``x_<breakdown>`` and ``y_<breakdown>`` columns.
+        min_cell : int, default 20
+            Minimum overlapping interaction count required for a paired
+            breakdown cell to be included in ``cells``.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before the two comparison filters are evaluated.
+        include_interaction_ids : bool, default True
+            Include per-outcome interaction-ID cohorts in the returned result.
+            Set to ``False`` when only aggregate counts and cells are needed.
+
+        Returns
+        -------
+        HeadToHeadResult
+            Overall outcome counts, paired breakdown cells, comparison
+            metadata, and optionally per-outcome interaction-ID cohorts.
+
+        Raises
+        ------
+        ValueError
+            If ``stage`` is not one of the available Decision Analyzer stage
+            names, or if ``breakdown`` is not a column in the decision data.
+
+        Examples
+        --------
+        Compare two groups at arbitration and return both summary counts and
+        interaction-ID cohorts:
+
+        >>> da.aggregates.head_to_head_at_stage(
+        ...     pl.col("Group") == "Retention",
+        ...     pl.col("Group") == "Sales",
+        ...     stage="Arbitration",
+        ... )
         """
         if breakdown not in self.da.decision_data.collect_schema().names():
             raise ValueError(f"breakdown must be an available column. {breakdown!r} was not found.")

--- a/python/pdstools/decision_analyzer/_aggregates.py
+++ b/python/pdstools/decision_analyzer/_aggregates.py
@@ -29,6 +29,146 @@ class Aggregates:
     def __init__(self, da: "DecisionAnalyzer") -> None:
         self.da = da
 
+    def remaining_at_stage(
+        self,
+        stage: str | None = None,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        """Return action rows remaining at a stage.
+
+        Rows are considered remaining at ``stage`` when their current stage is
+        the requested stage or any later stage in ``AvailableNBADStages``.
+
+        Parameters
+        ----------
+        stage : str, optional
+            Stage to evaluate. When omitted, returns rows with non-null
+            ``Priority`` after applying filters.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before selecting remaining rows.
+        strict_stage : bool, default True
+            Raise ``ValueError`` for unknown stages. When False, unknown stages
+            return an empty frame.
+        """
+        return self._remaining_rows_at_stage(
+            self.da.decision_data,
+            stage,
+            additional_filters,
+            strict_stage=strict_stage,
+        )
+
+    def _remaining_rows_at_stage(
+        self,
+        data: pl.LazyFrame,
+        stage: str | None = None,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        base = apply_filter(data, additional_filters)
+        if stage is None:
+            return base.filter(pl.col("Priority").is_not_null())
+
+        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
+        if stage_idx is None:
+            return base.limit(0)
+
+        remaining_stages = self.da.AvailableNBADStages[stage_idx:]
+        return base.filter(pl.col(self.da.level).is_in(remaining_stages))
+
+    def dropped_at_stage(
+        self,
+        stage: str,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        strict_stage: bool = True,
+    ) -> pl.LazyFrame:
+        """Return rows for interactions that lose their final action at ``stage``.
+
+        The cohort is computed as interactions remaining at ``stage`` minus
+        interactions remaining at the next stage, using the same filters on
+        both sides. Terminal stages return an empty frame.
+        """
+        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
+        if stage_idx is None or stage_idx >= len(self.da.AvailableNBADStages) - 1:
+            return self.remaining_at_stage(stage, additional_filters, strict_stage=False).limit(0)
+
+        current = self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
+        next_stage = self.da.AvailableNBADStages[stage_idx + 1]
+        next_ids = (
+            self.remaining_at_stage(next_stage, additional_filters, strict_stage=strict_stage)
+            .select("Interaction ID")
+            .unique()
+        )
+        return current.join(next_ids, on="Interaction ID", how="anti")
+
+    def filtered_actions_per_stage(
+        self,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        include_zero_stages: bool = True,
+        sort_by: str = "actions_filtered",
+    ) -> pl.DataFrame:
+        """Return per-stage action filtering counts.
+
+        Parameters
+        ----------
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied before aggregation.
+        include_zero_stages : bool, default True
+            Include all available stages except ``Output``, filling missing
+            stages with zero counts.
+        sort_by : {"actions_filtered", "interactions_affected", "stage"}, default "actions_filtered"
+            Output ordering. Count-based sorts are descending; ``"stage"``
+            preserves pipeline order.
+        """
+        valid_sorts = {"actions_filtered", "interactions_affected", "stage"}
+        if sort_by not in valid_sorts:
+            raise ValueError(f"sort_by must be one of {sorted(valid_sorts)}")
+
+        stage_order = [stage for stage in self.da.AvailableNBADStages if stage != "Output"]
+        filtered_view = apply_filter(self.da.preaggregated_filter_view, additional_filters).filter(
+            pl.col("Record Type") == "FILTERED_OUT"
+        )
+        result = (
+            filtered_view.with_columns(pl.col(self.da.level).cast(pl.Utf8))
+            .group_by(self.da.level)
+            .agg(
+                actions_filtered=pl.sum("Decisions"),
+                interactions_affected=pl.col("Interaction_IDs")
+                .list.explode(keep_nulls=False, empty_as_null=False)
+                .unique()
+                .count(),
+            )
+        )
+
+        if include_zero_stages:
+            result = (
+                pl.LazyFrame({self.da.level: stage_order})
+                .join(result, on=self.da.level, how="left")
+                .with_columns(pl.col("actions_filtered", "interactions_affected").fill_null(0))
+            )
+
+        result_df = result.with_columns(
+            pl.col("actions_filtered").cast(pl.Int64),
+            pl.col("interactions_affected").cast(pl.Int64),
+            pl.col(self.da.level)
+            .replace_strict(
+                {stage: idx for idx, stage in enumerate(stage_order)},
+                default=len(stage_order),
+                return_dtype=pl.Int64,
+            )
+            .alias("_stage_order"),
+        ).collect()
+
+        if sort_by == "stage":
+            result_df = result_df.sort("_stage_order")
+        else:
+            result_df = result_df.sort([sort_by, "_stage_order"], descending=[True, False])
+        return result_df.drop("_stage_order")
+
     def aggregate_remaining_per_stage(
         self,
         df: pl.LazyFrame,

--- a/python/pdstools/decision_analyzer/_aggregates.py
+++ b/python/pdstools/decision_analyzer/_aggregates.py
@@ -7,9 +7,10 @@ into the frames consumed by the plot layer and the Streamlit pages.
 
 from __future__ import annotations
 
-__all__ = ["Aggregates"]
+__all__ = ["Aggregates", "HeadToHeadResult"]
 
 from bisect import bisect_left
+from dataclasses import dataclass
 from typing import Literal, TYPE_CHECKING
 
 import polars as pl
@@ -18,6 +19,24 @@ from .utils import apply_filter, gini_coefficient
 
 if TYPE_CHECKING:
     from .DecisionAnalyzer import DecisionAnalyzer
+
+
+@dataclass(frozen=True)
+class HeadToHeadResult:
+    """Result of :meth:`Aggregates.head_to_head_at_stage`."""
+
+    overall: dict[str, int]
+    """Overall outcome counts: ``x_wins``, ``y_wins``, ``other``, ``total_overlap``, ``x_only``, ``y_only``."""
+    cells: pl.DataFrame
+    """Paired ``x_<breakdown>``/``y_<breakdown>`` overlap cells with per-cell outcome counts."""
+    breakdown: str
+    """Breakdown column used to pair the overlap cells."""
+    stage: str
+    """Stage the comparison was evaluated at."""
+    stage_semantics: str
+    """Human-readable description of the stage-cohort semantics."""
+    cohorts: dict[str, pl.DataFrame] | None = None
+    """Per-outcome interaction-ID cohorts, or ``None`` when not requested."""
 
 
 class Aggregates:
@@ -29,12 +48,16 @@ class Aggregates:
     def __init__(self, da: "DecisionAnalyzer") -> None:
         self.da = da
 
+    def _stage_index(self, stage: str) -> int:
+        """Return the pipeline index of ``stage``, raising on unknown stages."""
+        if stage not in self.da.AvailableNBADStages:
+            raise ValueError(f"Unknown stage {stage!r}. Expected one of: {self.da.AvailableNBADStages}")
+        return self.da.AvailableNBADStages.index(stage)
+
     def remaining_at_stage(
         self,
         stage: str | None = None,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
     ) -> pl.LazyFrame:
         """Return action rows remaining at a stage.
 
@@ -45,118 +68,93 @@ class Aggregates:
         ----------
         stage : str, optional
             Stage to evaluate. When omitted, returns rows with non-null
-            ``Priority`` after applying filters.
+            ``Priority`` after applying filters. An unknown stage raises
+            ``ValueError``.
         additional_filters : pl.Expr or list[pl.Expr], optional
             Filters applied before selecting remaining rows.
-        strict_stage : bool, default True
-            Raise ``ValueError`` for unknown stages. When False, unknown stages
-            return an empty frame.
         """
-        return self._remaining_rows_at_stage(
-            self.da.decision_data,
-            stage,
-            additional_filters,
-            strict_stage=strict_stage,
-        )
+        return self._remaining_rows_at_stage(self.da.decision_data, stage, additional_filters)
 
     def _remaining_rows_at_stage(
         self,
         data: pl.LazyFrame,
         stage: str | None = None,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
     ) -> pl.LazyFrame:
         base = apply_filter(data, additional_filters)
         if stage is None:
             return base.filter(pl.col("Priority").is_not_null())
 
-        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
-        if stage_idx is None:
-            return base.limit(0)
-
-        remaining_stages = self.da.AvailableNBADStages[stage_idx:]
+        remaining_stages = self.da.AvailableNBADStages[self._stage_index(stage) :]
         return base.filter(pl.col(self.da.level).is_in(remaining_stages))
 
     def dropped_at_stage(
         self,
         stage: str,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
     ) -> pl.LazyFrame:
         """Return rows for interactions that lose their final action at ``stage``.
 
         The cohort is computed as interactions remaining at ``stage`` minus
         interactions remaining at the next stage, using the same filters on
-        both sides. Terminal stages return an empty frame.
+        both sides. Terminal stages return an empty frame. An unknown stage
+        raises ``ValueError``.
         """
-        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
-        if stage_idx is None or stage_idx >= len(self.da.AvailableNBADStages) - 1:
-            return self.remaining_at_stage(stage, additional_filters, strict_stage=False).limit(0)
+        stage_idx = self._stage_index(stage)
+        if stage_idx >= len(self.da.AvailableNBADStages) - 1:
+            return self.remaining_at_stage(stage, additional_filters).limit(0)
 
-        current = self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
+        current = self.remaining_at_stage(stage, additional_filters)
         next_stage = self.da.AvailableNBADStages[stage_idx + 1]
-        next_ids = (
-            self.remaining_at_stage(next_stage, additional_filters, strict_stage=strict_stage)
-            .select("Interaction ID")
-            .unique()
-        )
+        next_ids = self.remaining_at_stage(next_stage, additional_filters).select("Interaction ID").unique()
         return current.join(next_ids, on="Interaction ID", how="anti")
 
     def available_at_stage(
         self,
         stage: str,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
     ) -> pl.LazyFrame:
         """Return action rows available when entering ``stage``.
 
         This is the row-producing counterpart to the ``available`` frame
-        returned by :meth:`get_funnel_data`.
+        returned by :meth:`get_funnel_data`. An unknown stage raises
+        ``ValueError``.
         """
-        return self.remaining_at_stage(stage, additional_filters, strict_stage=strict_stage)
+        return self.remaining_at_stage(stage, additional_filters)
 
     def passing_at_stage(
         self,
         stage: str,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
     ) -> pl.LazyFrame:
         """Return action rows that pass ``stage`` and remain afterward.
 
         This is the row-producing counterpart to the ``passing`` frame returned
         by :meth:`get_funnel_data`. For a pipeline stage, passing rows are the
         rows available at the next stage. Terminal stages return an empty
-        frame.
+        frame. An unknown stage raises ``ValueError``.
         """
-        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
-        if stage_idx is None or stage_idx >= len(self.da.AvailableNBADStages) - 1:
-            return self.remaining_at_stage(stage, additional_filters, strict_stage=False).limit(0)
+        stage_idx = self._stage_index(stage)
+        if stage_idx >= len(self.da.AvailableNBADStages) - 1:
+            return self.remaining_at_stage(stage, additional_filters).limit(0)
 
         next_stage = self.da.AvailableNBADStages[stage_idx + 1]
-        return self.remaining_at_stage(next_stage, additional_filters, strict_stage=strict_stage)
+        return self.remaining_at_stage(next_stage, additional_filters)
 
     def filtered_at_stage(
         self,
         stage: str,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
     ) -> pl.LazyFrame:
         """Return action rows filtered out at ``stage``.
 
         This is the row-producing counterpart to the ``filtered`` frame
         returned by :meth:`get_funnel_data` and the per-stage summary returned
-        by :meth:`filtered_actions_per_stage`.
+        by :meth:`filtered_actions_per_stage`. An unknown stage raises
+        ``ValueError``.
         """
+        self._stage_index(stage)
         base = apply_filter(self.da.decision_data, additional_filters)
-        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
-        if stage_idx is None:
-            return base.limit(0)
-
         return base.filter((pl.col(self.da.level) == stage) & (pl.col("Record Type") == "FILTERED_OUT"))
 
     def filtered_by_component(
@@ -164,15 +162,13 @@ class Aggregates:
         component_name: str,
         stage: str | None = None,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
     ) -> pl.LazyFrame:
         """Return action rows filtered by a named component.
 
         This is the row-producing counterpart to
         :meth:`get_filter_component_data` and component impact summaries.
         Pass ``stage`` to narrow the component cohort to a single pipeline
-        stage.
+        stage; an unknown stage raises ``ValueError``.
         """
         available = self.da.decision_data.collect_schema().names()
         if "Component Name" not in available:
@@ -184,18 +180,13 @@ class Aggregates:
         if stage is None:
             return base
 
-        stage_idx = self.da._stage_index(stage, strict_stage=strict_stage)
-        if stage_idx is None:
-            return base.limit(0)
-
+        self._stage_index(stage)
         return base.filter(pl.col(self.da.level) == stage)
 
     def without_actions_at_stage(
         self,
         stage: str,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        strict_stage: bool = True,
     ) -> pl.LazyFrame:
         """Return rows for interactions newly left without actions at ``stage``.
 
@@ -204,7 +195,118 @@ class Aggregates:
         present before an interaction loses all remaining actions, so callers
         can project the affected ``Interaction ID`` values.
         """
-        return self.dropped_at_stage(stage, additional_filters, strict_stage=strict_stage)
+        return self.dropped_at_stage(stage, additional_filters)
+
+    def head_to_head_at_stage(
+        self,
+        filter_x: pl.Expr | list[pl.Expr],
+        filter_y: pl.Expr | list[pl.Expr],
+        *,
+        stage: str = "Arbitration",
+        breakdown: str = "Group",
+        min_cell: int = 20,
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        include_interaction_ids: bool = True,
+    ) -> HeadToHeadResult:
+        """Compare two cohorts head-to-head among interactions where both participate.
+
+        The comparison uses full normalized decision data rows remaining at
+        ``stage`` and later stages. Within overlapping interactions, a side
+        wins when its best row is rank 1 and ranked above the other side;
+        overlaps won by a third action or tied on best rank are counted as
+        ``other``. Breakdown cells are paired as ``x_<breakdown>`` and
+        ``y_<breakdown>`` values so they represent true overlap cells, not only
+        the winning side.
+        """
+        if breakdown not in self.da.decision_data.collect_schema().names():
+            raise ValueError(f"breakdown must be an available column. {breakdown!r} was not found.")
+
+        stage_rows = self.remaining_at_stage(stage, additional_filters)
+        x_rows = apply_filter(stage_rows, filter_x)
+        y_rows = apply_filter(stage_rows, filter_y)
+
+        x_boundaries = x_rows.group_by("Interaction ID").agg(
+            x_best_rank=pl.col("Rank").min(),
+            x_worst_rank=pl.col("Rank").max(),
+            x_row_count=pl.len(),
+        )
+        y_boundaries = y_rows.group_by("Interaction ID").agg(
+            y_best_rank=pl.col("Rank").min(),
+            y_worst_rank=pl.col("Rank").max(),
+            y_row_count=pl.len(),
+        )
+
+        overlap = x_boundaries.join(y_boundaries, on="Interaction ID", how="inner").with_columns(
+            pl.when((pl.col("x_best_rank") == 1) & (pl.col("x_best_rank") < pl.col("y_best_rank")))
+            .then(pl.lit("x_wins"))
+            .when((pl.col("y_best_rank") == 1) & (pl.col("y_best_rank") < pl.col("x_best_rank")))
+            .then(pl.lit("y_wins"))
+            .otherwise(pl.lit("other"))
+            .alias("outcome")
+        )
+
+        x_ids = x_boundaries.select("Interaction ID")
+        y_ids = y_boundaries.select("Interaction ID")
+        x_only = x_ids.join(y_ids, on="Interaction ID", how="anti")
+        y_only = y_ids.join(x_ids, on="Interaction ID", how="anti")
+
+        counts = overlap.select(
+            x_wins=(pl.col("outcome") == "x_wins").sum(),
+            y_wins=(pl.col("outcome") == "y_wins").sum(),
+            other=(pl.col("outcome") == "other").sum(),
+            total_overlap=pl.len(),
+        ).collect()
+        overall = counts.row(0, named=True)
+        overall["x_only"] = x_only.select(pl.len()).collect().item()
+        overall["y_only"] = y_only.select(pl.len()).collect().item()
+
+        x_breakdown_col = f"x_{breakdown}"
+        y_breakdown_col = f"y_{breakdown}"
+        x_breakdown = x_rows.select("Interaction ID", pl.col(breakdown).alias(x_breakdown_col)).unique()
+        y_breakdown = y_rows.select("Interaction ID", pl.col(breakdown).alias(y_breakdown_col)).unique()
+        cells = (
+            x_breakdown.join(y_breakdown, on="Interaction ID", how="inner")
+            .join(overlap.select("Interaction ID", "outcome"), on="Interaction ID", how="inner")
+            .group_by([x_breakdown_col, y_breakdown_col])
+            .agg(
+                x_wins=pl.col("Interaction ID").filter(pl.col("outcome") == "x_wins").n_unique(),
+                y_wins=pl.col("Interaction ID").filter(pl.col("outcome") == "y_wins").n_unique(),
+                other=pl.col("Interaction ID").filter(pl.col("outcome") == "other").n_unique(),
+                total_overlap=pl.col("Interaction ID").n_unique(),
+            )
+            .filter(pl.col("total_overlap") >= min_cell)
+            .sort("total_overlap", descending=True)
+            .collect()
+        )
+
+        cohorts: dict[str, pl.DataFrame] | None = None
+        if include_interaction_ids:
+            outcome_ids = overlap.select("Interaction ID", "outcome")
+            cohorts = {
+                "x_wins": self._interaction_id_frame(
+                    outcome_ids.filter(pl.col("outcome") == "x_wins").select("Interaction ID")
+                ),
+                "y_wins": self._interaction_id_frame(
+                    outcome_ids.filter(pl.col("outcome") == "y_wins").select("Interaction ID")
+                ),
+                "other": self._interaction_id_frame(
+                    outcome_ids.filter(pl.col("outcome") == "other").select("Interaction ID")
+                ),
+                "x_only": self._interaction_id_frame(x_only),
+                "y_only": self._interaction_id_frame(y_only),
+            }
+
+        return HeadToHeadResult(
+            overall=overall,
+            cells=cells,
+            breakdown=breakdown,
+            stage=stage,
+            stage_semantics="rows remaining at the requested stage and later stages",
+            cohorts=cohorts,
+        )
+
+    def _interaction_id_frame(self, interaction_ids: pl.LazyFrame) -> pl.DataFrame:
+        return interaction_ids.select("Interaction ID").unique().collect()
 
     def filtered_actions_per_stage(
         self,

--- a/python/pdstools/decision_analyzer/_scoring.py
+++ b/python/pdstools/decision_analyzer/_scoring.py
@@ -545,8 +545,6 @@ class Scoring:
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
         *,
         source: str = "sample",
-        include_subject_id: bool = False,
-        include_group_columns: bool = False,
     ) -> pl.LazyFrame:
         """Interaction IDs where the comparison group wins or loses.
 
@@ -563,17 +561,11 @@ class Scoring:
             Extra filters (e.g. channel filter).
         source : {"sample", "full"}, default "sample"
             Data source to query.
-        include_subject_id : bool, default False
-            Include ``Subject ID`` when present.
-        include_group_columns : bool, default False
-            Include available ``Issue``, ``Group``, and ``Action`` detail columns.
 
         Returns
         -------
         pl.LazyFrame
-            By default, a single-column frame of unique ``Interaction ID``
-            values. Detail options add available columns and unique rows by
-            the selected output schema.
+            A single-column frame of unique ``Interaction ID`` values.
         """
         selected_group_rank_boundaries = self.get_selected_group_rank_boundaries(
             group_filter=group_filter,
@@ -589,17 +581,10 @@ class Scoring:
         else:
             interaction_filter = pl.col("Rank") < pl.col("selected_group_best_rank")
 
-        output_columns = ["Interaction ID"]
-        if include_subject_id and "Subject ID" in stage_filtered_data.collect_schema().names():
-            output_columns.append("Subject ID")
-        if include_group_columns:
-            available = set(stage_filtered_data.collect_schema().names())
-            output_columns.extend(col for col in ["Issue", "Group", "Action"] if col in available)
-
         return (
             stage_filtered_data.join(selected_group_rank_boundaries, on="Interaction ID", how="inner")
             .filter(interaction_filter)
-            .select(output_columns)
+            .select("Interaction ID")
             .unique()
         )
 

--- a/python/pdstools/decision_analyzer/_scoring.py
+++ b/python/pdstools/decision_analyzer/_scoring.py
@@ -109,6 +109,8 @@ class Scoring:
         self,
         group_filter: pl.Expr | list[pl.Expr],
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        source: str = "sample",
     ) -> pl.LazyFrame:
         """Compute selected-group rank boundaries per interaction.
 
@@ -117,7 +119,7 @@ class Scoring:
         selected rows in arbitration-relevant stages.
         """
         selected_rows = (
-            apply_filter(apply_filter(self.da.sample, additional_filters), group_filter)
+            apply_filter(apply_filter(self.da._stage_source(source), additional_filters), group_filter)
             .filter(pl.col(self.da.level).is_in(self.da.stages_from_arbitration_down))
             .select(["Interaction ID", "Rank"])
         )
@@ -541,6 +543,10 @@ class Scoring:
         group_filter: pl.Expr | list[pl.Expr],
         win: bool,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
+        *,
+        source: str = "sample",
+        include_subject_id: bool = False,
+        include_group_columns: bool = False,
     ) -> pl.LazyFrame:
         """Interaction IDs where the comparison group wins or loses.
 
@@ -555,17 +561,26 @@ class Scoring:
             actions outside the group).
         additional_filters : pl.Expr or list of pl.Expr, optional
             Extra filters (e.g. channel filter).
+        source : {"sample", "full"}, default "sample"
+            Data source to query.
+        include_subject_id : bool, default False
+            Include ``Subject ID`` when present.
+        include_group_columns : bool, default False
+            Include available ``Issue``, ``Group``, and ``Action`` detail columns.
 
         Returns
         -------
         pl.LazyFrame
-            Single-column frame of unique ``Interaction ID`` values.
+            By default, a single-column frame of unique ``Interaction ID``
+            values. Detail options add available columns and unique rows by
+            the selected output schema.
         """
         selected_group_rank_boundaries = self.get_selected_group_rank_boundaries(
             group_filter=group_filter,
             additional_filters=additional_filters,
+            source=source,
         )
-        stage_filtered_data = apply_filter(self.da.sample, additional_filters).filter(
+        stage_filtered_data = apply_filter(self.da._stage_source(source), additional_filters).filter(
             pl.col(self.da.level).is_in(self.da.stages_from_arbitration_down)
         )
 
@@ -574,10 +589,18 @@ class Scoring:
         else:
             interaction_filter = pl.col("Rank") < pl.col("selected_group_best_rank")
 
+        output_columns = ["Interaction ID"]
+        if include_subject_id and "Subject ID" in stage_filtered_data.collect_schema().names():
+            output_columns.append("Subject ID")
+        if include_group_columns:
+            available = set(stage_filtered_data.collect_schema().names())
+            output_columns.extend(col for col in ["Issue", "Group", "Action"] if col in available)
+
         return (
             stage_filtered_data.join(selected_group_rank_boundaries, on="Interaction ID", how="inner")
             .filter(interaction_filter)
-            .select(pl.col("Interaction ID").unique())
+            .select(output_columns)
+            .unique()
         )
 
     def get_win_loss_counts(

--- a/python/pdstools/decision_analyzer/_scoring.py
+++ b/python/pdstools/decision_analyzer/_scoring.py
@@ -118,6 +118,20 @@ class Scoring:
         downsampled ``sample`` — this backs the sample-scoped win/loss
         summaries and distributions. The exact full-data cohort is provided by
         :meth:`get_winning_or_losing_interactions`.
+
+        Parameters
+        ----------
+        group_filter : pl.Expr or list[pl.Expr]
+            Filter defining the selected comparison group.
+        additional_filters : pl.Expr or list[pl.Expr], optional
+            Filters applied to the sampled decision rows before selecting the
+            comparison group.
+
+        Returns
+        -------
+        pl.LazyFrame
+            One row per sampled interaction containing the selected group's
+            best rank, worst rank, and row count.
         """
         return self._selected_group_rank_boundaries(self.da.sample, group_filter, additional_filters)
 

--- a/python/pdstools/decision_analyzer/_scoring.py
+++ b/python/pdstools/decision_analyzer/_scoring.py
@@ -109,8 +109,6 @@ class Scoring:
         self,
         group_filter: pl.Expr | list[pl.Expr],
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        source: str = "sample",
     ) -> pl.LazyFrame:
         """Compute selected-group rank boundaries per interaction.
 
@@ -119,7 +117,7 @@ class Scoring:
         selected rows in arbitration-relevant stages.
         """
         selected_rows = (
-            apply_filter(apply_filter(self.da._stage_source(source), additional_filters), group_filter)
+            apply_filter(apply_filter(self.da.decision_data, additional_filters), group_filter)
             .filter(pl.col(self.da.level).is_in(self.da.stages_from_arbitration_down))
             .select(["Interaction ID", "Rank"])
         )
@@ -128,27 +126,6 @@ class Scoring:
             selected_group_best_rank=pl.col("Rank").min(),
             selected_group_worst_rank=pl.col("Rank").max(),
             selected_group_row_count=pl.len(),
-        )
-
-    def _remaining_at_stage(
-        self,
-        stage: str | None = None,
-        additional_filters: pl.Expr | list[pl.Expr] | None = None,
-    ) -> pl.LazyFrame:
-        """Return sample rows remaining at *stage*.
-
-        Uses the ``aggregate_remaining_per_stage`` logic: rows whose stage
-        order is >= the selected stage are "remaining" there.  If *stage*
-        is None, falls back to rows with non-null Priority.
-        """
-        legacy_stage = stage
-        if stage is not None and stage not in self.da.AvailableNBADStages:
-            legacy_stage = self.da.AvailableNBADStages[0]
-        return self.da.remaining_at_stage(
-            legacy_stage,
-            additional_filters,
-            source="sample",
-            strict_stage=False,
         )
 
     def get_sensitivity(
@@ -315,7 +292,7 @@ class Scoring:
             Extra filters applied to the sample (e.g. channel filter).
         """
         cols = [granularity, component]
-        df = self._remaining_at_stage(stage, additional_filters=additional_filters)
+        df = self.da._remaining_rows_at_stage(self.da.sample, stage, additional_filters=additional_filters)
         return df.select(cols).sort(granularity)
 
     def all_components_distribution(
@@ -339,7 +316,7 @@ class Scoring:
 
         available = set(self.da.sample.collect_schema().names())
         cols = [c for c in PRIO_COMPONENTS if c in available]
-        df = self._remaining_at_stage(stage, additional_filters=additional_filters)
+        df = self.da._remaining_rows_at_stage(self.da.sample, stage, additional_filters=additional_filters)
         return df.select([granularity, *cols]).sort(granularity)
 
     def get_win_loss_distribution_data(
@@ -543,8 +520,6 @@ class Scoring:
         group_filter: pl.Expr | list[pl.Expr],
         win: bool,
         additional_filters: pl.Expr | list[pl.Expr] | None = None,
-        *,
-        source: str = "sample",
     ) -> pl.LazyFrame:
         """Interaction IDs where the comparison group wins or loses.
 
@@ -559,8 +534,6 @@ class Scoring:
             actions outside the group).
         additional_filters : pl.Expr or list of pl.Expr, optional
             Extra filters (e.g. channel filter).
-        source : {"sample", "full"}, default "sample"
-            Data source to query.
 
         Returns
         -------
@@ -570,9 +543,8 @@ class Scoring:
         selected_group_rank_boundaries = self.get_selected_group_rank_boundaries(
             group_filter=group_filter,
             additional_filters=additional_filters,
-            source=source,
         )
-        stage_filtered_data = apply_filter(self.da._stage_source(source), additional_filters).filter(
+        stage_filtered_data = apply_filter(self.da.decision_data, additional_filters).filter(
             pl.col(self.da.level).is_in(self.da.stages_from_arbitration_down)
         )
 

--- a/python/pdstools/decision_analyzer/_scoring.py
+++ b/python/pdstools/decision_analyzer/_scoring.py
@@ -114,10 +114,21 @@ class Scoring:
 
         For each interaction where the selected comparison group is present,
         returns the best (lowest) and worst (highest) rank observed for the
-        selected rows in arbitration-relevant stages.
+        selected rows in arbitration-relevant stages. Computed on the
+        downsampled ``sample`` — this backs the sample-scoped win/loss
+        summaries and distributions. The exact full-data cohort is provided by
+        :meth:`get_winning_or_losing_interactions`.
         """
+        return self._selected_group_rank_boundaries(self.da.sample, group_filter, additional_filters)
+
+    def _selected_group_rank_boundaries(
+        self,
+        data: pl.LazyFrame,
+        group_filter: pl.Expr | list[pl.Expr],
+        additional_filters: pl.Expr | list[pl.Expr] | None = None,
+    ) -> pl.LazyFrame:
         selected_rows = (
-            apply_filter(apply_filter(self.da.decision_data, additional_filters), group_filter)
+            apply_filter(apply_filter(data, additional_filters), group_filter)
             .filter(pl.col(self.da.level).is_in(self.da.stages_from_arbitration_down))
             .select(["Interaction ID", "Rank"])
         )
@@ -523,6 +534,12 @@ class Scoring:
     ) -> pl.LazyFrame:
         """Interaction IDs where the comparison group wins or loses.
 
+        This is the exact-cohort handoff API and is computed on the full
+        ``decision_data`` (not the sample), so the returned interaction IDs
+        cover every matching decision. The sample-scoped win/loss *summaries*
+        (:meth:`get_win_loss_counts`, :meth:`get_win_loss_distribution_data`)
+        remain sample-backed for performance.
+
         Parameters
         ----------
         group_filter : pl.Expr or list of pl.Expr
@@ -540,7 +557,8 @@ class Scoring:
         pl.LazyFrame
             A single-column frame of unique ``Interaction ID`` values.
         """
-        selected_group_rank_boundaries = self.get_selected_group_rank_boundaries(
+        selected_group_rank_boundaries = self._selected_group_rank_boundaries(
+            self.da.decision_data,
             group_filter=group_filter,
             additional_filters=additional_filters,
         )

--- a/python/pdstools/decision_analyzer/_scoring.py
+++ b/python/pdstools/decision_analyzer/_scoring.py
@@ -292,7 +292,7 @@ class Scoring:
             Extra filters applied to the sample (e.g. channel filter).
         """
         cols = [granularity, component]
-        df = self.da._remaining_rows_at_stage(self.da.sample, stage, additional_filters=additional_filters)
+        df = self.da.aggregates._remaining_rows_at_stage(self.da.sample, stage, additional_filters=additional_filters)
         return df.select(cols).sort(granularity)
 
     def all_components_distribution(
@@ -316,7 +316,7 @@ class Scoring:
 
         available = set(self.da.sample.collect_schema().names())
         cols = [c for c in PRIO_COMPONENTS if c in available]
-        df = self.da._remaining_rows_at_stage(self.da.sample, stage, additional_filters=additional_filters)
+        df = self.da.aggregates._remaining_rows_at_stage(self.da.sample, stage, additional_filters=additional_filters)
         return df.select([granularity, *cols]).sort(granularity)
 
     def get_win_loss_distribution_data(

--- a/python/pdstools/decision_analyzer/_scoring.py
+++ b/python/pdstools/decision_analyzer/_scoring.py
@@ -139,12 +139,15 @@ class Scoring:
         order is >= the selected stage are "remaining" there.  If *stage*
         is None, falls back to rows with non-null Priority.
         """
-        base = apply_filter(self.da.sample, additional_filters)
-        if stage is None:
-            return base.filter(pl.col("Priority").is_not_null())
-        stage_idx = self.da.AvailableNBADStages.index(stage) if stage in self.da.AvailableNBADStages else 0
-        remaining_stages = self.da.AvailableNBADStages[stage_idx:]
-        return base.filter(pl.col(self.da.level).is_in(remaining_stages))
+        legacy_stage = stage
+        if stage is not None and stage not in self.da.AvailableNBADStages:
+            legacy_stage = self.da.AvailableNBADStages[0]
+        return self.da.remaining_at_stage(
+            legacy_stage,
+            additional_filters,
+            source="sample",
+            strict_stage=False,
+        )
 
     def get_sensitivity(
         self,

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -2076,21 +2076,6 @@ class TestMinimalStageCohorts:
         with pytest.raises(ValueError, match="Interaction ID"):
             da_minimal.get_interaction_ids("filtered_actions_per_stage")
 
-    def test_remaining_at_stage_interactions_returns_interaction_ids(self, da_minimal):
-        result = da_minimal.remaining_at_stage_interactions("Output")
-        assert result.columns == ["Interaction ID"]
-        assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
-
-    def test_remaining_at_stage_interactions_empty_filter(self, da_minimal):
-        result = da_minimal.remaining_at_stage_interactions("Output", pl.col("Channel") == "Missing")
-        assert result.height == 0
-        assert result.columns == ["Interaction ID"]
-
-    def test_remaining_at_stage_interactions_unknown_stage_can_return_empty(self, da_minimal):
-        result = da_minimal.remaining_at_stage_interactions("Not A Stage", strict_stage=False)
-        assert result.height == 0
-        assert result.columns == ["Interaction ID"]
-
     def test_dropped_at_stage_interactions_exact_ids(self, da_minimal):
         result = da_minimal.dropped_at_stage_interactions("Contact Policies and final Action processing")
         assert result.rows() == [("INT-002",)]

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -656,6 +656,48 @@ def da_win_loss_boundary_tiny():
     return DecisionAnalyzer(tiny_data, sample_size=10)
 
 
+@pytest.fixture
+def da_head_to_head_tiny():
+    """Tiny dataset with X wins, Y wins, third-party win, and one-sided rows."""
+    rows = [
+        ("S1", "I1", "X", "X1", 10.0),
+        ("S1", "I1", "Y", "Y1", 5.0),
+        ("S1", "I1", "Z", "Z1", 1.0),
+        ("S2", "I2", "X", "X1", 5.0),
+        ("S2", "I2", "Y", "Y1", 10.0),
+        ("S3", "I3", "X", "X1", 5.0),
+        ("S3", "I3", "Y", "Y1", 1.0),
+        ("S3", "I3", "Z", "Z1", 10.0),
+        ("S4", "I4", "X", "X1", 10.0),
+        ("S5", "I5", "Y", "Y1", 10.0),
+    ]
+    tiny_data = pl.LazyFrame(
+        {
+            "Primary_pySubjectID": [row[0] for row in rows],
+            "pxInteractionID": [row[1] for row in rows],
+            "pxDecisionTime": [datetime(2024, 1, 1, 0, 0, idx) for idx, _row in enumerate(rows)],
+            "pyIssue": ["Issue" for _row in rows],
+            "pyGroup": [row[2] for row in rows],
+            "pyName": [row[3] for row in rows],
+            "pyChannel": ["Web" for _row in rows],
+            "pyDirection": ["Inbound" for _row in rows],
+            "Value": [1.0 for _row in rows],
+            "ContextWeight": [1.0 for _row in rows],
+            "Weight": [1.0 for _row in rows],
+            "FinalPropensity": [1.0 for _row in rows],
+            "Priority": [row[4] for row in rows],
+            "Stage_pyStageGroup": ["Arbitration" for _row in rows],
+            "Stage_pyName": ["Arbitration" for _row in rows],
+            "Stage_pyOrder": [3000 for _row in rows],
+            "pxRecordType": ["FILTERED_OUT" for _row in rows],
+            "pxComponentName": ["Arbitration" for _row in rows],
+            "pxComponentType": ["Strategy" for _row in rows],
+            "pxStrategyName": ["Strategy" for _row in rows],
+        }
+    )
+    return DecisionAnalyzer(tiny_data, sample_size=10)
+
+
 class TestSelectedGroupRankBoundariesWinLoss:
     def test_selected_group_rank_boundaries_are_computed_per_interaction(self, da_win_loss_boundary_tiny):
         selected_group_filter = pl.col("Group") == "Selected"
@@ -887,6 +929,76 @@ class TestSelectedGroupRankBoundariesWinLoss:
                 win_rank=n,
             )
             assert counts["wins"] + counts["losses"] == counts["total"]
+
+
+class TestHeadToHeadAtStage:
+    def test_head_to_head_overall_counts(self, da_head_to_head_tiny):
+        result = da_head_to_head_tiny.head_to_head_at_stage(
+            pl.col("Group") == "X",
+            pl.col("Group") == "Y",
+            min_cell=1,
+        )
+
+        assert result["overall"] == {
+            "x_wins": 1,
+            "y_wins": 1,
+            "other": 1,
+            "total_overlap": 3,
+            "x_only": 1,
+            "y_only": 1,
+        }
+        assert result["stage_semantics"] == "rows remaining at the requested stage and later stages"
+
+    def test_head_to_head_cells_are_paired_breakdowns(self, da_head_to_head_tiny):
+        result = da_head_to_head_tiny.head_to_head_at_stage(
+            pl.col("Group") == "X",
+            pl.col("Group") == "Y",
+            min_cell=1,
+        )
+
+        cells = result["cells"]
+        assert cells.rows(named=True) == [
+            {
+                "x_Group": "X",
+                "y_Group": "Y",
+                "x_wins": 1,
+                "y_wins": 1,
+                "other": 1,
+                "total_overlap": 3,
+            }
+        ]
+
+    def test_head_to_head_returns_cohort_dataframes(self, da_head_to_head_tiny):
+        result = da_head_to_head_tiny.head_to_head_at_stage(
+            pl.col("Group") == "X",
+            pl.col("Group") == "Y",
+            min_cell=1,
+        )
+
+        cohorts = result["cohorts"]
+        assert cohorts["x_wins"].rows() == [("I1", "S1")]
+        assert cohorts["y_wins"].rows() == [("I2", "S2")]
+        assert cohorts["other"].rows() == [("I3", "S3")]
+        assert cohorts["x_only"].rows() == [("I4", "S4")]
+        assert cohorts["y_only"].rows() == [("I5", "S5")]
+
+    def test_head_to_head_can_omit_cohorts(self, da_head_to_head_tiny):
+        result = da_head_to_head_tiny.head_to_head_at_stage(
+            pl.col("Group") == "X",
+            pl.col("Group") == "Y",
+            min_cell=1,
+            include_interaction_ids=False,
+        )
+
+        assert "cohorts" not in result
+
+    def test_head_to_head_validates_breakdown(self, da_head_to_head_tiny):
+        with pytest.raises(ValueError, match="breakdown"):
+            da_head_to_head_tiny.head_to_head_at_stage(
+                pl.col("Group") == "X",
+                pl.col("Group") == "Y",
+                breakdown="Missing",
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -2076,17 +2076,22 @@ class TestMinimalStageCohorts:
         with pytest.raises(ValueError, match="Interaction ID"):
             da_minimal.get_interaction_ids("filtered_actions_per_stage")
 
-    def test_dropped_at_stage_interactions_exact_ids(self, da_minimal):
-        result = da_minimal.dropped_at_stage_interactions("Contact Policies and final Action processing")
+    def test_dropped_at_stage_returns_rows(self, da_minimal):
+        result = da_minimal.dropped_at_stage("Contact Policies and final Action processing").collect()
+        assert set(result["Interaction ID"].to_list()) == {"INT-002"}
+        assert result.select("Interaction ID").unique().height == 1
+
+    def test_get_interaction_ids_projects_dropped_at_stage(self, da_minimal):
+        result = da_minimal.get_interaction_ids("dropped_at_stage", "Contact Policies and final Action processing")
         assert result.rows() == [("INT-002",)]
 
     def test_dropped_at_terminal_stage_is_empty(self, da_minimal):
-        result = da_minimal.dropped_at_stage_interactions("Output")
-        assert result.height == 0
+        result = da_minimal.get_interaction_ids("dropped_at_stage", "Output")
         assert result.columns == ["Interaction ID"]
+        assert result.height == 0
 
-    def test_dropped_at_stage_interactions_unknown_stage_can_return_empty(self, da_minimal):
-        result = da_minimal.dropped_at_stage_interactions("Not A Stage", strict_stage=False)
+    def test_dropped_at_stage_unknown_stage_can_return_empty(self, da_minimal):
+        result = da_minimal.get_interaction_ids("dropped_at_stage", "Not A Stage", strict_stage=False)
         assert result.height == 0
 
 

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -1906,6 +1906,70 @@ class TestMinimalDatasetBasics:
         assert set(issues) == {"Sales", "Retention"}
 
 
+class TestMinimalStageCohorts:
+    """Verify exact stage row and interaction cohort APIs."""
+
+    def test_remaining_at_stage_known_stage_full_source(self, da_minimal):
+        rows = da_minimal.remaining_at_stage("Output", source="full").collect()
+        assert rows.height == 3
+        assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
+
+    def test_remaining_at_stage_known_stage_sample_source(self, da_minimal):
+        rows = da_minimal.remaining_at_stage("Output", source="sample").collect()
+        assert rows.height == 3
+        assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
+
+    def test_remaining_at_stage_none_filters_to_ranked_rows(self, da_minimal):
+        rows = da_minimal.remaining_at_stage(source="full").collect()
+        assert rows.height == 8
+        assert rows["Priority"].is_not_null().all()
+
+    def test_remaining_at_stage_rejects_unknown_stage(self, da_minimal):
+        with pytest.raises(ValueError, match="Unknown stage"):
+            da_minimal.remaining_at_stage("Not A Stage", source="full").collect()
+
+    def test_remaining_at_stage_unknown_stage_can_return_empty(self, da_minimal):
+        rows = da_minimal.remaining_at_stage("Not A Stage", source="full", strict_stage=False).collect()
+        assert rows.height == 0
+
+    def test_legacy_scoring_remaining_keeps_unknown_stage_fallback(self, da_minimal):
+        rows = da_minimal.scoring._remaining_at_stage("Not A Stage").collect()
+        assert rows.height == da_minimal.sample.collect().height
+
+    def test_remaining_at_stage_interactions_includes_subject_id(self, da_minimal):
+        result = da_minimal.remaining_at_stage_interactions("Output")
+        assert result.columns == ["Interaction ID", "Subject ID"]
+        assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
+        assert set(result["Subject ID"].to_list()) == {"CUST-001", "CUST-003"}
+
+    def test_remaining_at_stage_interactions_can_omit_subject_id(self, da_minimal):
+        result = da_minimal.remaining_at_stage_interactions("Output", include_subject_id=False)
+        assert result.columns == ["Interaction ID"]
+
+    def test_remaining_at_stage_interactions_empty_filter(self, da_minimal):
+        result = da_minimal.remaining_at_stage_interactions("Output", pl.col("Channel") == "Missing")
+        assert result.height == 0
+        assert result.columns == ["Interaction ID", "Subject ID"]
+
+    def test_remaining_at_stage_interactions_unknown_stage_can_return_empty(self, da_minimal):
+        result = da_minimal.remaining_at_stage_interactions("Not A Stage", strict_stage=False)
+        assert result.height == 0
+        assert result.columns == ["Interaction ID", "Subject ID"]
+
+    def test_dropped_at_stage_interactions_exact_ids(self, da_minimal):
+        result = da_minimal.dropped_at_stage_interactions("Contact Policies and final Action processing")
+        assert result.rows() == [("INT-002", "CUST-002")]
+
+    def test_dropped_at_terminal_stage_is_empty(self, da_minimal):
+        result = da_minimal.dropped_at_stage_interactions("Output")
+        assert result.height == 0
+        assert result.columns == ["Interaction ID", "Subject ID"]
+
+    def test_dropped_at_stage_interactions_unknown_stage_can_return_empty(self, da_minimal):
+        result = da_minimal.dropped_at_stage_interactions("Not A Stage", strict_stage=False)
+        assert result.height == 0
+
+
 class TestMinimalFunnelExactValues:
     """Exact-value tests for funnel data against the minimal dataset.
 

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -2153,6 +2153,15 @@ class TestMinimalFunnelExactValues:
         total = eligibility["action_occurrences"].sum()
         assert total == 12
 
+    def test_available_at_stage_returns_funnel_rows(self, da_minimal):
+        rows = da_minimal.aggregates.available_at_stage("Eligibility").collect()
+        assert rows.height == 12
+        assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
+
+    def test_get_interaction_count_counts_available_at_stage(self, da_minimal):
+        result = da_minimal.get_interaction_count("aggregates.available_at_stage", "Eligibility")
+        assert result == 3
+
     def test_available_at_eligibility_sales_filter(self, da_minimal):
         """7 Sales action occurrences available at Eligibility."""
         available, _, _ = da_minimal.aggregates.get_funnel_data(
@@ -2178,12 +2187,34 @@ class TestMinimalFunnelExactValues:
         total = eligibility["action_occurrences"].sum()
         assert total == 8
 
+    def test_passing_at_stage_returns_funnel_rows(self, da_minimal):
+        rows = da_minimal.aggregates.passing_at_stage("Eligibility").collect()
+        assert rows.height == 8
+        assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
+
+    def test_get_interaction_count_counts_passing_at_stage(self, da_minimal):
+        result = da_minimal.get_interaction_count(
+            "aggregates.passing_at_stage", "Contact Policies and final Action processing"
+        )
+        assert result == 2
+
     def test_filtered_at_eligibility(self, da_minimal):
         """4 action occurrences filtered at Eligibility overall."""
         _, _, filtered = da_minimal.aggregates.get_funnel_data(scope="Action")
         eligibility = filtered.filter(pl.col(da_minimal.level) == "Eligibility")
         total = eligibility["action_occurrences"].sum()
         assert total == 4
+
+    def test_filtered_at_stage_returns_funnel_rows(self, da_minimal):
+        rows = da_minimal.aggregates.filtered_at_stage("Eligibility").collect()
+        assert rows.height == 4
+        assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
+
+    def test_get_interaction_ids_projects_filtered_at_stage(self, da_minimal):
+        result = da_minimal.get_interaction_ids(
+            "aggregates.filtered_at_stage", "Contact Policies and final Action processing"
+        )
+        assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
 
     def test_funnel_summary_stages_match_funnel(self, da_minimal):
         """Summary table should show Available Actions + filtering stages, no Output."""
@@ -2494,6 +2525,22 @@ class TestMinimalFilterComponents:
         er = df.filter(pl.col("Component Name") == "EligibilityRule")
         assert er["Filtered Decisions"].item() == 3
 
+    def test_filtered_by_component_projects_contact_policy_ids(self, da_minimal):
+        result = da_minimal.get_interaction_ids("aggregates.filtered_by_component", "ContactPolicyRule")
+        assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
+
+    def test_get_interaction_count_counts_filtered_by_component(self, da_minimal):
+        result = da_minimal.get_interaction_count("aggregates.filtered_by_component", "EligibilityRule")
+        assert result == 3
+
+    def test_filtered_by_component_can_narrow_to_stage(self, da_minimal):
+        result = da_minimal.get_interaction_ids(
+            "aggregates.filtered_by_component",
+            "EligibilityRule",
+            stage="Eligibility",
+        )
+        assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
+
     def test_contact_policy_at_correct_stage(self, da_minimal):
         df = da_minimal.aggregates.get_filter_component_data(top_n=10)
         cp = df.filter(pl.col("Component Name") == "ContactPolicyRule")
@@ -2523,6 +2570,20 @@ class TestMinimalDecisionsWithoutActions:
         result = da_minimal.aggregates.get_decisions_without_actions_data()
         cp = result.filter(pl.col("Stage Group").str.contains("Contact Policies"))
         assert cp["decisions_without_actions"].item() == 1
+
+    def test_without_actions_at_stage_projects_knockout_ids(self, da_minimal):
+        result = da_minimal.get_interaction_ids(
+            "aggregates.without_actions_at_stage",
+            "Contact Policies and final Action processing",
+        )
+        assert result.rows() == [("INT-002",)]
+
+    def test_get_interaction_count_counts_without_actions_at_stage(self, da_minimal):
+        result = da_minimal.get_interaction_count(
+            "aggregates.without_actions_at_stage",
+            "Contact Policies and final Action processing",
+        )
+        assert result == 1
 
     def test_total_knockouts_equals_non_survivors(self, da_minimal):
         """Total knockouts = total decisions - Output survivors = 3 - 2 = 1."""

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -706,6 +706,53 @@ class TestSelectedGroupRankBoundariesWinLoss:
         assert losses_to_selected == ["I2"]
         assert wins_against_selected == ["I1"]
 
+    def test_winning_or_losing_interactions_default_schema_is_unchanged(self, da_win_loss_boundary_tiny):
+        selected_group_filter = pl.col("Group") == "Selected"
+
+        result = da_win_loss_boundary_tiny.scoring.get_winning_or_losing_interactions(
+            group_filter=selected_group_filter,
+            win=True,
+        ).collect()
+
+        assert result.columns == ["Interaction ID"]
+
+    def test_winning_or_losing_interactions_can_include_details(self, da_win_loss_boundary_tiny):
+        selected_group_filter = pl.col("Group") == "Selected"
+
+        result = (
+            da_win_loss_boundary_tiny.scoring.get_winning_or_losing_interactions(
+                group_filter=selected_group_filter,
+                win=True,
+                include_subject_id=True,
+                include_group_columns=True,
+            )
+            .sort("Action")
+            .collect()
+        )
+
+        assert result.columns == ["Interaction ID", "Subject ID", "Issue", "Group", "Action"]
+        assert result.rows() == [
+            ("I2", "S2", "Issue2", "Other", "F"),
+            ("I2", "S2", "Issue2", "Other", "G"),
+        ]
+
+    def test_winning_or_losing_interactions_supports_full_source(self, da_win_loss_boundary_tiny):
+        selected_group_filter = pl.col("Group") == "Selected"
+
+        result = (
+            da_win_loss_boundary_tiny.scoring.get_winning_or_losing_interactions(
+                group_filter=selected_group_filter,
+                win=False,
+                source="full",
+                include_subject_id=True,
+                include_group_columns=True,
+            )
+            .sort("Action")
+            .collect()
+        )
+
+        assert result.rows() == [("I1", "S1", "Issue1", "Other", "A")]
+
     def test_group_filter_status_distributions_match_expected_actions(self, da_win_loss_boundary_tiny):
         selected_group_filter = pl.col("Group") == "Selected"
 

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -2068,6 +2068,19 @@ class TestMinimalStageCohorts:
         result = da_minimal.get_interaction_count("aggregates.remaining_at_stage", "Output")
         assert result == 2
 
+    def test_get_interaction_ids_projects_dataframe_method(self, da_minimal):
+        da_minimal.row_dataframe = lambda: pl.DataFrame({"Interaction ID": ["INT-001", "INT-001", "INT-002"]})
+
+        result = da_minimal.get_interaction_ids("row_dataframe")
+
+        assert result.columns == ["Interaction ID"]
+        assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-002"}
+
+    def test_get_interaction_count_counts_dataframe_method(self, da_minimal):
+        da_minimal.row_dataframe = lambda: pl.DataFrame({"Interaction ID": ["INT-001", "INT-001", "INT-002"]})
+
+        assert da_minimal.get_interaction_count("row_dataframe") == 2
+
     def test_get_interaction_count_counts_dropped_at_stage(self, da_minimal):
         result = da_minimal.get_interaction_count(
             "aggregates.dropped_at_stage",
@@ -2090,6 +2103,18 @@ class TestMinimalStageCohorts:
     def test_get_interaction_count_requires_interaction_id_column(self, da_minimal):
         with pytest.raises(ValueError, match="Interaction ID"):
             da_minimal.get_interaction_count("aggregates.filtered_actions_per_stage")
+
+    def test_get_interaction_ids_requires_interaction_id_column_on_lazyframe(self, da_minimal):
+        da_minimal.row_lazyframe_without_id = lambda: pl.LazyFrame({"Other": ["value"]})
+
+        with pytest.raises(ValueError, match="Interaction ID"):
+            da_minimal.get_interaction_ids("row_lazyframe_without_id")
+
+    def test_get_interaction_ids_rejects_non_polars_result(self, da_minimal):
+        da_minimal.not_a_frame = lambda: {"Interaction ID": ["INT-001"]}
+
+        with pytest.raises(TypeError, match="Polars DataFrame or LazyFrame"):
+            da_minimal.get_interaction_ids("not_a_frame")
 
     def test_dropped_at_stage_returns_rows(self, da_minimal):
         result = da_minimal.aggregates.dropped_at_stage("Contact Policies and final Action processing").collect()
@@ -2192,6 +2217,14 @@ class TestMinimalFunnelExactValues:
         assert rows.height == 8
         assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
 
+    def test_passing_at_terminal_stage_is_empty(self, da_minimal):
+        rows = da_minimal.aggregates.passing_at_stage("Output").collect()
+        assert rows.height == 0
+
+    def test_passing_at_unknown_stage_can_return_empty(self, da_minimal):
+        rows = da_minimal.aggregates.passing_at_stage("Not A Stage", strict_stage=False).collect()
+        assert rows.height == 0
+
     def test_get_interaction_count_counts_passing_at_stage(self, da_minimal):
         result = da_minimal.get_interaction_count(
             "aggregates.passing_at_stage", "Contact Policies and final Action processing"
@@ -2209,6 +2242,10 @@ class TestMinimalFunnelExactValues:
         rows = da_minimal.aggregates.filtered_at_stage("Eligibility").collect()
         assert rows.height == 4
         assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
+
+    def test_filtered_at_unknown_stage_can_return_empty(self, da_minimal):
+        rows = da_minimal.aggregates.filtered_at_stage("Not A Stage", strict_stage=False).collect()
+        assert rows.height == 0
 
     def test_get_interaction_ids_projects_filtered_at_stage(self, da_minimal):
         result = da_minimal.get_interaction_ids(
@@ -2540,6 +2577,21 @@ class TestMinimalFilterComponents:
             stage="Eligibility",
         )
         assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
+
+    def test_filtered_by_component_requires_component_name_column(self, da_minimal):
+        da_minimal.decision_data = da_minimal.decision_data.drop("Component Name")
+
+        with pytest.raises(ValueError, match="Component Name"):
+            da_minimal.aggregates.filtered_by_component("EligibilityRule").collect()
+
+    def test_filtered_by_component_unknown_stage_can_return_empty(self, da_minimal):
+        result = da_minimal.get_interaction_ids(
+            "aggregates.filtered_by_component",
+            "EligibilityRule",
+            stage="Not A Stage",
+            strict_stage=False,
+        )
+        assert result.height == 0
 
     def test_contact_policy_at_correct_stage(self, da_minimal):
         df = da_minimal.aggregates.get_filter_component_data(top_n=10)

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -1729,7 +1729,7 @@ class TestFilteringAndScoping:
 
     def test_remaining_at_stage_none(self, da_v2):
         """stage=None falls back to non-null Priority rows."""
-        result = da_v2.remaining_at_stage(stage=None)
+        result = da_v2.aggregates.remaining_at_stage(stage=None)
         assert isinstance(result, pl.LazyFrame)
         df = result.collect()
         assert df.height == 1143136
@@ -1737,7 +1737,7 @@ class TestFilteringAndScoping:
         assert df["Priority"].null_count() == 0
 
     def test_remaining_at_stage_arbitration(self, da_v2):
-        result = da_v2.remaining_at_stage(stage="Arbitration")
+        result = da_v2.aggregates.remaining_at_stage(stage="Arbitration")
         df = result.collect()
         assert df.height == 29421
         stages = df[da_v2.level].unique().to_list()
@@ -2042,34 +2042,37 @@ class TestMinimalStageCohorts:
     """Verify exact stage row and interaction cohort APIs."""
 
     def test_remaining_at_stage_known_stage(self, da_minimal):
-        rows = da_minimal.remaining_at_stage("Output").collect()
+        rows = da_minimal.aggregates.remaining_at_stage("Output").collect()
         assert rows.height == 3
         assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
 
     def test_remaining_at_stage_none_filters_to_ranked_rows(self, da_minimal):
-        rows = da_minimal.remaining_at_stage().collect()
+        rows = da_minimal.aggregates.remaining_at_stage().collect()
         assert rows.height == 8
         assert rows["Priority"].is_not_null().all()
 
     def test_remaining_at_stage_rejects_unknown_stage(self, da_minimal):
         with pytest.raises(ValueError, match="Unknown stage"):
-            da_minimal.remaining_at_stage("Not A Stage").collect()
+            da_minimal.aggregates.remaining_at_stage("Not A Stage").collect()
 
     def test_remaining_at_stage_unknown_stage_can_return_empty(self, da_minimal):
-        rows = da_minimal.remaining_at_stage("Not A Stage", strict_stage=False).collect()
+        rows = da_minimal.aggregates.remaining_at_stage("Not A Stage", strict_stage=False).collect()
         assert rows.height == 0
 
     def test_get_interaction_ids_projects_public_row_method(self, da_minimal):
-        result = da_minimal.get_interaction_ids("remaining_at_stage", "Output")
+        result = da_minimal.get_interaction_ids("aggregates.remaining_at_stage", "Output")
         assert result.columns == ["Interaction ID"]
         assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
 
     def test_get_interaction_count_counts_public_row_method(self, da_minimal):
-        result = da_minimal.get_interaction_count("remaining_at_stage", "Output")
+        result = da_minimal.get_interaction_count("aggregates.remaining_at_stage", "Output")
         assert result == 2
 
     def test_get_interaction_count_counts_dropped_at_stage(self, da_minimal):
-        result = da_minimal.get_interaction_count("dropped_at_stage", "Contact Policies and final Action processing")
+        result = da_minimal.get_interaction_count(
+            "aggregates.dropped_at_stage",
+            "Contact Policies and final Action processing",
+        )
         assert result == 1
 
     def test_get_interaction_ids_rejects_unknown_method(self, da_minimal):
@@ -2078,32 +2081,35 @@ class TestMinimalStageCohorts:
 
     def test_get_interaction_ids_rejects_private_method(self, da_minimal):
         with pytest.raises(ValueError, match="public DecisionAnalyzer method"):
-            da_minimal.get_interaction_ids("_remaining_rows_at_stage")
+            da_minimal.get_interaction_ids("aggregates._remaining_rows_at_stage")
 
     def test_get_interaction_ids_requires_interaction_id_column(self, da_minimal):
         with pytest.raises(ValueError, match="Interaction ID"):
-            da_minimal.get_interaction_ids("filtered_actions_per_stage")
+            da_minimal.get_interaction_ids("aggregates.filtered_actions_per_stage")
 
     def test_get_interaction_count_requires_interaction_id_column(self, da_minimal):
         with pytest.raises(ValueError, match="Interaction ID"):
-            da_minimal.get_interaction_count("filtered_actions_per_stage")
+            da_minimal.get_interaction_count("aggregates.filtered_actions_per_stage")
 
     def test_dropped_at_stage_returns_rows(self, da_minimal):
-        result = da_minimal.dropped_at_stage("Contact Policies and final Action processing").collect()
+        result = da_minimal.aggregates.dropped_at_stage("Contact Policies and final Action processing").collect()
         assert set(result["Interaction ID"].to_list()) == {"INT-002"}
         assert result.select("Interaction ID").unique().height == 1
 
     def test_get_interaction_ids_projects_dropped_at_stage(self, da_minimal):
-        result = da_minimal.get_interaction_ids("dropped_at_stage", "Contact Policies and final Action processing")
+        result = da_minimal.get_interaction_ids(
+            "aggregates.dropped_at_stage",
+            "Contact Policies and final Action processing",
+        )
         assert result.rows() == [("INT-002",)]
 
     def test_dropped_at_terminal_stage_is_empty(self, da_minimal):
-        result = da_minimal.get_interaction_ids("dropped_at_stage", "Output")
+        result = da_minimal.get_interaction_ids("aggregates.dropped_at_stage", "Output")
         assert result.columns == ["Interaction ID"]
         assert result.height == 0
 
     def test_dropped_at_stage_unknown_stage_can_return_empty(self, da_minimal):
-        result = da_minimal.get_interaction_ids("dropped_at_stage", "Not A Stage", strict_stage=False)
+        result = da_minimal.get_interaction_ids("aggregates.dropped_at_stage", "Not A Stage", strict_stage=False)
         assert result.height == 0
 
 
@@ -2528,7 +2534,7 @@ class TestMinimalFilteredActionsPerStage:
     """Verify exact filtered action counts by stage."""
 
     def test_filtered_actions_per_stage_includes_zero_stages(self, da_minimal):
-        result = da_minimal.filtered_actions_per_stage(sort_by="stage")
+        result = da_minimal.aggregates.filtered_actions_per_stage(sort_by="stage")
 
         assert result[da_minimal.level].to_list() == [
             "Eligibility",
@@ -2539,7 +2545,7 @@ class TestMinimalFilteredActionsPerStage:
         assert result["interactions_affected"].to_list() == [3, 0, 3]
 
     def test_filtered_actions_per_stage_can_exclude_zero_stages(self, da_minimal):
-        result = da_minimal.filtered_actions_per_stage(include_zero_stages=False, sort_by="stage")
+        result = da_minimal.aggregates.filtered_actions_per_stage(include_zero_stages=False, sort_by="stage")
 
         assert result[da_minimal.level].to_list() == [
             "Eligibility",
@@ -2547,20 +2553,20 @@ class TestMinimalFilteredActionsPerStage:
         ]
 
     def test_filtered_actions_per_stage_sorts_by_actions_filtered(self, da_minimal):
-        result = da_minimal.filtered_actions_per_stage()
+        result = da_minimal.aggregates.filtered_actions_per_stage()
 
         assert result[da_minimal.level].to_list()[0] == "Contact Policies and final Action processing"
         assert result["actions_filtered"].to_list()[0] == 5
 
     def test_filtered_actions_per_stage_applies_filters(self, da_minimal):
-        result = da_minimal.filtered_actions_per_stage(pl.col("Channel") == "Mobile", sort_by="stage")
+        result = da_minimal.aggregates.filtered_actions_per_stage(pl.col("Channel") == "Mobile", sort_by="stage")
 
         assert result["actions_filtered"].to_list() == [2, 0, 2]
         assert result["interactions_affected"].to_list() == [1, 0, 1]
 
     def test_filtered_actions_per_stage_validates_sort_by(self, da_minimal):
         with pytest.raises(ValueError, match="sort_by"):
-            da_minimal.filtered_actions_per_stage(sort_by="not-a-sort")
+            da_minimal.aggregates.filtered_actions_per_stage(sort_by="not-a-sort")
 
 
 class TestMinimalFunnelSummaryExact:

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -2064,6 +2064,14 @@ class TestMinimalStageCohorts:
         assert result.columns == ["Interaction ID"]
         assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
 
+    def test_get_interaction_count_counts_public_row_method(self, da_minimal):
+        result = da_minimal.get_interaction_count("remaining_at_stage", "Output")
+        assert result == 2
+
+    def test_get_interaction_count_counts_dropped_at_stage(self, da_minimal):
+        result = da_minimal.get_interaction_count("dropped_at_stage", "Contact Policies and final Action processing")
+        assert result == 1
+
     def test_get_interaction_ids_rejects_unknown_method(self, da_minimal):
         with pytest.raises(ValueError, match="Unknown DecisionAnalyzer method"):
             da_minimal.get_interaction_ids("missing_method")
@@ -2075,6 +2083,10 @@ class TestMinimalStageCohorts:
     def test_get_interaction_ids_requires_interaction_id_column(self, da_minimal):
         with pytest.raises(ValueError, match="Interaction ID"):
             da_minimal.get_interaction_ids("filtered_actions_per_stage")
+
+    def test_get_interaction_count_requires_interaction_id_column(self, da_minimal):
+        with pytest.raises(ValueError, match="Interaction ID"):
+            da_minimal.get_interaction_count("filtered_actions_per_stage")
 
     def test_dropped_at_stage_returns_rows(self, da_minimal):
         result = da_minimal.dropped_at_stage("Contact Policies and final Action processing").collect()

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -906,13 +906,13 @@ class TestSelectedGroupRankBoundariesWinLoss:
 
 class TestHeadToHeadAtStage:
     def test_head_to_head_overall_counts(self, da_head_to_head_tiny):
-        result = da_head_to_head_tiny.head_to_head_at_stage(
+        result = da_head_to_head_tiny.aggregates.head_to_head_at_stage(
             pl.col("Group") == "X",
             pl.col("Group") == "Y",
             min_cell=1,
         )
 
-        assert result["overall"] == {
+        assert result.overall == {
             "x_wins": 1,
             "y_wins": 1,
             "other": 1,
@@ -920,16 +920,16 @@ class TestHeadToHeadAtStage:
             "x_only": 1,
             "y_only": 1,
         }
-        assert result["stage_semantics"] == "rows remaining at the requested stage and later stages"
+        assert result.stage_semantics == "rows remaining at the requested stage and later stages"
 
     def test_head_to_head_cells_are_paired_breakdowns(self, da_head_to_head_tiny):
-        result = da_head_to_head_tiny.head_to_head_at_stage(
+        result = da_head_to_head_tiny.aggregates.head_to_head_at_stage(
             pl.col("Group") == "X",
             pl.col("Group") == "Y",
             min_cell=1,
         )
 
-        cells = result["cells"]
+        cells = result.cells
         assert cells.rows(named=True) == [
             {
                 "x_Group": "X",
@@ -942,13 +942,13 @@ class TestHeadToHeadAtStage:
         ]
 
     def test_head_to_head_returns_cohort_dataframes(self, da_head_to_head_tiny):
-        result = da_head_to_head_tiny.head_to_head_at_stage(
+        result = da_head_to_head_tiny.aggregates.head_to_head_at_stage(
             pl.col("Group") == "X",
             pl.col("Group") == "Y",
             min_cell=1,
         )
 
-        cohorts = result["cohorts"]
+        cohorts = result.cohorts
         assert cohorts["x_wins"].rows() == [("I1",)]
         assert cohorts["y_wins"].rows() == [("I2",)]
         assert cohorts["other"].rows() == [("I3",)]
@@ -956,18 +956,18 @@ class TestHeadToHeadAtStage:
         assert cohorts["y_only"].rows() == [("I5",)]
 
     def test_head_to_head_can_omit_cohorts(self, da_head_to_head_tiny):
-        result = da_head_to_head_tiny.head_to_head_at_stage(
+        result = da_head_to_head_tiny.aggregates.head_to_head_at_stage(
             pl.col("Group") == "X",
             pl.col("Group") == "Y",
             min_cell=1,
             include_interaction_ids=False,
         )
 
-        assert "cohorts" not in result
+        assert result.cohorts is None
 
     def test_head_to_head_validates_breakdown(self, da_head_to_head_tiny):
         with pytest.raises(ValueError, match="breakdown"):
-            da_head_to_head_tiny.head_to_head_at_stage(
+            da_head_to_head_tiny.aggregates.head_to_head_at_stage(
                 pl.col("Group") == "X",
                 pl.col("Group") == "Y",
                 breakdown="Missing",
@@ -2055,18 +2055,13 @@ class TestMinimalStageCohorts:
         with pytest.raises(ValueError, match="Unknown stage"):
             da_minimal.aggregates.remaining_at_stage("Not A Stage").collect()
 
-    def test_remaining_at_stage_unknown_stage_can_return_empty(self, da_minimal):
-        rows = da_minimal.aggregates.remaining_at_stage("Not A Stage", strict_stage=False).collect()
-        assert rows.height == 0
-
     def test_get_interaction_ids_projects_public_row_method(self, da_minimal):
         result = da_minimal.get_interaction_ids("aggregates.remaining_at_stage", "Output")
         assert result.columns == ["Interaction ID"]
         assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
 
-    def test_get_interaction_count_counts_public_row_method(self, da_minimal):
-        result = da_minimal.get_interaction_count("aggregates.remaining_at_stage", "Output")
-        assert result == 2
+    def test_get_interaction_ids_height_counts_cohort(self, da_minimal):
+        assert da_minimal.get_interaction_ids("aggregates.remaining_at_stage", "Output").height == 2
 
     def test_get_interaction_ids_projects_dataframe_method(self, da_minimal):
         da_minimal.row_dataframe = lambda: pl.DataFrame({"Interaction ID": ["INT-001", "INT-001", "INT-002"]})
@@ -2075,18 +2070,7 @@ class TestMinimalStageCohorts:
 
         assert result.columns == ["Interaction ID"]
         assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-002"}
-
-    def test_get_interaction_count_counts_dataframe_method(self, da_minimal):
-        da_minimal.row_dataframe = lambda: pl.DataFrame({"Interaction ID": ["INT-001", "INT-001", "INT-002"]})
-
-        assert da_minimal.get_interaction_count("row_dataframe") == 2
-
-    def test_get_interaction_count_counts_dropped_at_stage(self, da_minimal):
-        result = da_minimal.get_interaction_count(
-            "aggregates.dropped_at_stage",
-            "Contact Policies and final Action processing",
-        )
-        assert result == 1
+        assert result.height == 2
 
     def test_get_interaction_ids_rejects_unknown_method(self, da_minimal):
         with pytest.raises(ValueError, match="Unknown DecisionAnalyzer method"):
@@ -2099,10 +2083,6 @@ class TestMinimalStageCohorts:
     def test_get_interaction_ids_requires_interaction_id_column(self, da_minimal):
         with pytest.raises(ValueError, match="Interaction ID"):
             da_minimal.get_interaction_ids("aggregates.filtered_actions_per_stage")
-
-    def test_get_interaction_count_requires_interaction_id_column(self, da_minimal):
-        with pytest.raises(ValueError, match="Interaction ID"):
-            da_minimal.get_interaction_count("aggregates.filtered_actions_per_stage")
 
     def test_get_interaction_ids_requires_interaction_id_column_on_lazyframe(self, da_minimal):
         da_minimal.row_lazyframe_without_id = lambda: pl.LazyFrame({"Other": ["value"]})
@@ -2131,10 +2111,6 @@ class TestMinimalStageCohorts:
     def test_dropped_at_terminal_stage_is_empty(self, da_minimal):
         result = da_minimal.get_interaction_ids("aggregates.dropped_at_stage", "Output")
         assert result.columns == ["Interaction ID"]
-        assert result.height == 0
-
-    def test_dropped_at_stage_unknown_stage_can_return_empty(self, da_minimal):
-        result = da_minimal.get_interaction_ids("aggregates.dropped_at_stage", "Not A Stage", strict_stage=False)
         assert result.height == 0
 
 
@@ -2183,9 +2159,8 @@ class TestMinimalFunnelExactValues:
         assert rows.height == 12
         assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
 
-    def test_get_interaction_count_counts_available_at_stage(self, da_minimal):
-        result = da_minimal.get_interaction_count("aggregates.available_at_stage", "Eligibility")
-        assert result == 3
+    def test_available_at_stage_height_counts_interactions(self, da_minimal):
+        assert da_minimal.get_interaction_ids("aggregates.available_at_stage", "Eligibility").height == 3
 
     def test_available_at_eligibility_sales_filter(self, da_minimal):
         """7 Sales action occurrences available at Eligibility."""
@@ -2221,15 +2196,11 @@ class TestMinimalFunnelExactValues:
         rows = da_minimal.aggregates.passing_at_stage("Output").collect()
         assert rows.height == 0
 
-    def test_passing_at_unknown_stage_can_return_empty(self, da_minimal):
-        rows = da_minimal.aggregates.passing_at_stage("Not A Stage", strict_stage=False).collect()
-        assert rows.height == 0
-
-    def test_get_interaction_count_counts_passing_at_stage(self, da_minimal):
-        result = da_minimal.get_interaction_count(
+    def test_passing_at_stage_height_counts_interactions(self, da_minimal):
+        result = da_minimal.get_interaction_ids(
             "aggregates.passing_at_stage", "Contact Policies and final Action processing"
         )
-        assert result == 2
+        assert result.height == 2
 
     def test_filtered_at_eligibility(self, da_minimal):
         """4 action occurrences filtered at Eligibility overall."""
@@ -2242,10 +2213,6 @@ class TestMinimalFunnelExactValues:
         rows = da_minimal.aggregates.filtered_at_stage("Eligibility").collect()
         assert rows.height == 4
         assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
-
-    def test_filtered_at_unknown_stage_can_return_empty(self, da_minimal):
-        rows = da_minimal.aggregates.filtered_at_stage("Not A Stage", strict_stage=False).collect()
-        assert rows.height == 0
 
     def test_get_interaction_ids_projects_filtered_at_stage(self, da_minimal):
         result = da_minimal.get_interaction_ids(
@@ -2566,9 +2533,8 @@ class TestMinimalFilterComponents:
         result = da_minimal.get_interaction_ids("aggregates.filtered_by_component", "ContactPolicyRule")
         assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-002", "INT-003"}
 
-    def test_get_interaction_count_counts_filtered_by_component(self, da_minimal):
-        result = da_minimal.get_interaction_count("aggregates.filtered_by_component", "EligibilityRule")
-        assert result == 3
+    def test_filtered_by_component_height_counts_interactions(self, da_minimal):
+        assert da_minimal.get_interaction_ids("aggregates.filtered_by_component", "EligibilityRule").height == 3
 
     def test_filtered_by_component_can_narrow_to_stage(self, da_minimal):
         result = da_minimal.get_interaction_ids(
@@ -2583,15 +2549,6 @@ class TestMinimalFilterComponents:
 
         with pytest.raises(ValueError, match="Component Name"):
             da_minimal.aggregates.filtered_by_component("EligibilityRule").collect()
-
-    def test_filtered_by_component_unknown_stage_can_return_empty(self, da_minimal):
-        result = da_minimal.get_interaction_ids(
-            "aggregates.filtered_by_component",
-            "EligibilityRule",
-            stage="Not A Stage",
-            strict_stage=False,
-        )
-        assert result.height == 0
 
     def test_contact_policy_at_correct_stage(self, da_minimal):
         df = da_minimal.aggregates.get_filter_component_data(top_n=10)
@@ -2630,12 +2587,12 @@ class TestMinimalDecisionsWithoutActions:
         )
         assert result.rows() == [("INT-002",)]
 
-    def test_get_interaction_count_counts_without_actions_at_stage(self, da_minimal):
-        result = da_minimal.get_interaction_count(
+    def test_without_actions_at_stage_height_counts_interactions(self, da_minimal):
+        result = da_minimal.get_interaction_ids(
             "aggregates.without_actions_at_stage",
             "Contact Policies and final Action processing",
         )
-        assert result == 1
+        assert result.height == 1
 
     def test_total_knockouts_equals_non_survivors(self, da_minimal):
         """Total knockouts = total decisions - Output survivors = 3 - 2 = 1."""

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -2059,6 +2059,23 @@ class TestMinimalStageCohorts:
         rows = da_minimal.remaining_at_stage("Not A Stage", strict_stage=False).collect()
         assert rows.height == 0
 
+    def test_get_interaction_ids_projects_public_row_method(self, da_minimal):
+        result = da_minimal.get_interaction_ids("remaining_at_stage", "Output")
+        assert result.columns == ["Interaction ID"]
+        assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
+
+    def test_get_interaction_ids_rejects_unknown_method(self, da_minimal):
+        with pytest.raises(ValueError, match="Unknown DecisionAnalyzer method"):
+            da_minimal.get_interaction_ids("missing_method")
+
+    def test_get_interaction_ids_rejects_private_method(self, da_minimal):
+        with pytest.raises(ValueError, match="public DecisionAnalyzer method"):
+            da_minimal.get_interaction_ids("_remaining_rows_at_stage")
+
+    def test_get_interaction_ids_requires_interaction_id_column(self, da_minimal):
+        with pytest.raises(ValueError, match="Interaction ID"):
+            da_minimal.get_interaction_ids("filtered_actions_per_stage")
+
     def test_remaining_at_stage_interactions_returns_interaction_ids(self, da_minimal):
         result = da_minimal.remaining_at_stage_interactions("Output")
         assert result.columns == ["Interaction ID"]

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -758,42 +758,16 @@ class TestSelectedGroupRankBoundariesWinLoss:
 
         assert result.columns == ["Interaction ID"]
 
-    def test_winning_or_losing_interactions_can_include_details(self, da_win_loss_boundary_tiny):
-        selected_group_filter = pl.col("Group") == "Selected"
-
-        result = (
-            da_win_loss_boundary_tiny.scoring.get_winning_or_losing_interactions(
-                group_filter=selected_group_filter,
-                win=True,
-                include_subject_id=True,
-                include_group_columns=True,
-            )
-            .sort("Action")
-            .collect()
-        )
-
-        assert result.columns == ["Interaction ID", "Subject ID", "Issue", "Group", "Action"]
-        assert result.rows() == [
-            ("I2", "S2", "Issue2", "Other", "F"),
-            ("I2", "S2", "Issue2", "Other", "G"),
-        ]
-
     def test_winning_or_losing_interactions_supports_full_source(self, da_win_loss_boundary_tiny):
         selected_group_filter = pl.col("Group") == "Selected"
 
-        result = (
-            da_win_loss_boundary_tiny.scoring.get_winning_or_losing_interactions(
-                group_filter=selected_group_filter,
-                win=False,
-                source="full",
-                include_subject_id=True,
-                include_group_columns=True,
-            )
-            .sort("Action")
-            .collect()
-        )
+        result = da_win_loss_boundary_tiny.scoring.get_winning_or_losing_interactions(
+            group_filter=selected_group_filter,
+            win=False,
+            source="full",
+        ).collect()
 
-        assert result.rows() == [("I1", "S1", "Issue1", "Other", "A")]
+        assert result.rows() == [("I1",)]
 
     def test_group_filter_status_distributions_match_expected_actions(self, da_win_loss_boundary_tiny):
         selected_group_filter = pl.col("Group") == "Selected"
@@ -976,11 +950,11 @@ class TestHeadToHeadAtStage:
         )
 
         cohorts = result["cohorts"]
-        assert cohorts["x_wins"].rows() == [("I1", "S1")]
-        assert cohorts["y_wins"].rows() == [("I2", "S2")]
-        assert cohorts["other"].rows() == [("I3", "S3")]
-        assert cohorts["x_only"].rows() == [("I4", "S4")]
-        assert cohorts["y_only"].rows() == [("I5", "S5")]
+        assert cohorts["x_wins"].rows() == [("I1",)]
+        assert cohorts["y_wins"].rows() == [("I2",)]
+        assert cohorts["other"].rows() == [("I3",)]
+        assert cohorts["x_only"].rows() == [("I4",)]
+        assert cohorts["y_only"].rows() == [("I5",)]
 
     def test_head_to_head_can_omit_cohorts(self, da_head_to_head_tiny):
         result = da_head_to_head_tiny.head_to_head_at_stage(
@@ -2095,72 +2069,33 @@ class TestMinimalStageCohorts:
         rows = da_minimal.scoring._remaining_at_stage("Not A Stage").collect()
         assert rows.height == da_minimal.sample.collect().height
 
-    def test_remaining_at_stage_interactions_includes_subject_id(self, da_minimal):
+    def test_remaining_at_stage_interactions_returns_interaction_ids(self, da_minimal):
         result = da_minimal.remaining_at_stage_interactions("Output")
-        assert result.columns == ["Interaction ID", "Subject ID"]
-        assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
-        assert set(result["Subject ID"].to_list()) == {"CUST-001", "CUST-003"}
-
-    def test_remaining_at_stage_interactions_can_omit_subject_id(self, da_minimal):
-        result = da_minimal.remaining_at_stage_interactions("Output", include_subject_id=False)
         assert result.columns == ["Interaction ID"]
+        assert set(result["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
 
     def test_remaining_at_stage_interactions_empty_filter(self, da_minimal):
         result = da_minimal.remaining_at_stage_interactions("Output", pl.col("Channel") == "Missing")
         assert result.height == 0
-        assert result.columns == ["Interaction ID", "Subject ID"]
+        assert result.columns == ["Interaction ID"]
 
     def test_remaining_at_stage_interactions_unknown_stage_can_return_empty(self, da_minimal):
         result = da_minimal.remaining_at_stage_interactions("Not A Stage", strict_stage=False)
         assert result.height == 0
-        assert result.columns == ["Interaction ID", "Subject ID"]
+        assert result.columns == ["Interaction ID"]
 
     def test_dropped_at_stage_interactions_exact_ids(self, da_minimal):
         result = da_minimal.dropped_at_stage_interactions("Contact Policies and final Action processing")
-        assert result.rows() == [("INT-002", "CUST-002")]
+        assert result.rows() == [("INT-002",)]
 
     def test_dropped_at_terminal_stage_is_empty(self, da_minimal):
         result = da_minimal.dropped_at_stage_interactions("Output")
         assert result.height == 0
-        assert result.columns == ["Interaction ID", "Subject ID"]
+        assert result.columns == ["Interaction ID"]
 
     def test_dropped_at_stage_interactions_unknown_stage_can_return_empty(self, da_minimal):
         result = da_minimal.dropped_at_stage_interactions("Not A Stage", strict_stage=False)
         assert result.height == 0
-
-
-class TestMinimalInteractionDetails:
-    """Verify interaction detail resolution for downstream cohorts."""
-
-    def test_get_interaction_details_defaults_to_subject_id(self, da_minimal):
-        result = da_minimal.get_interaction_details(["INT-001"]).sort("Interaction ID")
-        assert result.columns == ["Interaction ID", "Subject ID"]
-        assert result.rows() == [("INT-001", "CUST-001")]
-
-    def test_get_interaction_details_accepts_single_string(self, da_minimal):
-        result = da_minimal.get_interaction_details("INT-003")
-        assert result.rows() == [("INT-003", "CUST-003")]
-
-    def test_get_interaction_details_adds_available_columns(self, da_minimal):
-        result = da_minimal.get_interaction_details(["INT-001"], columns=["Issue", "Group", "Missing"])
-        assert result.columns == ["Interaction ID", "Subject ID", "Issue", "Group"]
-        assert result.height == 4
-        assert set(result["Issue"].to_list()) == {"Sales", "Retention"}
-
-    def test_get_interaction_details_deduplicates_selected_columns(self, da_minimal):
-        result = da_minimal.get_interaction_details(["INT-001", "INT-001"])
-        assert result.rows() == [("INT-001", "CUST-001")]
-
-    def test_get_interaction_details_empty_input_preserves_schema(self, da_minimal):
-        result = da_minimal.get_interaction_details([], columns=["Issue"])
-        assert result.height == 0
-        assert result.columns == ["Interaction ID", "Subject ID", "Issue"]
-
-    def test_get_interaction_details_without_subject_id_column(self):
-        raw = pl.scan_csv(f"{basePath}/data/da/sample_eev2_minimal.csv").drop("Primary_pySubjectID")
-        da = DecisionAnalyzer(raw, sample_size=5000)
-        result = da.get_interaction_details(["INT-001"])
-        assert result.columns == ["Interaction ID"]
 
 
 class TestOverviewStatsAccessor:

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -1970,6 +1970,52 @@ class TestMinimalStageCohorts:
         assert result.height == 0
 
 
+class TestMinimalInteractionDetails:
+    """Verify interaction detail resolution for downstream cohorts."""
+
+    def test_get_interaction_details_defaults_to_subject_id(self, da_minimal):
+        result = da_minimal.get_interaction_details(["INT-001"]).sort("Interaction ID")
+        assert result.columns == ["Interaction ID", "Subject ID"]
+        assert result.rows() == [("INT-001", "CUST-001")]
+
+    def test_get_interaction_details_accepts_single_string(self, da_minimal):
+        result = da_minimal.get_interaction_details("INT-003")
+        assert result.rows() == [("INT-003", "CUST-003")]
+
+    def test_get_interaction_details_adds_available_columns(self, da_minimal):
+        result = da_minimal.get_interaction_details(["INT-001"], columns=["Issue", "Group", "Missing"])
+        assert result.columns == ["Interaction ID", "Subject ID", "Issue", "Group"]
+        assert result.height == 4
+        assert set(result["Issue"].to_list()) == {"Sales", "Retention"}
+
+    def test_get_interaction_details_deduplicates_selected_columns(self, da_minimal):
+        result = da_minimal.get_interaction_details(["INT-001", "INT-001"])
+        assert result.rows() == [("INT-001", "CUST-001")]
+
+    def test_get_interaction_details_empty_input_preserves_schema(self, da_minimal):
+        result = da_minimal.get_interaction_details([], columns=["Issue"])
+        assert result.height == 0
+        assert result.columns == ["Interaction ID", "Subject ID", "Issue"]
+
+    def test_get_interaction_details_without_subject_id_column(self):
+        raw = pl.scan_csv(f"{basePath}/data/da/sample_eev2_minimal.csv").drop("Primary_pySubjectID")
+        da = DecisionAnalyzer(raw, sample_size=5000)
+        result = da.get_interaction_details(["INT-001"])
+        assert result.columns == ["Interaction ID"]
+
+
+class TestOverviewStatsAccessor:
+    def test_get_overview_stats_returns_dict(self, da_minimal):
+        result = da_minimal.get_overview_stats()
+        assert isinstance(result, dict)
+        assert result["Decisions"] == 3
+
+    def test_get_overview_stats_returns_copy(self, da_minimal):
+        result = da_minimal.get_overview_stats()
+        result["Decisions"] = -1
+        assert da_minimal.get_overview_stats()["Decisions"] == 3
+
+
 class TestMinimalFunnelExactValues:
     """Exact-value tests for funnel data against the minimal dataset.
 

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -2468,6 +2468,45 @@ class TestMinimalDecisionsWithoutActions:
         assert result["decisions_without_actions"].sum() == 1
 
 
+class TestMinimalFilteredActionsPerStage:
+    """Verify exact filtered action counts by stage."""
+
+    def test_filtered_actions_per_stage_includes_zero_stages(self, da_minimal):
+        result = da_minimal.filtered_actions_per_stage(sort_by="stage")
+
+        assert result[da_minimal.level].to_list() == [
+            "Eligibility",
+            "Arbitration",
+            "Contact Policies and final Action processing",
+        ]
+        assert result["actions_filtered"].to_list() == [4, 0, 5]
+        assert result["interactions_affected"].to_list() == [3, 0, 3]
+
+    def test_filtered_actions_per_stage_can_exclude_zero_stages(self, da_minimal):
+        result = da_minimal.filtered_actions_per_stage(include_zero_stages=False, sort_by="stage")
+
+        assert result[da_minimal.level].to_list() == [
+            "Eligibility",
+            "Contact Policies and final Action processing",
+        ]
+
+    def test_filtered_actions_per_stage_sorts_by_actions_filtered(self, da_minimal):
+        result = da_minimal.filtered_actions_per_stage()
+
+        assert result[da_minimal.level].to_list()[0] == "Contact Policies and final Action processing"
+        assert result["actions_filtered"].to_list()[0] == 5
+
+    def test_filtered_actions_per_stage_applies_filters(self, da_minimal):
+        result = da_minimal.filtered_actions_per_stage(pl.col("Channel") == "Mobile", sort_by="stage")
+
+        assert result["actions_filtered"].to_list() == [2, 0, 2]
+        assert result["interactions_affected"].to_list() == [1, 0, 1]
+
+    def test_filtered_actions_per_stage_validates_sort_by(self, da_minimal):
+        with pytest.raises(ValueError, match="sort_by"):
+            da_minimal.filtered_actions_per_stage(sort_by="not-a-sort")
+
+
 class TestMinimalFunnelSummaryExact:
     """Verify exact funnel summary values (percentages and averages).
 

--- a/python/tests/decision_analyzer/test_DecisionAnalyzer.py
+++ b/python/tests/decision_analyzer/test_DecisionAnalyzer.py
@@ -758,13 +758,12 @@ class TestSelectedGroupRankBoundariesWinLoss:
 
         assert result.columns == ["Interaction ID"]
 
-    def test_winning_or_losing_interactions_supports_full_source(self, da_win_loss_boundary_tiny):
+    def test_winning_or_losing_interactions_uses_full_data(self, da_win_loss_boundary_tiny):
         selected_group_filter = pl.col("Group") == "Selected"
 
         result = da_win_loss_boundary_tiny.scoring.get_winning_or_losing_interactions(
             group_filter=selected_group_filter,
             win=False,
-            source="full",
         ).collect()
 
         assert result.rows() == [("I1",)]
@@ -1730,17 +1729,17 @@ class TestFilteringAndScoping:
 
     def test_remaining_at_stage_none(self, da_v2):
         """stage=None falls back to non-null Priority rows."""
-        result = da_v2.scoring._remaining_at_stage(stage=None)
+        result = da_v2.remaining_at_stage(stage=None)
         assert isinstance(result, pl.LazyFrame)
         df = result.collect()
-        assert df.height == 816372
+        assert df.height == 1143136
         # All rows should have non-null Priority
         assert df["Priority"].null_count() == 0
 
     def test_remaining_at_stage_arbitration(self, da_v2):
-        result = da_v2.scoring._remaining_at_stage(stage="Arbitration")
+        result = da_v2.remaining_at_stage(stage="Arbitration")
         df = result.collect()
-        assert df.height == 21133
+        assert df.height == 29421
         stages = df[da_v2.level].unique().to_list()
         for s in stages:
             assert s in da_v2.stages_from_arbitration_down
@@ -2042,32 +2041,23 @@ class TestMinimalDatasetBasics:
 class TestMinimalStageCohorts:
     """Verify exact stage row and interaction cohort APIs."""
 
-    def test_remaining_at_stage_known_stage_full_source(self, da_minimal):
-        rows = da_minimal.remaining_at_stage("Output", source="full").collect()
-        assert rows.height == 3
-        assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
-
-    def test_remaining_at_stage_known_stage_sample_source(self, da_minimal):
-        rows = da_minimal.remaining_at_stage("Output", source="sample").collect()
+    def test_remaining_at_stage_known_stage(self, da_minimal):
+        rows = da_minimal.remaining_at_stage("Output").collect()
         assert rows.height == 3
         assert set(rows["Interaction ID"].to_list()) == {"INT-001", "INT-003"}
 
     def test_remaining_at_stage_none_filters_to_ranked_rows(self, da_minimal):
-        rows = da_minimal.remaining_at_stage(source="full").collect()
+        rows = da_minimal.remaining_at_stage().collect()
         assert rows.height == 8
         assert rows["Priority"].is_not_null().all()
 
     def test_remaining_at_stage_rejects_unknown_stage(self, da_minimal):
         with pytest.raises(ValueError, match="Unknown stage"):
-            da_minimal.remaining_at_stage("Not A Stage", source="full").collect()
+            da_minimal.remaining_at_stage("Not A Stage").collect()
 
     def test_remaining_at_stage_unknown_stage_can_return_empty(self, da_minimal):
-        rows = da_minimal.remaining_at_stage("Not A Stage", source="full", strict_stage=False).collect()
+        rows = da_minimal.remaining_at_stage("Not A Stage", strict_stage=False).collect()
         assert rows.height == 0
-
-    def test_legacy_scoring_remaining_keeps_unknown_stage_fallback(self, da_minimal):
-        rows = da_minimal.scoring._remaining_at_stage("Not A Stage").collect()
-        assert rows.height == da_minimal.sample.collect().height
 
     def test_remaining_at_stage_interactions_returns_interaction_ids(self, da_minimal):
         result = da_minimal.remaining_at_stage_interactions("Output")


### PR DESCRIPTION
## Summary

Adds explicit DecisionAnalyzer cohort/detail APIs for downstream workflows such as pen portraits, while keeping existing aggregate and plotting APIs stable by default.

This PR introduces public APIs for:

- extracting rows and exact interaction cohorts remaining or dropped at a stage
- returning overview stats as a concrete dictionary
- requesting opt-in win/loss interaction details without changing the default one-column sampled ID output
- summarizing filtered actions per stage
- comparing two filters head-to-head at a stage with paired breakdown cells and optional cohort DataFrames

## Compatibility

Existing aggregate, scoring, and plot defaults are preserved. The private `_remaining_at_stage` helper remains available as a compatibility shim.
