### PR TITLE
Fix AGB stump model sanity checks

### DIFF
--- a/examples/articles/AGBExplained.ipynb
+++ b/examples/articles/AGBExplained.ipynb
@@ -87,10 +87,62 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df0efdbd",
+   "id": "quick-sanity-caveat",
    "metadata": {},
    "source": [
     "**Caveat:** Pooled AUC—computed by mixing prediction scores and outcomes across all actions before drawing a single ROC curve—is systematically inflated by action base-rate differences and action-mix. It is therefore not a reliable measure of the discriminative power of any individual action model. For model-performance assessment, prefer the response-count weighted average of per-action AUC values, explained in **Pooled vs weighted-average AUC** below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quick-sanity-intro",
+   "metadata": {},
+   "source": [
+    "## 0. Quick Sanity Check\n",
+    "\n",
+    "Before diving into the detailed walkthrough below, it's worth checking whether\n",
+    "a model has actually learned anything meaningful. A handful of `metrics`\n",
+    "values, taken together, tell you that at a glance:\n",
+    "\n",
+    "- **Too few trees / mostly stumps** — the model hasn't had enough responses\n",
+    "  (or enough signal) to build real structure yet.\n",
+    "- **Pooled AUC ≈ 0.5** — no discriminative power; predictions are\n",
+    "  indistinguishable from random. (As elsewhere in this notebook, this is the\n",
+    "  *pooled* AUC exported with the model — not the weighted-average AUC across\n",
+    "  actions.)\n",
+    "- **Negatives ≤ positives** — for a typical NBA response model this is\n",
+    "  inverted (responses are usually rare), and can indicate a sampling issue,\n",
+    "  a very high base rate, or a still-forming candidate model.\n",
+    "- **Very few active predictors** — the model is only using a sliver of the\n",
+    "  available data to make decisions.\n",
+    "\n",
+    "None of these are fatal on their own (a brand-new candidate model is\n",
+    "*supposed* to look like this for a while), but several at once mean a\n",
+    "model's plots and metrics are not yet a reliable read on its real-world\n",
+    "performance. `ADMTreesModel.sanity_check()` runs these checks for you:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "quick-sanity-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quick sanity check — flags a handful of \"this model may not have learned\n",
+    "# anything useful yet\" signals.\n",
+    "result = AGBModel.sanity_check()\n",
+    "\n",
+    "print(f\"Sanity check ({result['n_trees']} trees, Pooled AUC={result['pooled_auc']:.4f}, \"\n",
+    "      f\"{result['positive_count']:,} pos / {result['negative_count']:,} neg):\\n\")\n",
+    "if result[\"flags\"]:\n",
+    "    print(f\"⚠ {len(result['flags'])} red flag(s):\")\n",
+    "    for msg in result[\"flags\"]:\n",
+    "        print(f\"  ⚠ {msg}\")\n",
+    "    print(\"\\nTreat the detailed sections below as illustrative of the mechanics,\")\n",
+    "    print(\"not as a reliable read on this model's real-world performance yet.\")\n",
+    "else:\n",
+    "    print(\"✓ No red flags from this quick check — proceed to the detailed walkthrough below.\")"
    ]
   },
   {
@@ -508,35 +560,29 @@
    "source": [
     "## 4. Feature Importance: Which Predictors Drive the Model?\n",
     "\n",
-    "A predictor's importance is measured by its **total split gain** — the sum\n",
-    "of gain values at every split node that uses that predictor, across all trees.\n",
+    "A predictor's importance is measured by its **total split gain** — the sum of gain values at every split node that uses that predictor, across all trees.\n",
     "\n",
-    "> **Note on Prediction Studio:** In the Prediction Studio UI, feature\n",
-    "> importance is shown as a **0–100 score that sums to 100** across all\n",
-    "> active predictors.  The plots below use raw total gain (absolute scale),\n",
-    "> which is more useful for analysis but differs from the normalized UI value.\n",
-    "> Prediction Studio also offers **treatment-level feature importance**, showing\n",
-    "> which predictors matter most for each individual treatment.\n",
+    "> **Note on Prediction Studio:** In the Prediction Studio UI, feature importance is shown as a **0–100 score that sums to 100** across all active predictors. The plots below use raw total gain (absolute scale), which is more useful for analysis but differs from the normalized UI value. Prediction Studio also offers **treatment-level feature importance**, showing which predictors matter most for each individual treatment.\n",
     "\n",
-    "Predictors are grouped into **Predictor Groups** that indicate the data source:\n",
+    "Predictors are grouped into ADM-style **PredictorCategory** values that indicate the data source. The base categories and colors are the same defaults used by ADM plots:\n",
     "\n",
-    "| Prefix | Predictor Group | Source |\n",
+    "| Prefix or match | Predictor category | Source |\n",
     "|---|---|---|\n",
-    "| `py*` | Context Keys | Pega system context keys (e.g. `pyTreatment`, `pyGroup`) |\n",
+    "| *(no dot)* | Primary | Primary/context predictors such as `pyTreatment`, `pyGroup`, and `pyName` |\n",
     "| `IH.*` | IH | Interaction History predictors |\n",
     "| `Customer.*` | Customer | Customer attribute predictors |\n",
+    "| `Param.*` | Param | Parameter predictors |\n",
     "| `<other>.*` | `<other>` | Any other dot-prefixed namespace |\n",
-    "| *(custom)* | External Models | External model scores — configure below |\n",
+    "| HC external-score keywords | External Model | Predictors whose names contain terms such as `Propensity`, `Score`, `Prediction`, or `ModelScore` |\n",
+    "\n",
+    "The next cell applies the same external-model keyword defaults used by the Health Check import screen, so score-like predictors are colored and labelled consistently with ADM Health Check outputs.\n",
     "\n",
     "### Predictors pre-processing\n",
     "\n",
-    "- **Symbolic predictors** use a custom encoding that allows for more granular\n",
-    "  bins than the classic Naïve Bayes algorithm.\n",
-    "- **Numeric predictors** are pre-processed using **percentile streaming**,\n",
-    "  which is robust against extreme outliers.\n",
+    "- **Symbolic predictors** use a custom encoding that allows for more granular bins than the classic Naïve Bayes algorithm.\n",
+    "- **Numeric predictors** are pre-processed using **percentile streaming**, which is robust against extreme outliers.\n",
     "\n",
-    "Both pre-processing steps contribute to AGB's higher predictive power compared\n",
-    "to the classic algorithm.\n"
+    "Both pre-processing steps contribute to AGB's higher predictive power compared to the classic algorithm."
    ]
   },
   {
@@ -590,37 +636,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ---------------------------------------------------------------------------\n",
-    "# Custom Predictor Group assignment  (dataset-specific — edit as needed)\n",
-    "# ---------------------------------------------------------------------------\n",
-    "# External model scores are predictors that come from a separate model or\n",
-    "# scoring pipeline (e.g. propensity scores, risk scores).  They often share a\n",
-    "# common name prefix that distinguishes them from IH.* or Customer.* fields.\n",
-    "#\n",
-    "# Replace the `str.starts_with(...)` condition below with the actual prefix\n",
-    "# (or pattern) used in this dataset.  Examples:\n",
-    "#   pl.col(\"predictor\").str.starts_with(\"ExtScore\")\n",
-    "#   pl.col(\"predictor\").is_in([\"PropensityModel\", \"RiskScore\"])\n",
-    "#\n",
-    "# Set EXTERNAL_SCORE_PREFIX = None to skip this grouping entirely.\n",
+    "# Health Check uses these default keyword matches for external model scores.\n",
+    "# Keep this notebook aligned so AGB and ADM Health Check plots label score-like\n",
+    "# predictors consistently.\n",
+    "from pdstools.adm.trees._plots import _PREDICTOR_CATEGORY_VALUE\n",
     "\n",
-    "from pdstools.adm.trees._plots import _PREDICTOR_GROUP_VALUE\n",
+    "HEALTH_CHECK_EXTERNAL_MODEL_KEYWORDS = (\n",
+    "    \"Propensity\",\n",
+    "    \"Score\",\n",
+    "    \"Class\",\n",
+    "    \"Classifier\",\n",
+    "    \"Classification\",\n",
+    "    \"Probability\",\n",
+    "    \"Prediction\",\n",
+    "    \"Predicted\",\n",
+    "    \"ModelScore\",\n",
+    ")\n",
     "\n",
-    "EXTERNAL_SCORE_PREFIX = \"Customer.Scores.ExtModelScore\"\n",
+    "external_model_score_expr = pl.any_horizontal(\n",
+    "    *[\n",
+    "        pl.col(\"predictor\").cast(pl.Utf8).str.contains(keyword, literal=True)\n",
+    "        for keyword in HEALTH_CHECK_EXTERNAL_MODEL_KEYWORDS\n",
+    "    ]\n",
+    ")\n",
     "\n",
-    "if EXTERNAL_SCORE_PREFIX is not None:\n",
-    "    AGBModel.plot.predictor_group_expr = (\n",
-    "        pl.when(pl.col(\"predictor\").str.starts_with(EXTERNAL_SCORE_PREFIX))\n",
-    "        .then(pl.lit(\"External Models\"))\n",
-    "        .otherwise(_PREDICTOR_GROUP_VALUE)\n",
-    "        .alias(\"Predictor Group\")\n",
-    "    )\n",
-    "    # \"External Models\" is already in the default colormap; extend only if you\n",
-    "    # need additional custom groups:\n",
-    "    # AGBModel.plot.predictor_group_colormap = {\n",
-    "    #     **AGBModel.plot.predictor_group_colormap,\n",
-    "    #     \"My Custom Group\": \"#AABBCC\",\n",
-    "    # }\n"
+    "AGBModel.plot.predictor_category_expr = (\n",
+    "    pl.when(external_model_score_expr)\n",
+    "    .then(pl.lit(\"External Model\"))\n",
+    "    .otherwise(_PREDICTOR_CATEGORY_VALUE)\n",
+    "    .alias(\"PredictorCategory\")\n",
+    ")"
    ]
   },
   {
@@ -649,8 +694,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Gain share by predictor group (IH.* vs Customer.* vs py* / Context Keys)\n",
-    "AGBModel.plot.gain_by_namespace()\n"
+    "# Gain share by predictor category (IH.* vs Customer.* vs Primary / Param)\n",
+    "AGBModel.plot.gain_by_namespace()"
    ]
   },
   {
@@ -658,7 +703,7 @@
    "id": "64538517",
    "metadata": {},
    "source": [
-    "**Interpreting this chart:** Each bar shows one predictor group's share of total split gain. **Good:** several groups each claiming 15–40% of the gain, indicating the model draws on diverse signals. A single group above 70–80% may indicate that other data sources are unavailable or that those predictors are inactive.\n"
+    "**Interpreting this chart:** Each bar shows one predictor category's share of total split gain. **Good:** several categories each claiming 15–40% of the gain, indicating the model draws on diverse signals. A single category above 70–80% may indicate that other data sources are unavailable or that those predictors are inactive.\n"
    ]
   },
   {
@@ -839,7 +884,7 @@
     "\n",
     "### Pooled vs weighted-average AUC\n",
     "\n",
-    "**Pooled AUC** mixes prediction scores and outcomes from multiple actions into one combined ROC calculation. As the whitepaper shows, this number is structurally inflated by cross-action base-rate separation, so a high pooled AUC can coexist with weak per-action models.\n",
+    "**Pooled AUC** mixes prediction scores and outcomes from multiple actions into one combined ROC calculation. This number is structurally inflated by cross-action base-rate separation, so a high pooled AUC can coexist with weak per-action models.\n",
     "\n",
     "**Weighted-average AUC** is the response-count weighted average of per-action AUC values. This is the honest, actionable portfolio metric because it answers the operational question that matters in NBA: does each action model rank likely responders above likely non-responders within its own action?\n",
     "\n",
@@ -859,12 +904,20 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pdstools",
+   "display_name": "pdstools (3.12.6.final.0)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/articles/AGBExplained.ipynb
+++ b/examples/articles/AGBExplained.ipynb
@@ -90,7 +90,7 @@
    "id": "quick-sanity-caveat",
    "metadata": {},
    "source": [
-    "**Caveat:** Pooled AUC—computed by mixing prediction scores and outcomes across all actions before drawing a single ROC curve—is systematically inflated by action base-rate differences and action-mix. It is therefore not a reliable measure of the discriminative power of any individual action model. For model-performance assessment, prefer the response-count weighted average of per-action AUC values, explained in **Pooled vs weighted-average AUC** below."
+    "**Caveat:** Pooled AUC—computed by mixing prediction scores and outcomes across all actions before drawing a single ROC curve—is systematically inflated by action base-rate differences and action-mix. It is therefore not a reliable measure of the discriminative power of any individual action model. For model-performance assessment, prefer the response-count weighted average of per-action AUC values: this is the AUC shown in Prediction Studio's Adaptive Model Performance view. The standalone AGB JSON export used in this notebook does not contain the per-action AUCs needed to calculate that weighted value; it only exposes the exported pooled AUC scalar. See **Pooled vs weighted-average AUC** below."
    ]
   },
   {
@@ -886,7 +886,9 @@
     "\n",
     "**Pooled AUC** mixes prediction scores and outcomes from multiple actions into one combined ROC calculation. This number is structurally inflated by cross-action base-rate separation, so a high pooled AUC can coexist with weak per-action models.\n",
     "\n",
-    "**Weighted-average AUC** is the response-count weighted average of per-action AUC values. This is the honest, actionable portfolio metric because it answers the operational question that matters in NBA: does each action model rank likely responders above likely non-responders within its own action?\n",
+    "**Weighted-average AUC** is the response-count weighted average of per-action AUC values. This is the AUC displayed in Prediction Studio's **Adaptive Model Performance** view, and it is the honest, actionable portfolio metric because it answers the operational question that matters in NBA: does each action model rank likely responders above likely non-responders within its own action?\n",
+    "\n",
+    "The standalone AGB JSON export used in this notebook does **not** include the per-action AUC values and response counts needed to calculate weighted-average AUC. It only exposes the exported pooled AUC scalar. To inspect weighted-average AUC, use Prediction Studio's Adaptive Model Performance view or an ADM/datamart source that contains per-action model performance rows.\n",
     "\n",
     "In practice, report weighted-average AUC as the primary portfolio measure and treat pooled AUC only as a descriptive aggregate, not as evidence of model quality.\n",
     "\n",

--- a/python/pdstools/adm/trees/_model.py
+++ b/python/pdstools/adm/trees/_model.py
@@ -380,6 +380,71 @@ class ADMTreesModel:
         """
         return self._compute_metrics()
 
+    def sanity_check(self) -> dict[str, Any]:
+        """Flag common signs that this model has not learned anything useful yet.
+
+        Runs a handful of heuristic checks against :attr:`metrics` — very
+        few trees, mostly-stump trees, near-random AUC, an inverted or very
+        low response volume, or a narrow active-predictor set — that
+        together indicate a model is too early in its training lifecycle
+        for its plots and metrics to be a reliable read on real-world
+        performance.
+
+        Returns
+        -------
+        dict
+            Dictionary with keys ``n_trees``, ``pooled_auc``,
+            ``positive_count``, ``negative_count``, and ``flags`` (a list
+            of human-readable warning strings; empty when no red flags
+            apply).
+        """
+        m = self.metrics
+        n_trees = m["number_of_trees"]
+        n_stumps = m["number_of_stump_trees"]
+        total_splits = m["number_of_numeric_splits"] + m["number_of_symbolic_splits"]
+        avg_splits_per_tree = total_splits / n_trees if n_trees else 0
+        pos, neg = m["response_positive_count"], m["response_negative_count"]
+        active_predictors = m["total_number_of_active_predictors"]
+        pooled_auc = m["auc"]
+
+        checks = [
+            (
+                n_trees < 10,
+                f"Only {n_trees} tree(s) — model has barely started learning.",
+            ),
+            (
+                n_trees > 0 and n_stumps / n_trees > 0.5,
+                f"{n_stumps}/{n_trees} trees are stumps (no split) — mostly non-informative trees.",
+            ),
+            (
+                avg_splits_per_tree <= 1,
+                f"Avg splits/tree = {avg_splits_per_tree:.2f} — model is not developing structure (SOP-ADM009).",
+            ),
+            (
+                abs(pooled_auc - 0.5) < 0.02,
+                f"Pooled AUC = {pooled_auc:.4f} — statistically indistinguishable from random.",
+            ),
+            (
+                neg < pos,
+                f"Negatives ({neg:,}) < positives ({pos:,}) — inverted response ratio; unusual for an NBA response model.",
+            ),
+            (
+                min(pos, neg) < 200,
+                f"Very low response volume (positives={pos:,}, negatives={neg:,}) — metrics are not yet statistically stable.",
+            ),
+            (
+                active_predictors < 5,
+                f"Only {active_predictors} active predictor(s) — model is deciding on a very narrow feature set.",
+            ),
+        ]
+        return {
+            "n_trees": n_trees,
+            "pooled_auc": pooled_auc,
+            "positive_count": pos,
+            "negative_count": neg,
+            "flags": [msg for is_flag, msg in checks if is_flag],
+        }
+
     @staticmethod
     def metric_descriptions() -> dict[str, str]:
         """Return a dictionary mapping metric names to human-readable descriptions."""
@@ -869,6 +934,7 @@ class ADMTreesModel:
 
         gains_per_split = pl.DataFrame(
             {"split": all_splits, "gains": all_gains, "predictor": all_predictors},
+            schema={"split": pl.String, "gains": pl.Float64, "predictor": pl.String},
         )
         return splits_per_tree, gains_per_tree, gains_per_split
 
@@ -923,7 +989,11 @@ class ADMTreesModel:
                     "meangains": mean(gains) if gains else 0,
                 },
             )
-        return pl.from_dicts(rows)
+        # Without an explicit schema, polars infers "gains" as List(Null) when
+        # every tree has an empty gains list (e.g. a single-tree, zero-split
+        # cold-start candidate), which breaks numeric ops like `list.sum()`
+        # and `cum_sum()` downstream. Pin the element type explicitly.
+        return pl.from_dicts(rows, schema_overrides={"gains": pl.List(pl.Float64)})
 
     def get_all_values_per_split(self) -> dict[str, set]:
         """All distinct split values seen for each predictor."""

--- a/python/pdstools/adm/trees/_model.py
+++ b/python/pdstools/adm/trees/_model.py
@@ -403,9 +403,31 @@ class ADMTreesModel:
         n_stumps = m["number_of_stump_trees"]
         total_splits = m["number_of_numeric_splits"] + m["number_of_symbolic_splits"]
         avg_splits_per_tree = total_splits / n_trees if n_trees else 0
-        pos, neg = m["response_positive_count"], m["response_negative_count"]
+        pos = cast("int | None", m["response_positive_count"])
+        neg = cast("int | None", m["response_negative_count"])
         active_predictors = m["total_number_of_active_predictors"]
         pooled_auc = m["auc"]
+        has_response_counts = pos is not None and neg is not None
+        inverted_response = False
+        low_response_volume = False
+        if pos is not None and neg is not None:
+            inverted_response = neg < pos
+            low_response_volume = min(pos, neg) < 200
+        pooled_auc_msg = (
+            f"Pooled AUC = {pooled_auc:.4f} — statistically indistinguishable from random."
+            if pooled_auc is not None
+            else ""
+        )
+        inverted_response_msg = (
+            f"Negatives ({neg:,}) < positives ({pos:,}) — inverted response ratio; unusual for an NBA response model."
+            if has_response_counts
+            else ""
+        )
+        low_volume_msg = (
+            f"Very low response volume (positives={pos:,}, negatives={neg:,}) — metrics are not yet statistically stable."
+            if has_response_counts
+            else ""
+        )
 
         checks = [
             (
@@ -421,16 +443,20 @@ class ADMTreesModel:
                 f"Avg splits/tree = {avg_splits_per_tree:.2f} — model is not developing structure (SOP-ADM009).",
             ),
             (
-                abs(pooled_auc - 0.5) < 0.02,
-                f"Pooled AUC = {pooled_auc:.4f} — statistically indistinguishable from random.",
+                pooled_auc is not None and abs(pooled_auc - 0.5) < 0.02,
+                pooled_auc_msg,
             ),
             (
-                neg < pos,
-                f"Negatives ({neg:,}) < positives ({pos:,}) — inverted response ratio; unusual for an NBA response model.",
+                not has_response_counts,
+                "Response counts are unavailable — volume-based stability checks were skipped.",
             ),
             (
-                min(pos, neg) < 200,
-                f"Very low response volume (positives={pos:,}, negatives={neg:,}) — metrics are not yet statistically stable.",
+                inverted_response,
+                inverted_response_msg,
+            ),
+            (
+                low_response_volume,
+                low_volume_msg,
             ),
             (
                 active_predictors < 5,

--- a/python/pdstools/adm/trees/_plots.py
+++ b/python/pdstools/adm/trees/_plots.py
@@ -19,35 +19,35 @@ from typing import TYPE_CHECKING, ClassVar, Literal, SupportsFloat, cast, overlo
 
 import polars as pl
 
+from ...utils import cdh_utils
 from ...utils.namespaces import LazyNamespace, MissingDependenciesException
-from ...utils.pega_template import colorway as _colorway
+from ...utils.plot_utils import abbreviate_label
+from ..ADMDatamart import _STANDARD_PREDICTOR_CATEGORY_COLORS
 from ._nodes import _iter_nodes
 
-# Fixed color assignments for well-known predictor groups.
-# Keyed alphabetically to match the Pega colorway order so the same group
-# always gets the same colour across every plot in the notebook.
-_PREDICTOR_GROUP_COLORMAP: dict[str, str] = {
-    grp: _colorway[i % len(_colorway)]
-    for i, grp in enumerate(sorted(["Context Keys", "Customer", "External Models", "IH", "Param"]))
-}
+# Fixed color assignments for well-known predictor categories, shared with
+# ADMDatamart predictor-category plots.
+_PREDICTOR_CATEGORY_COLORMAP: dict[str, str] = dict(_STANDARD_PREDICTOR_CATEGORY_COLORS)
 
 # Un-aliased value expression — import and extend this in notebooks to add
-# custom predictor groups before calling plot methods.
+# custom predictor categories before calling plot methods.
 # Example (in a notebook cell):
-#   from pdstools.adm.trees._plots import _PREDICTOR_GROUP_VALUE
-#   AGBModel.plot.predictor_group_expr = (
+#   from pdstools.adm.trees._plots import _PREDICTOR_CATEGORY_VALUE
+#   AGBModel.plot.predictor_category_expr = (
 #       pl.when(pl.col("predictor").str.starts_with("MyPrefix"))
-#       .then(pl.lit("External Models"))
-#       .otherwise(_PREDICTOR_GROUP_VALUE)
-#       .alias("Predictor Group")
+#       .then(pl.lit("External Model"))
+#       .otherwise(_PREDICTOR_CATEGORY_VALUE)
+#       .alias("PredictorCategory")
 #   )
-_PREDICTOR_GROUP_VALUE: pl.Expr = (
-    pl.when(pl.col("predictor").str.splitn(".", 2).struct.field("field_0").str.starts_with("py"))
-    .then(pl.lit("Context Keys"))
-    .otherwise(pl.col("predictor").str.splitn(".", 2).struct.field("field_0"))
-)
+_PREDICTOR_CATEGORY_VALUE: pl.Expr = cdh_utils.default_predictor_categorization("predictor").meta.undo_aliases()
 
-_PREDICTOR_GROUP_EXPR: pl.Expr = _PREDICTOR_GROUP_VALUE.alias("Predictor Group")
+_PREDICTOR_CATEGORY_EXPR: pl.Expr = _PREDICTOR_CATEGORY_VALUE.alias("PredictorCategory")
+
+# Backwards-compatible aliases for notebooks written before the AGB plots were
+# aligned with ADM's PredictorCategory terminology.
+_PREDICTOR_GROUP_COLORMAP = _PREDICTOR_CATEGORY_COLORMAP
+_PREDICTOR_GROUP_VALUE = _PREDICTOR_CATEGORY_VALUE
+_PREDICTOR_GROUP_EXPR = _PREDICTOR_CATEGORY_EXPR
 
 logger = logging.getLogger(__name__)
 
@@ -72,26 +72,30 @@ class Plots(LazyNamespace):
 
     def __init__(self, trees_model: "ADMTreesModel") -> None:
         self.trees_model = trees_model
-        self.predictor_group_expr: pl.Expr = _PREDICTOR_GROUP_EXPR
-        """Polars expression producing the ``"Predictor Group"`` column.
+        self.predictor_category_expr: pl.Expr = _PREDICTOR_CATEGORY_EXPR
+        """Polars expression producing the ``"PredictorCategory"`` column.
 
         Set this attribute to a custom expression to override the default
-        grouping (e.g., to map external-score predictors to their own group).
-        See :data:`_PREDICTOR_GROUP_VALUE` for a composable base expression.
+        categorization (e.g., to map external-score predictors to their own
+        category). See :data:`_PREDICTOR_CATEGORY_VALUE` for a composable base
+        expression.
         """
-        self.predictor_group_colormap: dict[str, str] = _PREDICTOR_GROUP_COLORMAP
-        """Color map from predictor group name to hex color string.
+        self.predictor_category_colormap: dict[str, str] = _PREDICTOR_CATEGORY_COLORMAP
+        """Color map from predictor category name to hex color string.
 
-        Extend this dict when you introduce a custom predictor group so the new
-        group always gets a consistent color across all plots.
+        Extend this dict when you introduce a custom predictor category so the
+        new category always gets a consistent color across all plots.
         """
-        self.predictor_group_order: list[str] = list(_PREDICTOR_GROUP_COLORMAP)
-        """Fixed display order of predictor groups in plot legends and axes.
+        self.predictor_category_order: list[str] = list(_PREDICTOR_CATEGORY_COLORMAP)
+        """Fixed display order of predictor categories in plot legends and axes.
 
         Defaults to alphabetical order (the key order of
-        :data:`_PREDICTOR_GROUP_COLORMAP`).  Extend or reorder this list when
-        you add custom groups so legends remain consistent across all plots.
+        :data:`_PREDICTOR_CATEGORY_COLORMAP`).  Extend or reorder this list when
+        you add custom categories so legends remain consistent across all plots.
         """
+        self.predictor_group_expr = self.predictor_category_expr
+        self.predictor_group_colormap = self.predictor_category_colormap
+        self.predictor_group_order = self.predictor_category_order
         super().__init__()
 
     # ------------------------------------------------------------------
@@ -138,6 +142,8 @@ class Plots(LazyNamespace):
         figlist = []
         for (name,), data in self.trees_model.gains_per_split.group_by("predictor"):
             if subset is None or name in subset:
+                split_values = data.get_column("split").unique(maintain_order=True).to_list()
+                split_tick_text = [abbreviate_label(value, max_length=48) for value in split_values]
                 fig = make_subplots()
                 fig.add_trace(
                     go.Box(
@@ -160,6 +166,15 @@ class Plots(LazyNamespace):
                     title=f"Splits on {name}",
                     xaxis_title="Split",
                     yaxis_title="Number",
+                    xaxis_automargin=True,
+                    margin=dict(b=120),
+                )
+                fig.update_xaxes(
+                    tickmode="array",
+                    tickvals=split_values,
+                    ticktext=split_tick_text,
+                    tickangle=45,
+                    automargin=True,
                 )
                 figlist.append(fig)
         return figlist
@@ -444,6 +459,7 @@ class Plots(LazyNamespace):
             title="Total gain and root score per tree",
             xaxis_title="Tree index",
             template="none",
+            margin=dict(r=100),
         )
         fig.update_yaxes(title_text="Total gain", secondary_y=False)
         fig.update_yaxes(title_text="Root score", secondary_y=True)
@@ -484,15 +500,18 @@ class Plots(LazyNamespace):
             .select(["treeID", "total_gain"])
         )
         grand_total = base["total_gain"].sum()
