### PR TITLE
Fix empty predictor plot handling in HealthCheck

### DIFF
--- a/python/pdstools/adm/Aggregates.py
+++ b/python/pdstools/adm/Aggregates.py
@@ -146,6 +146,7 @@ class Aggregates:
                 (pl.col("EntryType") == "Active") if active_only else (pl.col("EntryType") != "Classifier"),
             ),
             query,
+            allow_empty=True,
         )
         unique_predictors = df.select(pl.col("PredictorName").unique()).collect()["PredictorName"]
 

--- a/python/pdstools/adm/Plots/_predictors.py
+++ b/python/pdstools/adm/Plots/_predictors.py
@@ -298,6 +298,7 @@ class _PredictorPlotsMixin(_PlotsBase):
             .filter(pl.col("EntryType") != "Classifier")
             .filter(pl.col("ResponseCountBin") > 0),
             query=query,
+            allow_empty=True,
         )
         if active_only:
             df = df.filter(pl.col("EntryType") == "Active")

--- a/python/tests/adm/test_plots.py
+++ b/python/tests/adm/test_plots.py
@@ -519,6 +519,15 @@ def test_predictor_category_performance(sample: ADMDatamart):
     assert isinstance(plot, Figure)
 
 
+def test_predictor_category_performance_empty_query(sample: ADMDatamart):
+    query = pl.col("ModelID") == "missing-model"
+
+    df = sample.plot.predictor_category_performance(query=query, return_df=True)
+
+    assert df.is_empty()
+    assert sample.plot.predictor_category_performance(query=query) is None
+
+
 def test_predictor_contribution(sample: ADMDatamart):
     df = sample.plot.predictor_contribution(return_df=True).collect()
     assert df.shape == (3, 4)
@@ -570,6 +579,16 @@ def test_predictor_performance_heatmap(sample: ADMDatamart):
     assert "Name" not in df.collect().columns
     assert "Predictor" in df.collect().columns
     assert "Sales/CreditCards/ChannelAction_Template" in df.collect().columns
+
+
+def test_predictor_performance_heatmap_empty_query(sample: ADMDatamart):
+    query = pl.col("ModelID") == "missing-model"
+
+    df = sample.plot.predictor_performance_heatmap(query=query, return_df=True).collect()
+
+    assert df.shape == (0, 1)
+    assert df.columns == ["Name"]
+    assert sample.plot.predictor_performance_heatmap(query=query) is None
 
 
 def test_tree_map(sample: ADMDatamart):


### PR DESCRIPTION
## Summary
- Allow predictor plot filtering paths to handle empty filtered inputs without raising.
- Prevent HealthCheck predictor-analysis sections from embedding traceback callouts when no eligible predictor rows are available.
- Add regression coverage for empty-query behavior in the affected predictor plots.

## Validation
- `uv run pytest python/tests/adm/test_plots.py -k "predictor_category_performance or predictor_performance_heatmap"`
- `uv run pre-commit run --all-files`
- `git push` pre-push checks: `pyright`, `pyrefly`
- Focused regenerated HealthCheck HTML scan returned no report errors.