### PR TITLE
fix: source performance colorscale from MetricLimits

### DIFF
--- a/python/pdstools/utils/pega_template.py
+++ b/python/pdstools/utils/pega_template.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import plotly.graph_objects as go
 import plotly.io as pio
 
+from .plot_utils import get_colorscale
+
 colorway = [
     "#001F5F",  # dark blue
     "#10A5AC",
@@ -19,6 +21,8 @@ colorway = [
     "#A7A9B4",  # medium grey
     "#D0D1DB",  # light grey
 ]
+# Generic visual ramps. They are not tied to MetricLimits until a call site maps
+# them to a concrete metric ID with canonical thresholds.
 neutral_positive = [(0, "#FFB546"), (0.1, "#FCE880"), (0.6, "#66CB66"), (1, "#27803E")]
 
 negative_positive = [
@@ -35,15 +39,11 @@ positive_negative = [
     (0.8, "#FF853D"),
     (1, "#DE4342"),
 ]
-performance = [
-    (0, "#DE4342"),
-    (0.1, "#FFB546"),
-    (0.3, "#66CB66"),
-    (0.6, "#27803E"),
-    (0.9, "#FFB546"),
-    (1, "#0000FF"),
-]
+# Performance is metric-specific: source it from ModelPerformance limits.
+performance = get_colorscale("Performance")
 
+# Success-rate quality depends on channel and implementation details; there is
+# intentionally no SuccessRate row in MetricLimits.csv today.
 success = [(0, "#DE4342"), (0.2, "#66CB66"), (1, "#27803E")]
 
 pio.templates["pega"] = go.layout.Template(

--- a/python/pdstools/utils/plot_utils.py
+++ b/python/pdstools/utils/plot_utils.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import polars as pl
 
+from .metric_limits import MetricLimits
+
 if TYPE_CHECKING:
     from plotly.graph_objs import Figure as _Figure
 
@@ -41,14 +43,46 @@ LIFT_DIRECTION_COLORS: dict[str, str] = {
 # Colorscales for metric visualizations in Plotly charts
 # These define continuous color gradients based on metric values
 
+PERFORMANCE_RANGE_MIN = 0.5
+PERFORMANCE_RANGE_MAX = 1.0
+
+
+def _scale_performance_limit(value: float) -> float:
+    return (value - PERFORMANCE_RANGE_MIN) / (PERFORMANCE_RANGE_MAX - PERFORMANCE_RANGE_MIN)
+
+
+def _model_performance_colorscale() -> list[tuple[float, str]]:
+    limits = MetricLimits.get_limit_for_metric("ModelPerformance")
+    minimum = limits.get("minimum")
+    best_practice_min = limits.get("best_practice_min")
+    best_practice_max = limits.get("best_practice_max")
+    maximum = limits.get("maximum")
+
+    if minimum is None or best_practice_min is None or best_practice_max is None or maximum is None:
+        raise ValueError("ModelPerformance must define all color-scale thresholds in MetricLimits.csv.")
+
+    min_position = _scale_performance_limit(float(minimum))
+    best_practice_min_position = _scale_performance_limit(float(best_practice_min))
+    best_practice_max_position = _scale_performance_limit(float(best_practice_max))
+    max_position = _scale_performance_limit(float(maximum))
+
+    return [
+        (0, "#d91c29"),
+        (min_position, "#d91c29"),
+        (min_position, "#F76923"),
+        (best_practice_min_position, "#F76923"),
+        (best_practice_min_position, "#20aa50"),
+        (best_practice_max_position, "#20aa50"),
+        (best_practice_max_position, "#F76923"),
+        (max_position, "#F76923"),
+        (max_position, "#d91c29"),
+        (1, "#d91c29"),
+    ]
+
+
 COLORSCALES: dict[str, Any] = {
-    "Performance": [
-        (0, "#d91c29"),  # Red - poor performance
-        (0.01, "#F76923"),  # Orange - below threshold
-        (0.3, "#20aa50"),  # Green - acceptable
-        (0.8, "#20aa50"),  # Green - good
-        (1, "#0000FF"),  # Blue - exceptional (overfit?)
-    ],
+    "Performance": _model_performance_colorscale(),
+    # Keep hardcoded until a canonical SuccessRate metric exists in MetricLimits.csv.
     "SuccessRate": [
         (0, "#d91c29"),  # Red - no success
         (0.01, "#F76923"),  # Orange - low success

--- a/python/tests/utils/test_plot_utils.py
+++ b/python/tests/utils/test_plot_utils.py
@@ -1,7 +1,49 @@
 import polars as pl
 import plotly.express as px
+import pytest
 
-from pdstools.utils.plot_utils import fig_update_facet, hide_metric_annotations_on_non_rightmost
+from pdstools.utils.metric_limits import MetricLimits
+from pdstools.utils.plot_utils import (
+    fig_update_facet,
+    get_colorscale,
+    hide_metric_annotations_on_non_rightmost,
+)
+
+
+def test_performance_colorscale_uses_metric_limits():
+    limits = MetricLimits.get_limit_for_metric("ModelPerformance")
+
+    def position(limit_name: str) -> float:
+        return (limits[limit_name] - 0.5) / 0.5
+
+    colorscale = get_colorscale("Performance")
+
+    assert [color for _, color in colorscale] == [
+        "#d91c29",
+        "#d91c29",
+        "#F76923",
+        "#F76923",
+        "#20aa50",
+        "#20aa50",
+        "#F76923",
+        "#F76923",
+        "#d91c29",
+        "#d91c29",
+    ]
+    assert [scale_position for scale_position, _ in colorscale] == pytest.approx(
+        [
+            0,
+            position("minimum"),
+            position("minimum"),
+            position("best_practice_min"),
+            position("best_practice_min"),
+            position("best_practice_max"),
+            position("best_practice_max"),
+            position("maximum"),
+            position("maximum"),
+            1,
+        ],
+    )
 
 
 def _make_faceted_scatter(n_facets: int, col_wrap: int = 2) -> "px.Figure":


### PR DESCRIPTION
## Summary

Fixes #806.

Single-sources the ADM model Performance colorscale from `MetricLimits.csv` by deriving the Plotly scale from `MetricLimits.get_limit_for_metric("ModelPerformance")`.

## Changes

- Replaced the hardcoded `COLORSCALES["Performance"]` breakpoints with thresholds derived from `ModelPerformance`.
- Normalized `ModelPerformance` thresholds onto the existing Plotly AUC color range `[0.5, 1.0]`.
- Updated the legacy `pega_template.performance` scale to reuse `get_colorscale("Performance")`.
- Left `SuccessRate` and generic template ramps hardcoded, with comments explaining that they do not currently have canonical `MetricLimits` metric IDs.
- Added a regression test proving the Performance colorscale positions are computed from `MetricLimits`.
