### PR TITLE
fix(report_utils): inline local JS so CDN-mode HTML is a single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- CDN-mode HTML reports (``full_embed=False``) are now genuinely
+  self-contained single files. Quarto's local JavaScript assets are inlined
+  alongside the CSS that #679 already handled, and fonts/images referenced
+  from within that CSS are embedded as data URIs. The now-unreferenced
+  ``<basename>_files/`` folder is dropped, so ``bundle_quarto_resources``
+  no longer has a resources folder to zip and the Health Check returns
+  ``HealthCheck.html`` rather than ``HealthCheck.zip``. This gives an
+  esbuild-free path to a standalone report, which matters for hardened
+  images that strip the esbuild binary for CVE reasons. Remote CDN
+  references (Plotly, MathJax) are deliberately left untouched.
 - Explanations: `missing=False` had no effect on
   `predictor_contributions` (the exclusion filter compared two literals) and
   was never applied at all on the value-level path.

--- a/python/pdstools/utils/report_utils/__init__.py
+++ b/python/pdstools/utils/report_utils/__init__.py
@@ -69,9 +69,12 @@ from ._filenames import (
 )
 from ._html import (
     _inline_css,
+    _inline_js,
     bundle_quarto_resources,
     check_report_for_errors,
+    drop_inlined_resources,
     generate_zipped_report,
+    inline_local_assets,
 )
 from ._polars_helpers import (
     avg_by_hierarchy,
@@ -122,6 +125,7 @@ __all__ = [
     "create_metric_itable",
     # query serialisation
     "deserialize_query",
+    "drop_inlined_resources",
     "exclusive_0_1_range_rag",
     "gains_table",
     "generate_zipped_report",
@@ -129,6 +133,7 @@ __all__ = [
     # quarto execution / callouts / credits
     "get_pandoc_with_version",
     "get_quarto_with_version",
+    "inline_local_assets",
     "is_esbuild_available",
     "logger",
     "max_by_hierarchy",

--- a/python/pdstools/utils/report_utils/_html.py
+++ b/python/pdstools/utils/report_utils/_html.py
@@ -186,8 +186,8 @@ def inline_local_assets(html_path: Path, base_dir: Path) -> tuple[int, int]:
     return _inline_css(html_path, base_dir), _inline_js(html_path, base_dir)
 
 
-def drop_inlined_resources(html_path: Path) -> bool:
-    """Delete a Quarto ``<stem>_files`` folder once nothing references it.
+def drop_inlined_resources(html_path: Path, *resource_stems: str) -> int:
+    """Delete Quarto resources folders once nothing references them.
 
     Called after :func:`inline_local_assets`. If the HTML still mentions the
     resources folder — an asset type we do not inline, or a file that failed to
@@ -196,29 +196,42 @@ def drop_inlined_resources(html_path: Path) -> bool:
     Parameters
     ----------
     html_path : Path
-        The rendered HTML file whose companion resources folder to consider.
+        The rendered HTML file whose companion resources folders to consider.
+    *resource_stems : str
+        Optional additional stems for resources folders. Quarto usually names
+        the folder after the source ``.qmd`` file, which can differ from the
+        output HTML stem when the report filename includes a suffix.
 
     Returns
     -------
-    bool
-        True if the resources folder was removed.
+    int
+        Number of resources folders removed.
     """
     html_path = Path(html_path)
-    resources_dir = html_path.with_name(f"{html_path.stem}_files")
-    if not (html_path.is_file() and resources_dir.is_dir()):
-        return False
+    if not html_path.is_file():
+        return 0
 
-    if resources_dir.name in html_path.read_text(encoding="utf-8"):
-        logger.info(
-            "%s still references %s; keeping the resources folder.",
-            html_path.name,
-            resources_dir.name,
-        )
-        return False
+    stems = dict.fromkeys((html_path.stem, *resource_stems))
+    content = html_path.read_text(encoding="utf-8")
+    removed = 0
+    for stem in stems:
+        if not stem:
+            continue
+        resources_dir = html_path.with_name(f"{stem}_files")
+        if not resources_dir.is_dir():
+            continue
+        if resources_dir.name in content:
+            logger.info(
+                "%s still references %s; keeping the resources folder.",
+                html_path.name,
+                resources_dir.name,
+            )
+            continue
 
-    shutil.rmtree(resources_dir, ignore_errors=True)
-    logger.debug("Removed fully inlined resources folder %s", resources_dir.name)
-    return True
+        shutil.rmtree(resources_dir, ignore_errors=True)
+        logger.debug("Removed fully inlined resources folder %s", resources_dir.name)
+        removed += 1
+    return removed
 
 
 def generate_zipped_report(output_filename: str, folder_to_zip: Path):

--- a/python/pdstools/utils/report_utils/_html.py
+++ b/python/pdstools/utils/report_utils/_html.py
@@ -312,6 +312,7 @@ def drop_inlined_resources(html_path: Path, *resource_stems: str) -> int:
             )
             continue
 
+        # Only delete the folder after every reference to it has been inlined.
         shutil.rmtree(resources_dir, ignore_errors=True)
         logger.debug("Removed fully inlined resources folder %s", resources_dir.name)
         removed += 1
@@ -396,6 +397,7 @@ def bundle_quarto_resources(output_path: Path) -> Path:
     if not resources_dir.is_dir():
         return output_path
 
+    # Fallback: if local resources remain, ship a complete ZIP rather than broken HTML.
     zip_path = output_path.with_suffix(".zip")
     logger.info(
         f"Bundling {output_path.name} with resources folder {resources_dir.name} into {zip_path.name}",

--- a/python/pdstools/utils/report_utils/_html.py
+++ b/python/pdstools/utils/report_utils/_html.py
@@ -20,10 +20,24 @@ _SCRIPT_SRC_RE = re.compile(
     r"<script\b[^>]*\bsrc=[\"']([^\"']+)[\"'][^>]*>\s*</script>",
     re.IGNORECASE,
 )
+_SCRIPT_OPEN_TAG_RE = re.compile(r"<script\b[^>]*>", re.IGNORECASE)
 _CSS_URL_RE = re.compile(r"url\(\s*([\"']?)([^\"')]+)\1\s*\)", re.IGNORECASE)
+_HTML_ATTR_RE = re.compile(r"\s+([^\s=/>]+)(?:\s*=\s*(\"[^\"]*\"|'[^']*'|[^\s>]+))?")
+_MODULE_NAMESPACE_IMPORT_RE = re.compile(
+    r"^\s*import\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+[\"']([^\"']+)[\"'];\s*$",
+    re.MULTILINE,
+)
+_JS_EXPORT_DECL_RE = re.compile(
+    r"(^\s*)export\s+(async\s+function|function|class|const|let|var)\s+([A-Za-z_$][\w$]*)",
+    re.MULTILINE,
+)
+_JS_EXPORT_LIST_RE = re.compile(r"^\s*export\s*\{([^}]+)\};?\s*$", re.MULTILINE)
 
 # References we never try to localise: they are already remote or self-contained.
 _REMOTE_PREFIXES = ("http://", "https://", "//", "data:", "#", "about:")
+_STYLE_ATTR_ALLOWLIST = {"id", "class", "media", "nonce", "title", "type"}
+_STYLE_DROP_ATTRS = {"href", "rel", "integrity", "crossorigin", "referrerpolicy"}
+_SCRIPT_DROP_ATTRS = {"src", "integrity", "crossorigin", "referrerpolicy"}
 
 
 def _is_remote(reference: str) -> bool:
@@ -35,6 +49,67 @@ def _as_data_uri(path: Path) -> str:
     """Encode a binary asset (font, image) as a base64 ``data:`` URI."""
     mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
     return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
+
+
+def _preserved_attrs(
+    tag: str,
+    *,
+    drop_attrs: set[str],
+    allow_attrs: set[str] | None = None,
+) -> str:
+    """Return attributes safe to carry onto an inlined replacement tag."""
+    attrs: list[str] = []
+    for match in _HTML_ATTR_RE.finditer(tag):
+        name = match.group(1)
+        attr_name = name.lower()
+        if attr_name in drop_attrs:
+            continue
+        if allow_attrs is not None and attr_name not in allow_attrs and not attr_name.startswith("data-"):
+            continue
+        value = match.group(2)
+        attrs.append(name if value is None else f"{name}={value}")
+    return f" {' '.join(attrs)}" if attrs else ""
+
+
+def _strip_module_exports(js_content: str) -> tuple[str, list[str]]:
+    """Strip named exports from a local ES module and return their names."""
+    exports: list[str] = []
+
+    def _replace_declaration(match: re.Match) -> str:
+        exports.append(match.group(3))
+        return f"{match.group(1)}{match.group(2)} {match.group(3)}"
+
+    def _replace_export_list(match: re.Match) -> str:
+        for item in match.group(1).split(","):
+            parts = item.strip().split()
+            if len(parts) == 3 and parts[1] == "as":
+                exports.append(f"{parts[2]}: {parts[0]}")
+            elif len(parts) == 1 and parts[0]:
+                exports.append(parts[0])
+        return ""
+
+    js_content = _JS_EXPORT_DECL_RE.sub(_replace_declaration, js_content)
+    js_content = _JS_EXPORT_LIST_RE.sub(_replace_export_list, js_content)
+    return js_content, exports
+
+
+def _inline_local_module_imports(js_content: str, js_dir: Path) -> str:
+    """Inline local ``import * as name from './module.js'`` dependencies."""
+
+    def _replace(match: re.Match) -> str:
+        namespace = match.group(1)
+        reference = match.group(2)
+        if _is_remote(reference):
+            return match.group(0)
+        module_path = (js_dir / reference).resolve()
+        if not module_path.is_file():
+            logger.warning("JS module file not found, leaving import intact: %s", module_path)
+            return match.group(0)
+        module_content = _inline_local_module_imports(module_path.read_text(encoding="utf-8"), module_path.parent)
+        module_content, exports = _strip_module_exports(module_content)
+        return f"const {namespace} = (() => {{\n{module_content}\nreturn {{{', '.join(exports)}}};\n}})();"
+
+    return _MODULE_NAMESPACE_IMPORT_RE.sub(_replace, js_content)
 
 
 def _inline_css_urls(css: str, css_dir: Path) -> str:
@@ -109,8 +184,13 @@ def _inline_css(html_path: Path, base_dir: Path) -> int:
             logger.warning("CSS file not found, leaving <link> tag intact: %s", css_path)
             return tag
         css_content = _inline_css_urls(css_path.read_text(encoding="utf-8"), css_path.parent)
+        style_attrs = _preserved_attrs(
+            tag,
+            drop_attrs=_STYLE_DROP_ATTRS,
+            allow_attrs=_STYLE_ATTR_ALLOWLIST,
+        )
         inlined += 1
-        return f"<style>\n{css_content}\n</style>"
+        return f"<style{style_attrs}>\n{css_content}\n</style>"
 
     patched = _LINK_STYLESHEET_RE.sub(_replace, content)
     if inlined:
@@ -151,11 +231,15 @@ def _inline_js(html_path: Path, base_dir: Path) -> int:
         if not js_path.is_file():
             logger.warning("JS file not found, leaving <script> tag intact: %s", js_path)
             return match.group(0)
-        js_content = js_path.read_text(encoding="utf-8")
+        js_content = _inline_local_module_imports(js_path.read_text(encoding="utf-8"), js_path.parent)
         # A literal "</script>" inside the source would close the tag early.
         js_content = js_content.replace("</script>", "<\\/script>")
+        open_tag_match = _SCRIPT_OPEN_TAG_RE.search(match.group(0))
+        script_attrs = (
+            _preserved_attrs(open_tag_match.group(0), drop_attrs=_SCRIPT_DROP_ATTRS) if open_tag_match else ""
+        )
         inlined += 1
-        return f"<script>\n{js_content}\n</script>"
+        return f"<script{script_attrs}>\n{js_content}\n</script>"
 
     patched = _SCRIPT_SRC_RE.sub(_replace, content)
     if inlined:

--- a/python/pdstools/utils/report_utils/_html.py
+++ b/python/pdstools/utils/report_utils/_html.py
@@ -1,7 +1,9 @@
-"""HTML post-processing: CSS inlining, zip bundling, error scanning."""
+"""HTML post-processing: local asset inlining, zip bundling, error scanning."""
 
 from __future__ import annotations
 
+import base64
+import mimetypes
 import re
 import shutil
 import zipfile
@@ -14,6 +16,59 @@ _LINK_STYLESHEET_RE = re.compile(
     re.IGNORECASE,
 )
 _HREF_ATTR_RE = re.compile(r"\bhref=[\"']([^\"']+)[\"']", re.IGNORECASE)
+_SCRIPT_SRC_RE = re.compile(
+    r"<script\b[^>]*\bsrc=[\"']([^\"']+)[\"'][^>]*>\s*</script>",
+    re.IGNORECASE,
+)
+_CSS_URL_RE = re.compile(r"url\(\s*([\"']?)([^\"')]+)\1\s*\)", re.IGNORECASE)
+
+# References we never try to localise: they are already remote or self-contained.
+_REMOTE_PREFIXES = ("http://", "https://", "//", "data:", "#", "about:")
+
+
+def _is_remote(reference: str) -> bool:
+    """Whether a URL reference points somewhere other than the local filesystem."""
+    return reference.strip().startswith(_REMOTE_PREFIXES)
+
+
+def _as_data_uri(path: Path) -> str:
+    """Encode a binary asset (font, image) as a base64 ``data:`` URI."""
+    mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
+
+
+def _inline_css_urls(css: str, css_dir: Path) -> str:
+    """Rewrite relative ``url(...)`` references in a stylesheet to data URIs.
+
+    Stylesheets pull in fonts and images by relative path. Once the CSS text is
+    lifted into a ``<style>`` block those paths break, so the referenced assets
+    are embedded directly. Remote and already-inline references are untouched,
+    as are references that do not resolve to a file on disk.
+
+    Parameters
+    ----------
+    css : str
+        Stylesheet text.
+    css_dir : Path
+        Directory of the stylesheet, used to resolve relative references.
+
+    Returns
+    -------
+    str
+        The stylesheet with resolvable local references replaced by data URIs.
+    """
+
+    def _replace(match: re.Match) -> str:
+        reference = match.group(2).strip()
+        if _is_remote(reference):
+            return match.group(0)
+        # Strip cache-busting query strings and fragments: "font.woff?v=2#iefix".
+        asset_path = (css_dir / reference.split("?")[0].split("#")[0]).resolve()
+        if not asset_path.is_file():
+            return match.group(0)
+        return f'url("{_as_data_uri(asset_path)}")'
+
+    return _CSS_URL_RE.sub(_replace, css)
 
 
 def _inline_css(html_path: Path, base_dir: Path) -> int:
@@ -21,6 +76,7 @@ def _inline_css(html_path: Path, base_dir: Path) -> int:
 
     Replaces each ``<link rel="stylesheet" href="...">`` whose ``href`` is a
     relative path with an inline ``<style>`` block containing the CSS text.
+    Fonts and images referenced from within that CSS are embedded as data URIs.
     Absolute URLs (``http://``, ``https://``, ``//``) are left untouched.
     Missing files are logged as warnings and left alone.
 
@@ -46,13 +102,13 @@ def _inline_css(html_path: Path, base_dir: Path) -> int:
         if not href_match:
             return tag
         href = str(href_match.group(1))
-        if href.startswith(("http://", "https://", "//")):
+        if _is_remote(href):
             return tag
         css_path = (base_dir / href).resolve()
         if not css_path.is_file():
             logger.warning("CSS file not found, leaving <link> tag intact: %s", css_path)
             return tag
-        css_content = css_path.read_text(encoding="utf-8")
+        css_content = _inline_css_urls(css_path.read_text(encoding="utf-8"), css_path.parent)
         inlined += 1
         return f"<style>\n{css_content}\n</style>"
 
@@ -61,6 +117,108 @@ def _inline_css(html_path: Path, base_dir: Path) -> int:
         html_path.write_text(patched, encoding="utf-8")
         logger.debug("Inlined %d CSS file(s) into %s", inlined, html_path.name)
     return inlined
+
+
+def _inline_js(html_path: Path, base_dir: Path) -> int:
+    """Inline relative ``<script src="...">`` tags in an HTML file.
+
+    Replaces each script tag whose ``src`` is a relative path with an inline
+    ``<script>`` block containing the JavaScript source. Absolute URLs are left
+    untouched, so CDN-hosted libraries keep loading from the CDN. Missing files
+    are logged as warnings and left alone.
+
+    Parameters
+    ----------
+    html_path : Path
+        HTML file to patch in-place.
+    base_dir : Path
+        Directory used to resolve relative ``src`` values.
+
+    Returns
+    -------
+    int
+        Number of JavaScript files successfully inlined.
+    """
+    content = html_path.read_text(encoding="utf-8")
+    inlined = 0
+
+    def _replace(match: re.Match) -> str:
+        nonlocal inlined
+        src = str(match.group(1))
+        if _is_remote(src):
+            return match.group(0)
+        js_path = (base_dir / src).resolve()
+        if not js_path.is_file():
+            logger.warning("JS file not found, leaving <script> tag intact: %s", js_path)
+            return match.group(0)
+        js_content = js_path.read_text(encoding="utf-8")
+        # A literal "</script>" inside the source would close the tag early.
+        js_content = js_content.replace("</script>", "<\\/script>")
+        inlined += 1
+        return f"<script>\n{js_content}\n</script>"
+
+    patched = _SCRIPT_SRC_RE.sub(_replace, content)
+    if inlined:
+        html_path.write_text(patched, encoding="utf-8")
+        logger.debug("Inlined %d JS file(s) into %s", inlined, html_path.name)
+    return inlined
+
+
+def inline_local_assets(html_path: Path, base_dir: Path) -> tuple[int, int]:
+    """Inline every locally-hosted CSS and JS asset an HTML report depends on.
+
+    This is the CDN-mode counterpart to Quarto's ``embed-resources``: it makes
+    the HTML self-contained without invoking esbuild, which is unavailable in
+    hardened environments. Remote (CDN) references are deliberately preserved.
+
+    Parameters
+    ----------
+    html_path : Path
+        HTML file to patch in-place.
+    base_dir : Path
+        Directory used to resolve relative references.
+
+    Returns
+    -------
+    tuple[int, int]
+        Number of CSS and JS files inlined, respectively.
+    """
+    return _inline_css(html_path, base_dir), _inline_js(html_path, base_dir)
+
+
+def drop_inlined_resources(html_path: Path) -> bool:
+    """Delete a Quarto ``<stem>_files`` folder once nothing references it.
+
+    Called after :func:`inline_local_assets`. If the HTML still mentions the
+    resources folder — an asset type we do not inline, or a file that failed to
+    resolve — the folder is kept so the report is not broken.
+
+    Parameters
+    ----------
+    html_path : Path
+        The rendered HTML file whose companion resources folder to consider.
+
+    Returns
+    -------
+    bool
+        True if the resources folder was removed.
+    """
+    html_path = Path(html_path)
+    resources_dir = html_path.with_name(f"{html_path.stem}_files")
+    if not (html_path.is_file() and resources_dir.is_dir()):
+        return False
+
+    if resources_dir.name in html_path.read_text(encoding="utf-8"):
+        logger.info(
+            "%s still references %s; keeping the resources folder.",
+            html_path.name,
+            resources_dir.name,
+        )
+        return False
+
+    shutil.rmtree(resources_dir, ignore_errors=True)
+    logger.debug("Removed fully inlined resources folder %s", resources_dir.name)
+    return True
 
 
 def generate_zipped_report(output_filename: str, folder_to_zip: Path):

--- a/python/pdstools/utils/report_utils/_quarto.py
+++ b/python/pdstools/utils/report_utils/_quarto.py
@@ -11,7 +11,7 @@ import traceback
 from pathlib import Path
 
 from ._common import logger
-from ._html import _inline_css
+from ._html import drop_inlined_resources, inline_local_assets
 
 
 def _write_params_files(
@@ -225,8 +225,17 @@ def run_quarto(
     if not full_embed and output_type == "html" and output_filename is not None:
         html_path = temp_dir / output_filename
         if html_path.is_file():
-            n_inlined = _inline_css(html_path, temp_dir)
-            logger.info("Inlined %d CSS stylesheet(s) into %s", n_inlined, output_filename)
+            n_css, n_js = inline_local_assets(html_path, temp_dir)
+            logger.info(
+                "Inlined %d CSS stylesheet(s) and %d script(s) into %s",
+                n_css,
+                n_js,
+                output_filename,
+            )
+            # With every local asset inlined the companion folder is dead weight;
+            # dropping it keeps the report a single distributable HTML file.
+            if drop_inlined_resources(html_path):
+                logger.info("%s is self-contained; dropped its resources folder.", output_filename)
 
     return return_code
 

--- a/python/pdstools/utils/report_utils/_quarto.py
+++ b/python/pdstools/utils/report_utils/_quarto.py
@@ -234,7 +234,8 @@ def run_quarto(
             )
             # With every local asset inlined the companion folder is dead weight;
             # dropping it keeps the report a single distributable HTML file.
-            if drop_inlined_resources(html_path):
+            n_removed = drop_inlined_resources(html_path, Path(qmd_file).stem if qmd_file else "")
+            if n_removed:
                 logger.info("%s is self-contained; dropped its resources folder.", output_filename)
 
     return return_code

--- a/python/tests/healthcheck/test_healthcheck.py
+++ b/python/tests/healthcheck/test_healthcheck.py
@@ -1,6 +1,7 @@
 import pathlib
 import re
 import zipfile
+from html.parser import HTMLParser
 
 import pytest
 from openpyxl import load_workbook
@@ -10,6 +11,54 @@ from pdstools.utils.report_utils import check_report_for_errors
 basePath = pathlib.Path(__file__).parent.parent.parent.parent
 
 PLOTLY_CDN_LOAD_RE = re.compile(r"(?:src=|import\s+)[\"']https://cdn\.plot\.ly/")
+CSS_URL_RE = re.compile(r"url\(\s*([\"']?)([^\"')]+)\1\s*\)", re.IGNORECASE)
+REMOTE_REFERENCE_PREFIXES = ("http://", "https://", "//", "data:", "#", "about:", "javascript:", "mailto:", "tel:")
+
+
+class ResourceReferenceParser(HTMLParser):
+    """Collect live HTML resource references from generated reports."""
+
+    def __init__(self):
+        super().__init__()
+        self.references: list[tuple[str, str, str]] = []
+        self.style_chunks: list[str] = []
+        self._in_style = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "style":
+            self._in_style = True
+        for attr, value in attrs:
+            if attr in {"href", "src"} and value:
+                self.references.append((tag, attr, value))
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "style":
+            self._in_style = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_style:
+            self.style_chunks.append(data)
+
+
+def _is_local_file_reference(reference: str) -> bool:
+    return bool(reference.strip()) and not reference.strip().startswith(REMOTE_REFERENCE_PREFIXES)
+
+
+def _local_file_references(html: str) -> list[str]:
+    parser = ResourceReferenceParser()
+    parser.feed(html)
+    references = [
+        f"{tag}[{attr}]={reference}"
+        for tag, attr, reference in parser.references
+        if _is_local_file_reference(reference)
+    ]
+    references.extend(
+        f"style[url]={reference.strip()}"
+        for style in parser.style_chunks
+        for reference in (match.group(2) for match in CSS_URL_RE.finditer(style))
+        if _is_local_file_reference(reference)
+    )
+    return references
 
 
 def _assert_report_path(actual: pathlib.Path, parent: pathlib.Path, expected_stem: str) -> None:
@@ -87,15 +136,23 @@ def test_GenerateHealthCheck(sample: ADMDatamart, tmp_path):
     assert len(errors) == 0, "HealthCheck report contains errors:\n" + "\n".join(f"  - {e}" for e in errors)
 
 
-def test_GenerateHealthCheck_cdn_returns_single_html(sample: ADMDatamart, tmp_path):
-    """CDN-backed Health Check renders as one HTML file, not a resources zip."""
-    hc = sample.generate.health_check(output_dir=tmp_path, full_embed=False)
+def test_GenerateHealthCheck_default_cdn_is_djs_copy_safe(sample: ADMDatamart, tmp_path, monkeypatch):
+    """Default CDN Health Check can be copied as one standalone HTML file."""
+    monkeypatch.chdir(tmp_path)
+
+    hc = sample.generate.health_check(output_type="html")
 
     assert hc == tmp_path / "HealthCheck.html"
     html = hc.read_text(encoding="utf-8")
     assert PLOTLY_CDN_LOAD_RE.search(html)
     assert "HealthCheck_files/" not in html
     assert not (tmp_path / "HealthCheck.zip").exists()
+
+    upload_dir = tmp_path / "upload"
+    upload_dir.mkdir()
+    copied_html = upload_dir / "HealthCheck.html"
+    copied_html.write_bytes(hc.read_bytes())
+    assert _local_file_references(copied_html.read_text(encoding="utf-8")) == []
 
 
 def test_GenerateHealthCheck_named_cdn_drops_qmd_resources(sample: ADMDatamart, tmp_path):

--- a/python/tests/healthcheck/test_healthcheck.py
+++ b/python/tests/healthcheck/test_healthcheck.py
@@ -87,6 +87,33 @@ def test_GenerateHealthCheck(sample: ADMDatamart, tmp_path):
     assert len(errors) == 0, "HealthCheck report contains errors:\n" + "\n".join(f"  - {e}" for e in errors)
 
 
+def test_GenerateHealthCheck_cdn_returns_single_html(sample: ADMDatamart, tmp_path):
+    """CDN-backed Health Check renders as one HTML file, not a resources zip."""
+    hc = sample.generate.health_check(output_dir=tmp_path, full_embed=False)
+
+    assert hc == tmp_path / "HealthCheck.html"
+    html = hc.read_text(encoding="utf-8")
+    assert PLOTLY_CDN_LOAD_RE.search(html)
+    assert "HealthCheck_files/" not in html
+    assert not (tmp_path / "HealthCheck.zip").exists()
+
+
+def test_GenerateHealthCheck_named_cdn_drops_qmd_resources(sample: ADMDatamart, tmp_path):
+    """CDN cleanup removes the QMD-stem resources folder for named outputs."""
+    hc = sample.generate.health_check(
+        output_dir=tmp_path,
+        name="cdn_named",
+        full_embed=False,
+        keep_temp_files=True,
+    )
+
+    assert hc == tmp_path / "HealthCheck_cdn_named.html"
+    temp_dirs = list(tmp_path.glob("tmp_cdn_named_*"))
+    assert len(temp_dirs) == 1
+    assert not (temp_dirs[0] / "HealthCheck_files").exists()
+    assert "HealthCheck_files/" not in (temp_dirs[0] / "HealthCheck_cdn_named.html").read_text(encoding="utf-8")
+
+
 def test_GenerateHealthCheck_custom_categorization_with_unmatched_predictors(sample: ADMDatamart, tmp_path):
     sample.apply_predictor_categorization({"External Model": "Propensity"})
 

--- a/python/tests/utils/test_report_utils.py
+++ b/python/tests/utils/test_report_utils.py
@@ -1421,7 +1421,19 @@ class TestDropInlinedResources:
 
         report_utils.inline_local_assets(html_file, tmp_path)
 
-        assert report_utils.drop_inlined_resources(html_file) is True
+        assert report_utils.drop_inlined_resources(html_file) == 1
+        assert not resources.exists()
+
+    def test_removes_qmd_stem_folder_when_output_stem_differs(self, tmp_path):
+        html_file = tmp_path / "HealthCheck_customer.html"
+        resources = tmp_path / "HealthCheck_files"
+        resources.mkdir()
+        (resources / "quarto.js").write_text("var q = 1;", encoding="utf-8")
+        html_file.write_text('<script src="HealthCheck_files/quarto.js"></script>', encoding="utf-8")
+
+        report_utils.inline_local_assets(html_file, tmp_path)
+
+        assert report_utils.drop_inlined_resources(html_file, "HealthCheck") == 1
         assert not resources.exists()
 
     def test_keeps_folder_when_still_referenced(self, tmp_path):
@@ -1431,15 +1443,15 @@ class TestDropInlinedResources:
         (resources / "fig.png").write_bytes(b"png")
         html_file.write_text('<img src="report_files/fig.png">', encoding="utf-8")
 
-        assert report_utils.drop_inlined_resources(html_file) is False
+        assert report_utils.drop_inlined_resources(html_file) == 0
         assert resources.exists()
 
     def test_no_resources_folder_is_noop(self, tmp_path):
         html_file = tmp_path / "solo.html"
         html_file.write_text("<html></html>", encoding="utf-8")
 
-        assert report_utils.drop_inlined_resources(html_file) is False
+        assert report_utils.drop_inlined_resources(html_file) == 0
 
     def test_missing_html_is_noop(self, tmp_path):
         (tmp_path / "ghost_files").mkdir()
-        assert report_utils.drop_inlined_resources(tmp_path / "ghost.html") is False
+        assert report_utils.drop_inlined_resources(tmp_path / "ghost.html") == 0

--- a/python/tests/utils/test_report_utils.py
+++ b/python/tests/utils/test_report_utils.py
@@ -469,6 +469,56 @@ def test_run_quarto_sets_plotly_renderer_env(tmp_path, monkeypatch):
     assert captured_renderers == ["notebook", "notebook_connected"]
 
 
+def test_run_quarto_inlines_and_drops_cdn_html_resources(tmp_path, monkeypatch):
+    """CDN HTML post-processing inlines local assets before resource cleanup."""
+
+    class FakeStdout:
+        def readline(self):
+            return ""
+
+    class FakeProcess:
+        stdout = FakeStdout()
+
+        def wait(self):
+            return 0
+
+    html_path = tmp_path / "HealthCheck_customer.html"
+    html_path.write_text("<html></html>", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(
+        report_utils._quarto,
+        "get_quarto_with_version",
+        lambda: ("quarto", "1.4.0"),
+    )
+    monkeypatch.setattr(report_utils._quarto.subprocess, "Popen", lambda *_args, **_kwargs: FakeProcess())
+    monkeypatch.setattr(
+        report_utils._quarto,
+        "inline_local_assets",
+        lambda path, base_dir: calls.append(("inline", path, base_dir)) or (2, 3),
+    )
+    monkeypatch.setattr(
+        report_utils._quarto,
+        "drop_inlined_resources",
+        lambda path, stem: calls.append(("drop", path, stem)) or 1,
+    )
+
+    assert (
+        report_utils.run_quarto(
+            qmd_file="HealthCheck.qmd",
+            output_filename="HealthCheck_customer.html",
+            output_type="html",
+            temp_dir=tmp_path,
+            full_embed=False,
+        )
+        == 0
+    )
+    assert calls == [
+        ("inline", html_path, tmp_path),
+        ("drop", html_path, "HealthCheck"),
+    ]
+
+
 def test_create_metric_gttable_callable_rag_with_metric_format():
     """Test that columns with callable RAG functions still get formatting from MetricFormats.
 
@@ -1362,14 +1412,14 @@ class TestInlineJs:
         (tmp_path / "module.js").write_text("window.moduleLoaded = true;", encoding="utf-8")
         html_file = tmp_path / "report.html"
         html_file.write_text(
-            '<script type="module" src="module.js" data-owner="quarto" crossorigin="anonymous"></script>',
+            '<script type="module" src="module.js" data-owner="quarto" crossorigin="anonymous" defer></script>',
             encoding="utf-8",
         )
 
         assert report_utils._inline_js(html_file, tmp_path) == 1
 
         result = html_file.read_text(encoding="utf-8")
-        assert '<script type="module" data-owner="quarto">' in result
+        assert '<script type="module" data-owner="quarto" defer>' in result
         assert "window.moduleLoaded = true;" in result
         assert "src=" not in result
         assert "crossorigin=" not in result
@@ -1399,6 +1449,55 @@ class TestInlineJs:
         assert "function init() { window.tabsLoaded = true; }" in result
         assert "return {init};" in result
         assert "tabsets.init();" in result
+
+    def test_inlined_module_script_handles_export_lists(self, tmp_path):
+        modules = tmp_path / "libs"
+        modules.mkdir()
+        (modules / "helpers.js").write_text(
+            "const raw = 1;\nconst direct = 2;\nexport { raw as exposed, direct };",
+            encoding="utf-8",
+        )
+        (modules / "main.js").write_text(
+            'import * as helpers from "./helpers.js";\nwindow.answer = helpers.exposed + helpers.direct;',
+            encoding="utf-8",
+        )
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<script type="module" src="libs/main.js"></script>', encoding="utf-8")
+
+        assert report_utils._inline_js(html_file, tmp_path) == 1
+
+        result = html_file.read_text(encoding="utf-8")
+        assert "export {" not in result
+        assert "return {exposed: raw, direct};" in result
+        assert "window.answer = helpers.exposed + helpers.direct;" in result
+
+    def test_inlined_module_script_leaves_remote_imports(self, tmp_path):
+        (tmp_path / "main.js").write_text(
+            'import * as remote from "https://cdn.example.com/remote.js";\nremote.init();',
+            encoding="utf-8",
+        )
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<script type="module" src="main.js"></script>', encoding="utf-8")
+
+        assert report_utils._inline_js(html_file, tmp_path) == 1
+        assert 'import * as remote from "https://cdn.example.com/remote.js";' in html_file.read_text(encoding="utf-8")
+
+    def test_inlined_module_script_leaves_missing_local_imports(self, tmp_path, caplog):
+        import logging
+
+        (tmp_path / "main.js").write_text(
+            'import * as missing from "./missing.js";\nmissing.init();',
+            encoding="utf-8",
+        )
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<script type="module" src="main.js"></script>', encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            assert report_utils._inline_js(html_file, tmp_path) == 1
+
+        result = html_file.read_text(encoding="utf-8")
+        assert 'import * as missing from "./missing.js";' in result
+        assert "missing.js" in caplog.text
 
 
 class TestInlineCssUrls:

--- a/python/tests/utils/test_report_utils.py
+++ b/python/tests/utils/test_report_utils.py
@@ -1270,3 +1270,176 @@ class TestInlineCss:
         result = html_file.read_text(encoding="utf-8")
         assert n == 1
         assert css in result
+
+
+# ---------------------------------------------------------------------------
+# _inline_js / inline_local_assets / drop_inlined_resources tests
+# ---------------------------------------------------------------------------
+
+
+class TestInlineJs:
+    def test_relative_script_is_inlined(self, tmp_path):
+        js = "console.log('hi');"
+        (tmp_path / "app.js").write_text(js, encoding="utf-8")
+
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<html><body><script src="app.js"></script></body></html>', encoding="utf-8")
+
+        n = report_utils._inline_js(html_file, tmp_path)
+
+        result = html_file.read_text(encoding="utf-8")
+        assert n == 1
+        assert js in result
+        assert 'src="app.js"' not in result
+
+    def test_absolute_url_is_left_alone(self, tmp_path):
+        html = '<html><body><script src="https://cdn.plot.ly/plotly.min.js"></script></body></html>'
+        html_file = tmp_path / "report.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        n = report_utils._inline_js(html_file, tmp_path)
+
+        assert n == 0
+        assert html_file.read_text(encoding="utf-8") == html
+
+    def test_protocol_relative_url_is_left_alone(self, tmp_path):
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<script src="//cdn.example.com/a.js"></script>', encoding="utf-8")
+
+        assert report_utils._inline_js(html_file, tmp_path) == 0
+
+    def test_closing_script_tag_in_source_is_escaped(self, tmp_path):
+        (tmp_path / "tricky.js").write_text('var s = "</script>";', encoding="utf-8")
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<script src="tricky.js"></script>', encoding="utf-8")
+
+        report_utils._inline_js(html_file, tmp_path)
+
+        result = html_file.read_text(encoding="utf-8")
+        assert "<\\/script>" in result
+        assert result.count("</script>") == 1
+
+    def test_missing_file_logs_warning_and_leaves_tag(self, tmp_path, caplog):
+        import logging
+
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<script src="missing.js"></script>', encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            n = report_utils._inline_js(html_file, tmp_path)
+
+        assert n == 0
+        assert 'src="missing.js"' in html_file.read_text(encoding="utf-8")
+        assert "missing.js" in caplog.text
+
+    def test_subdirectory_src_resolved(self, tmp_path):
+        libs = tmp_path / "report_files" / "libs"
+        libs.mkdir(parents=True)
+        (libs / "quarto.js").write_text("window.q = 1;", encoding="utf-8")
+
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<script src="report_files/libs/quarto.js"></script>', encoding="utf-8")
+
+        assert report_utils._inline_js(html_file, tmp_path) == 1
+        assert "window.q = 1;" in html_file.read_text(encoding="utf-8")
+
+
+class TestInlineCssUrls:
+    """Assets referenced from within an inlined stylesheet become data URIs."""
+
+    def test_relative_font_is_embedded(self, tmp_path):
+        libs = tmp_path / "report_files" / "libs"
+        libs.mkdir(parents=True)
+        (libs / "font.woff").write_bytes(b"\x00font-bytes")
+        (libs / "icons.css").write_text('@font-face { src: url("./font.woff"); }', encoding="utf-8")
+
+        html_file = tmp_path / "report.html"
+        html_file.write_text(
+            '<link rel="stylesheet" href="report_files/libs/icons.css">',
+            encoding="utf-8",
+        )
+
+        assert report_utils._inline_css(html_file, tmp_path) == 1
+
+        result = html_file.read_text(encoding="utf-8")
+        assert 'url("data:font/woff;base64,' in result
+        assert "./font.woff" not in result
+
+    def test_query_string_and_fragment_are_stripped_when_resolving(self, tmp_path):
+        (tmp_path / "font.woff").write_bytes(b"bytes")
+        (tmp_path / "icons.css").write_text(
+            "@font-face { src: url(font.woff?v=2#iefix); }",
+            encoding="utf-8",
+        )
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<link rel="stylesheet" href="icons.css">', encoding="utf-8")
+
+        report_utils._inline_css(html_file, tmp_path)
+
+        assert "data:font/woff;base64," in html_file.read_text(encoding="utf-8")
+
+    def test_remote_and_unresolvable_urls_are_left_alone(self, tmp_path):
+        (tmp_path / "a.css").write_text(
+            "a { background: url(https://cdn.example.com/x.png); } b { background: url(gone.png); }",
+            encoding="utf-8",
+        )
+        html_file = tmp_path / "report.html"
+        html_file.write_text('<link rel="stylesheet" href="a.css">', encoding="utf-8")
+
+        report_utils._inline_css(html_file, tmp_path)
+
+        result = html_file.read_text(encoding="utf-8")
+        assert "url(https://cdn.example.com/x.png)" in result
+        assert "url(gone.png)" in result
+
+
+class TestInlineLocalAssets:
+    def test_inlines_css_and_js_and_reports_counts(self, tmp_path):
+        (tmp_path / "a.css").write_text("body { color: red; }", encoding="utf-8")
+        (tmp_path / "a.js").write_text("var a = 1;", encoding="utf-8")
+
+        html_file = tmp_path / "report.html"
+        html_file.write_text(
+            '<link rel="stylesheet" href="a.css"><script src="a.js"></script>',
+            encoding="utf-8",
+        )
+
+        assert report_utils.inline_local_assets(html_file, tmp_path) == (1, 1)
+
+        result = html_file.read_text(encoding="utf-8")
+        assert "body { color: red; }" in result
+        assert "var a = 1;" in result
+
+
+class TestDropInlinedResources:
+    def test_removes_folder_once_unreferenced(self, tmp_path):
+        html_file = tmp_path / "report.html"
+        resources = tmp_path / "report_files"
+        resources.mkdir()
+        (resources / "quarto.js").write_text("var q = 1;", encoding="utf-8")
+        html_file.write_text('<script src="report_files/quarto.js"></script>', encoding="utf-8")
+
+        report_utils.inline_local_assets(html_file, tmp_path)
+
+        assert report_utils.drop_inlined_resources(html_file) is True
+        assert not resources.exists()
+
+    def test_keeps_folder_when_still_referenced(self, tmp_path):
+        html_file = tmp_path / "report.html"
+        resources = tmp_path / "report_files"
+        resources.mkdir()
+        (resources / "fig.png").write_bytes(b"png")
+        html_file.write_text('<img src="report_files/fig.png">', encoding="utf-8")
+
+        assert report_utils.drop_inlined_resources(html_file) is False
+        assert resources.exists()
+
+    def test_no_resources_folder_is_noop(self, tmp_path):
+        html_file = tmp_path / "solo.html"
+        html_file.write_text("<html></html>", encoding="utf-8")
+
+        assert report_utils.drop_inlined_resources(html_file) is False
+
+    def test_missing_html_is_noop(self, tmp_path):
+        (tmp_path / "ghost_files").mkdir()
+        assert report_utils.drop_inlined_resources(tmp_path / "ghost.html") is False

--- a/python/tests/utils/test_report_utils.py
+++ b/python/tests/utils/test_report_utils.py
@@ -1188,7 +1188,7 @@ class TestInlineCss:
         result = html_file.read_text(encoding="utf-8")
         assert n == 1
         assert css in result
-        assert "<style>" in result
+        assert "<style" in result
         assert 'href="style.css"' not in result
 
     def test_href_before_rel_is_inlined(self, tmp_path):
@@ -1204,7 +1204,7 @@ class TestInlineCss:
         result = html_file.read_text(encoding="utf-8")
         assert n == 1
         assert css in result
-        assert "<style>" in result
+        assert "<style" in result
 
     def test_absolute_url_is_left_alone(self, tmp_path):
         html = '<html><head><link rel="stylesheet" href="https://cdn.example.com/bootstrap.css"></head></html>'
@@ -1270,6 +1270,21 @@ class TestInlineCss:
         result = html_file.read_text(encoding="utf-8")
         assert n == 1
         assert css in result
+
+    def test_inlined_style_preserves_safe_attributes(self, tmp_path):
+        (tmp_path / "print.css").write_text("body { color: black; }", encoding="utf-8")
+        html_file = tmp_path / "report.html"
+        html_file.write_text(
+            '<link rel="stylesheet" href="print.css" media="print" nonce="abc" data-owner="quarto">',
+            encoding="utf-8",
+        )
+
+        assert report_utils._inline_css(html_file, tmp_path) == 1
+
+        result = html_file.read_text(encoding="utf-8")
+        assert '<style media="print" nonce="abc" data-owner="quarto">' in result
+        assert "href=" not in result
+        assert "rel=" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -1342,6 +1357,48 @@ class TestInlineJs:
 
         assert report_utils._inline_js(html_file, tmp_path) == 1
         assert "window.q = 1;" in html_file.read_text(encoding="utf-8")
+
+    def test_inlined_script_preserves_non_resource_attributes(self, tmp_path):
+        (tmp_path / "module.js").write_text("window.moduleLoaded = true;", encoding="utf-8")
+        html_file = tmp_path / "report.html"
+        html_file.write_text(
+            '<script type="module" src="module.js" data-owner="quarto" crossorigin="anonymous"></script>',
+            encoding="utf-8",
+        )
+
+        assert report_utils._inline_js(html_file, tmp_path) == 1
+
+        result = html_file.read_text(encoding="utf-8")
+        assert '<script type="module" data-owner="quarto">' in result
+        assert "window.moduleLoaded = true;" in result
+        assert "src=" not in result
+        assert "crossorigin=" not in result
+
+    def test_inlined_module_script_folds_local_namespace_imports(self, tmp_path):
+        modules = tmp_path / "libs" / "quarto-html"
+        (modules / "tabsets").mkdir(parents=True)
+        (modules / "tabsets" / "tabsets.js").write_text(
+            "export function init() { window.tabsLoaded = true; }",
+            encoding="utf-8",
+        )
+        (modules / "quarto.js").write_text(
+            'import * as tabsets from "./tabsets/tabsets.js";\ntabsets.init();',
+            encoding="utf-8",
+        )
+        html_file = tmp_path / "report.html"
+        html_file.write_text(
+            '<script type="module" src="libs/quarto-html/quarto.js"></script>',
+            encoding="utf-8",
+        )
+
+        assert report_utils._inline_js(html_file, tmp_path) == 1
+
+        result = html_file.read_text(encoding="utf-8")
+        assert "import * as tabsets" not in result
+        assert "const tabsets = (() =>" in result
+        assert "function init() { window.tabsLoaded = true; }" in result
+        assert "return {init};" in result
+        assert "tabsets.init();" in result
 
 
 class TestInlineCssUrls:


### PR DESCRIPTION
CDN-mode HTML reports (full_embed=False) were emitted as a zip rather than an HTML file. Quarto leaves its local JavaScript in a companion <basename>_files/ folder, and bundle_quarto_resources wraps the pair into <basename>.zip so they travel together. Health Check therefore returned HealthCheck.zip, and callers expecting an HTML file broke.

#679 already established the fix for the CSS half of this problem; it just stopped short of JavaScript. Extend the same approach:

- _inline_css now rewrites relative url(...) references inside the CSS it inlines into data URIs. Lifting CSS text into a <style> block breaks those paths, which orphaned the bootstrap-icons font.
- _inline_js gives local <script src> tags the same treatment. A literal "</script>" in the source is escaped so it cannot close the tag early. Remote references are deliberately preserved, so Plotly and MathJax keep loading from their CDNs.
- inline_local_assets composes the two, and drop_inlined_resources removes the companion folder once nothing references it. Reports that reference an asset type we do not inline (model reports embed figure-html PNGs) keep their folder, so the zip fallback still applies and bundle_quarto_resources is unchanged.

This matters beyond the extension: full_embed=True is the only other route to a standalone report, and it needs esbuild, which hardened images strip for CVE reasons. Inlining gets there without it.

Verified end to end against cdh_sample: health_check() now returns a single 1.8MB HealthCheck.html with no companion folder, all 23 Plotly figures render, and bootstrap/tippy/anchor/clipboard all initialise.