-        df = base.with_columns((pl.col("total_gain").cum_sum() / grand_total).alias("cumulative_gain_share")).select(
-            ["treeID", "cumulative_gain_share"]
+        # A model with no positive-gain splits yet (e.g. a single stump tree)
+        # has grand_total == 0, making the share undefined rather than 0 %.
+        share_expr = (
+            pl.lit(None, dtype=pl.Float64) if not grand_total else (pl.col("total_gain").cum_sum() / grand_total)
         )
+        df = base.with_columns(share_expr.alias("cumulative_gain_share")).select(["treeID", "cumulative_gain_share"])
         if return_df:
             return df
 
         half_idx = (
             df.filter(pl.col("cumulative_gain_share") >= 0.5)["treeID"].first()
-            if (df["cumulative_gain_share"] >= 0.5).any()
+            if grand_total and (df["cumulative_gain_share"] >= 0.5).any()
             else None
         )
         fig = go.Figure()
@@ -559,7 +578,7 @@ class Plots(LazyNamespace):
         -------
         plotly.graph_objects.Figure or pl.DataFrame
             Figure when ``return_df=False``; DataFrame with columns
-            ``predictor``, ``total_gain``, ``Predictor Group`` when
+            ``predictor``, ``total_gain``, ``PredictorCategory`` when
             ``return_df=True``.
         """
         try:
@@ -572,7 +591,7 @@ class Plots(LazyNamespace):
             .agg(pl.col("gains").sum().alias("total_gain"))
             .sort("total_gain", descending=True)
             .head(top_n)
-            .with_columns(self.predictor_group_expr)
+            .with_columns(self.predictor_category_expr)
         )
         if return_df:
             return df
@@ -582,16 +601,16 @@ class Plots(LazyNamespace):
             sorted_df,
             x="total_gain",
             y="predictor",
-            color="Predictor Group",
+            color="PredictorCategory",
             orientation="h",
             title=f"Top {top_n} predictors by total gain",
-            labels={"total_gain": "Total gain", "predictor": "", "Predictor Group": "Predictor Group"},
+            labels={"total_gain": "Total gain", "predictor": "", "PredictorCategory": "Predictor category"},
             template="none",
             category_orders={
                 "predictor": sorted_df["predictor"].to_list(),
-                "Predictor Group": self.predictor_group_order,
+                "PredictorCategory": self.predictor_category_order,
             },
-            color_discrete_map=self.predictor_group_colormap,
+            color_discrete_map=self.predictor_category_colormap,
         ).update_layout(yaxis_automargin=True, yaxis_autorange="reversed")
 
     @overload
@@ -620,7 +639,7 @@ class Plots(LazyNamespace):
         plotly.graph_objects.Figure or pl.DataFrame
             Figure when ``return_df=False``; DataFrame with columns
             ``predictor``, ``early_gain``, ``late_gain``, ``total_gain``,
-            ``Predictor Group`` when ``return_df=True``.
+            ``PredictorCategory`` when ``return_df=True``.
         """
         try:
             import plotly.express as px
@@ -645,10 +664,10 @@ class Plots(LazyNamespace):
                 if node.split is not None and node.gain > 0:
                     rows.append({"predictor": node.split.variable, "gain": node.gain, "bucket": bucket})
 
-        if not rows:
-            raise ValueError("No gain data found in tree splits.")
-
-        raw = pl.DataFrame(rows)
+        raw = pl.DataFrame(
+            rows,
+            schema={"predictor": pl.String, "gain": pl.Float64, "bucket": pl.String},
+        )
         early = (
             raw.filter(pl.col("bucket") == "early").group_by("predictor").agg(pl.col("gain").sum().alias("early_gain"))
         )
@@ -661,18 +680,23 @@ class Plots(LazyNamespace):
             )
             .with_columns(
                 (pl.col("early_gain") + pl.col("late_gain")).alias("total_gain"),
-                self.predictor_group_expr,
+                self.predictor_category_expr,
             )
         )
         if return_df:
             return df
 
-        max_val = max(df["early_gain"].max() or 0.0, df["late_gain"].max() or 0.0)
+        if df.is_empty():
+            import plotly.graph_objects as go
+
+            return go.Figure().update_layout(title="Early vs late tree gain per predictor")
+
+        max_val = max(df["early_gain"].max() or 0.0, df["late_gain"].max() or 0.0) or 1.0
         fig = px.scatter(
             df,
             x="early_gain",
             y="late_gain",
-            color="Predictor Group",
+            color="PredictorCategory",
             size="total_gain",
             hover_name="predictor",
             log_x=True,
@@ -681,11 +705,11 @@ class Plots(LazyNamespace):
             labels={
                 "early_gain": f"Gain in first {quarter} trees",
                 "late_gain": f"Gain in last {quarter} trees",
-                "Predictor Group": "Predictor Group",
+                "PredictorCategory": "Predictor category",
             },
             template="none",
-            category_orders={"Predictor Group": self.predictor_group_order},
-            color_discrete_map=self.predictor_group_colormap,
+            category_orders={"PredictorCategory": self.predictor_category_order},
+            color_discrete_map=self.predictor_category_colormap,
         )
         fig.add_shape(
             type="line",
@@ -708,12 +732,13 @@ class Plots(LazyNamespace):
         *,
         return_df: bool = False,
     ) -> "go.Figure | pl.DataFrame":
-        """Plot total information gain broken down by predictor group.
+        """Plot total information gain broken down by predictor category.
 
-        The predictor group is the first dot-separated segment of the predictor
-        name (e.g. ``IH``, ``Customer``, ``Param``), with Pega context-key
-        predictors (``py*``) collapsed into ``Context Keys``.  Override
-        ``AGBModel.plot.predictor_group_expr`` to define custom groups.
+        The predictor category follows ADM's default categorisation: dotted
+        names use their first segment (for example, ``IH``, ``Customer``,
+        ``Param``), while undotted names such as ``pyGroup`` are ``Primary``.
+        Override ``AGBModel.plot.predictor_category_expr`` to define custom
+        categories.
 
         Parameters
         ----------
@@ -724,7 +749,7 @@ class Plots(LazyNamespace):
         -------
         plotly.graph_objects.Figure or pl.DataFrame
             Figure when ``return_df=False``; DataFrame with columns
-            ``Predictor Group``, ``total_gain``, ``gain_share`` when
+            ``PredictorCategory``, ``total_gain``, ``gain_share`` when
             ``return_df=True``.
         """
         try:
@@ -733,8 +758,8 @@ class Plots(LazyNamespace):
             raise MissingDependenciesException(["plotly"], "AGB", deps_group="adm") from None
 
         df = (
-            self.trees_model.gains_per_split.with_columns(self.predictor_group_expr)
-            .group_by("Predictor Group")
+            self.trees_model.gains_per_split.with_columns(self.predictor_category_expr)
+            .group_by("PredictorCategory")
             .agg(pl.col("gains").sum().alias("total_gain"))
             .sort("total_gain", descending=True)
         )
@@ -747,16 +772,16 @@ class Plots(LazyNamespace):
         fig = px.bar(
             sorted_df,
             x="total_gain",
-            y="Predictor Group",
-            color="Predictor Group",
+            y="PredictorCategory",
+            color="PredictorCategory",
             orientation="h",
-            title="Total gain by predictor group",
-            labels={"total_gain": "Total gain", "Predictor Group": ""},
+            title="Total gain by predictor category",
+            labels={"total_gain": "Total gain", "PredictorCategory": ""},
             template="none",
-            category_orders={"Predictor Group": self.predictor_group_order},
-            color_discrete_map=self.predictor_group_colormap,
+            category_orders={"PredictorCategory": sorted_df["PredictorCategory"].to_list()},
+            color_discrete_map=self.predictor_category_colormap,
         )
-        fig.update_layout(showlegend=False, yaxis_autorange="reversed")
+        fig.update_layout(showlegend=False, yaxis_automargin=True, yaxis_autorange="reversed")
         return fig
 
     @overload
@@ -786,7 +811,7 @@ class Plots(LazyNamespace):
         plotly.graph_objects.Figure or pl.DataFrame
             Figure when ``return_df=False``; DataFrame with columns
             ``predictor``, ``mean_depth``, ``tree_coverage``, ``total_gain``,
-            ``Predictor Group`` when ``return_df=True``.
+            ``PredictorCategory`` when ``return_df=True``.
         """
         try:
             import plotly.express as px
@@ -806,10 +831,10 @@ class Plots(LazyNamespace):
                         }
                     )
 
-        if not rows:
-            raise ValueError("No split data found in trees.")
-
-        raw = pl.DataFrame(rows)
+        raw = pl.DataFrame(
+            rows,
+            schema={"predictor": pl.String, "depth": pl.Int64, "gain": pl.Float64, "treeID": pl.Int64},
+        )
         df = (
             raw.group_by("predictor")
             .agg(
@@ -817,27 +842,32 @@ class Plots(LazyNamespace):
                 pl.col("treeID").n_unique().alias("tree_coverage"),
                 pl.col("gain").sum().alias("total_gain"),
             )
-            .with_columns(self.predictor_group_expr)
+            .with_columns(self.predictor_category_expr)
         )
         if return_df:
             return df
+
+        if df.is_empty():
+            import plotly.graph_objects as go
+
+            return go.Figure().update_layout(title="Feature role map (router vs refiner)")
 
         return px.scatter(
             df,
             x="mean_depth",
             y="tree_coverage",
             size="total_gain",
-            color="Predictor Group",
+            color="PredictorCategory",
             hover_name="predictor",
             title="Feature role map (router vs refiner)",
             labels={
                 "mean_depth": "Mean split depth",
                 "tree_coverage": "Tree coverage (# trees)",
-                "Predictor Group": "Predictor Group",
+                "PredictorCategory": "Predictor category",
             },
             template="none",
-            category_orders={"Predictor Group": self.predictor_group_order},
-            color_discrete_map=self.predictor_group_colormap,
+            category_orders={"PredictorCategory": self.predictor_category_order},
+            color_discrete_map=self.predictor_category_colormap,
         )
 
     @overload
@@ -1147,9 +1177,9 @@ class Plots(LazyNamespace):
         fig = px.area(
             df,
             title="Variable types per tree",
-            labels={"index": "Tree number", "value": "Number of splits", "variable": "Predictor Group"},
+            labels={"index": "Tree number", "value": "Number of splits", "variable": "Predictor category"},
             template="none",
-            color_discrete_map=self.predictor_group_colormap,
+            color_discrete_map=self.predictor_category_colormap,
             **kwargs,
         )
         fig.layout["updatemenus"] += (

--- a/python/tests/adm/test_ADMTrees.py
+++ b/python/tests/adm/test_ADMTrees.py
@@ -953,6 +953,7 @@ def test_plot_gain_per_tree_figure(rich_model: ADMTreesModel):
 
     fig = rich_model.plot.gain_per_tree()
     assert isinstance(fig, go.Figure)
+    assert fig.layout.margin.r == 100
 
 
 # ---------------------------------------------------------------------------
@@ -987,13 +988,13 @@ def test_plot_cumulative_gain_share_figure(rich_model: ADMTreesModel):
 
 def test_plot_feature_importance_by_gain_return_df(rich_model: ADMTreesModel):
     df = rich_model.plot.feature_importance_by_gain(return_df=True)
-    assert df.columns == ["predictor", "total_gain", "Predictor Group"]
+    assert df.columns == ["predictor", "total_gain", "PredictorCategory"]
     assert df.height == 15
     # Top predictor must be pyGroup.
     assert df["predictor"][0] == "pyGroup"
     assert df["total_gain"][0] == pytest.approx(48305.23435, rel=1e-4)
-    # py* predictors are grouped under "Context Keys".
-    assert df["Predictor Group"][0] == "Context Keys"
+    # Undotted py* context fields follow ADM's default Primary category.
+    assert df["PredictorCategory"][0] == "Primary"
     # All rows are sorted descending by total_gain.
     gains = df["total_gain"].to_list()
     assert gains == sorted(gains, reverse=True)
@@ -1009,6 +1010,10 @@ def test_plot_feature_importance_by_gain_figure(rich_model: ADMTreesModel):
 
     fig = rich_model.plot.feature_importance_by_gain()
     assert isinstance(fig, go.Figure)
+    colors_by_category = {trace.name: trace.marker.color for trace in fig.data}
+    assert colors_by_category["Customer"] == "#001F5F"
+    assert colors_by_category["IH"] == "#10A5AC"
+    assert colors_by_category["Primary"] == "#63666F"
 
 
 # ---------------------------------------------------------------------------
@@ -1018,7 +1023,7 @@ def test_plot_feature_importance_by_gain_figure(rich_model: ADMTreesModel):
 
 def test_plot_early_vs_late_gain_return_df(rich_model: ADMTreesModel):
     df = rich_model.plot.early_vs_late_gain(return_df=True)
-    assert df.columns == ["predictor", "early_gain", "late_gain", "total_gain", "Predictor Group"]
+    assert df.columns == ["predictor", "early_gain", "late_gain", "total_gain", "PredictorCategory"]
     assert df.height == 179
     # Every predictor that appears has non-negative gains in each bucket.
     assert (df["early_gain"] >= 0).all()
@@ -1031,8 +1036,8 @@ def test_plot_early_vs_late_gain_return_df(rich_model: ADMTreesModel):
     row = df.filter(df["predictor"] == "pyGroup").row(0, named=True)
     assert row["early_gain"] == pytest.approx(15286.858930, rel=1e-4)
     assert row["late_gain"] == pytest.approx(6791.741500, rel=1e-4)
-    # py* predictors are grouped under "Context Keys".
-    assert row["Predictor Group"] == "Context Keys"
+    # Undotted py* context fields follow ADM's default Primary category.
+    assert row["PredictorCategory"] == "Primary"
 
 
 def test_plot_early_vs_late_gain_figure(rich_model: ADMTreesModel):
@@ -1049,14 +1054,14 @@ def test_plot_early_vs_late_gain_figure(rich_model: ADMTreesModel):
 
 def test_plot_gain_by_namespace_return_df(rich_model: ADMTreesModel):
     df = rich_model.plot.gain_by_namespace(return_df=True)
-    assert df.columns == ["Predictor Group", "total_gain", "gain_share"]
-    # 4 distinct predictor groups (IH, Context Keys, Customer, Param).
+    assert df.columns == ["PredictorCategory", "total_gain", "gain_share"]
+    # 4 distinct predictor categories (IH, Primary, Customer, Param).
     assert df.height == 4
     # gain_share must sum to 1.
     assert df["gain_share"].sum() == pytest.approx(1.0, abs=1e-9)
-    # IH is the dominant predictor group.
+    # IH is the dominant predictor category.
     top = df.sort("total_gain", descending=True).row(0, named=True)
-    assert top["Predictor Group"] == "IH"
+    assert top["PredictorCategory"] == "IH"
     assert top["gain_share"] == pytest.approx(0.45146, abs=1e-4)
 
 
@@ -1065,6 +1070,10 @@ def test_plot_gain_by_namespace_figure(rich_model: ADMTreesModel):
 
     fig = rich_model.plot.gain_by_namespace()
     assert isinstance(fig, go.Figure)
+    expected_order = rich_model.plot.gain_by_namespace(return_df=True)["PredictorCategory"].to_list()
+    assert list(fig.layout.yaxis.categoryarray) == expected_order
+    assert fig.layout.yaxis.autorange == "reversed"
+    assert fig.layout.yaxis.automargin is True
 
 
 # ---------------------------------------------------------------------------
@@ -1074,17 +1083,17 @@ def test_plot_gain_by_namespace_figure(rich_model: ADMTreesModel):
 
 def test_plot_feature_role_map_return_df(rich_model: ADMTreesModel):
     df = rich_model.plot.feature_role_map(return_df=True)
-    assert df.columns == ["predictor", "mean_depth", "tree_coverage", "total_gain", "Predictor Group"]
+    assert df.columns == ["predictor", "mean_depth", "tree_coverage", "total_gain", "PredictorCategory"]
     assert df.height == 194
     # pyGroup is used in 63 distinct trees.
     row = df.filter(df["predictor"] == "pyGroup").row(0, named=True)
     assert row["tree_coverage"] == 63
     assert row["total_gain"] == pytest.approx(48305.23435, rel=1e-4)
     assert row["mean_depth"] == pytest.approx(4.3161, abs=1e-3)
-    # py* predictors are grouped under "Context Keys".
-    assert row["Predictor Group"] == "Context Keys"
-    # Exactly 4 predictor groups present.
-    assert df["Predictor Group"].n_unique() == 4
+    # Undotted py* context fields follow ADM's default Primary category.
+    assert row["PredictorCategory"] == "Primary"
+    # Exactly 4 predictor categories present.
+    assert df["PredictorCategory"].n_unique() == 4
 
 
 def test_plot_feature_role_map_figure(rich_model: ADMTreesModel):

--- a/python/tests/adm/test_ADMTrees.py
+++ b/python/tests/adm/test_ADMTrees.py
@@ -255,6 +255,45 @@ def test_metrics_stump_count_exported(exported_model: ADMTreesModel):
     assert m["tree_depth_std"] == 2.11
 
 
+def test_sanity_check_flags_immature_stump_model():
+    model = ADMTreesModel(
+        trees={"model": [{"score": 0.0}]},
+        model=[{"score": 0.0}],
+        properties={
+            "auc": 0.5,
+            "trainingStats": {"positiveCount": 25, "negativeCount": 10},
+        },
+    )
+
+    result = model.sanity_check()
+
+    assert result == {
+        "n_trees": 1,
+        "pooled_auc": 0.5,
+        "positive_count": 25,
+        "negative_count": 10,
+        "flags": [
+            "Only 1 tree(s) — model has barely started learning.",
+            "1/1 trees are stumps (no split) — mostly non-informative trees.",
+            "Avg splits/tree = 0.00 — model is not developing structure (SOP-ADM009).",
+            "Pooled AUC = 0.5000 — statistically indistinguishable from random.",
+            "Negatives (10) < positives (25) — inverted response ratio; unusual for an NBA response model.",
+            "Very low response volume (positives=25, negatives=10) — metrics are not yet statistically stable.",
+            "Only 0 active predictor(s) — model is deciding on a very narrow feature set.",
+        ],
+    }
+
+
+def test_sanity_check_handles_missing_response_counts():
+    model = ADMTreesModel(trees={"model": [{"score": 0.0}]}, model=[{"score": 0.0}], properties={"auc": 0.7})
+
+    result = model.sanity_check()
+
+    assert result["positive_count"] is None
+    assert result["negative_count"] is None
+    assert "Response counts are unavailable — volume-based stability checks were skipped." in result["flags"]
+
+
 # --- split type tests -------------------------------------------------------
 
 
@@ -929,6 +968,40 @@ def rich_model() -> ADMTreesModel:
     return ADMTreesModel.from_file(f"{basePath}/data/agb/ModelExportWithSampleCount.json")
 
 
+@pytest.fixture
+def stump_model() -> ADMTreesModel:
+    """Minimal model with one tree and no splits."""
+    return ADMTreesModel(
+        trees={"model": [{"score": 0.0}]},
+        model=[{"score": 0.0}],
+        properties={
+            "auc": 0.7,
+            "trainingStats": {"positiveCount": 500, "negativeCount": 500},
+        },
+    )
+
+
+def test_stump_model_empty_gain_tables_keep_numeric_schema(stump_model: ADMTreesModel):
+    import polars as pl
+
+    assert stump_model.gains_per_split.schema == {
+        "split": pl.String,
+        "gains": pl.Float64,
+        "predictor": pl.String,
+    }
+
+    tree_stats = stump_model.tree_stats
+    assert tree_stats.schema["gains"] == pl.List(pl.Float64)
+    assert tree_stats.row(0, named=True) == {
+        "treeID": 0,
+        "score": 0.0,
+        "depth": 0,
+        "nsplits": 0,
+        "gains": [],
+        "meangains": 0,
+    }
+
+
 # ---------------------------------------------------------------------------
 # plot.gain_per_tree
 # ---------------------------------------------------------------------------
@@ -979,6 +1052,17 @@ def test_plot_cumulative_gain_share_figure(rich_model: ADMTreesModel):
 
     fig = rich_model.plot.cumulative_gain_share()
     assert isinstance(fig, go.Figure)
+
+
+def test_plot_cumulative_gain_share_stump_model(stump_model: ADMTreesModel):
+    import plotly.graph_objects as go
+
+    df = stump_model.plot.cumulative_gain_share(return_df=True)
+    assert df.to_dict(as_series=False) == {"treeID": [0], "cumulative_gain_share": [None]}
+
+    fig = stump_model.plot.cumulative_gain_share()
+    assert isinstance(fig, go.Figure)
+    assert fig.data[0].y == (None,)
 
 
 # ---------------------------------------------------------------------------
@@ -1047,6 +1131,18 @@ def test_plot_early_vs_late_gain_figure(rich_model: ADMTreesModel):
     assert isinstance(fig, go.Figure)
 
 
+def test_plot_early_vs_late_gain_stump_model_returns_empty_figure(stump_model: ADMTreesModel):
+    import plotly.graph_objects as go
+
+    df = stump_model.plot.early_vs_late_gain(return_df=True)
+    assert df.columns == ["predictor", "early_gain", "late_gain", "total_gain", "PredictorCategory"]
+    assert df.is_empty()
+
+    fig = stump_model.plot.early_vs_late_gain()
+    assert isinstance(fig, go.Figure)
+    assert fig.layout.title.text == "Early vs late tree gain per predictor"
+
+
 # ---------------------------------------------------------------------------
 # plot.gain_by_namespace
 # ---------------------------------------------------------------------------
@@ -1101,6 +1197,18 @@ def test_plot_feature_role_map_figure(rich_model: ADMTreesModel):
 
     fig = rich_model.plot.feature_role_map()
     assert isinstance(fig, go.Figure)
+
+
+def test_plot_feature_role_map_stump_model_returns_empty_figure(stump_model: ADMTreesModel):
+    import plotly.graph_objects as go
+
+    df = stump_model.plot.feature_role_map(return_df=True)
+    assert df.columns == ["predictor", "mean_depth", "tree_coverage", "total_gain", "PredictorCategory"]
+    assert df.is_empty()
+
+    fig = stump_model.plot.feature_role_map()
+    assert isinstance(fig, go.Figure)
+    assert fig.layout.title.text == "Feature role map (router vs refiner)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds safer AGB model handling and improves the AGB explanation notebook.

**Changes**

- Added [ADMTreesModel.sanity_check()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to flag underdeveloped or suspicious AGB exports.
- Hardened AGB tree stats and plot data paths for stump/empty-model edge cases.
- Updated AGB plots to use ADM [PredictorCategory](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) terminology and default colors.
- Improved plot readability for long labels and horizontal category charts.
- Updated [AGBExplained.ipynb](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with the sanity check, clearer AUC caveats, and Health Check-aligned external-model keyword categorization.