### PR TITLE
Proving Otto Wrong Again

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -18,6 +18,7 @@ from ..pega_io.File import read_dataflow_output, read_ds_export
 from ..utils import cdh_utils
 from ..utils.cdh_utils import _polars_capitalize
 from ..utils.cdh_utils._io import _DATABRICKS_MODEL_SNAPSHOTS_COLUMNS
+from ..utils.cdh_utils._metrics import _auc_ci_from_binned_rows
 from . import Schema
 from .Aggregates import Aggregates
 from .Analysis import Analysis
@@ -1172,63 +1173,7 @@ class ADMDatamart:
             - idx_max - The maximum bin index that can be reached given the current binning of all predictors
 
         """
-        import numpy as np
-
         cdh_utils.validate_confidence_level(confidence_level)
-
-        def find_binindex(bounds, score):
-            if score is None:
-                return None
-            bounds = [bound for bound in bounds if bound is not None]
-            if not bounds:
-                return None
-            if len(bounds) == 1:
-                return 0
-            # Polars has search_sorted but it seems it doesn't do
-            # the exact same thing as numpy searchsorted. We could
-            # also use python's native bisect but that seems slower.
-            return min(
-                max(1, np.searchsorted(bounds, score, side="right").item()),
-                len(bounds),
-            )
-
-        def auc_from_active_bins(pos, neg, idx_min, idx_max):
-            if idx_min is None or idx_max is None:
-                return None
-            active_pos = pos[idx_min:idx_max]
-            active_neg = neg[idx_min:idx_max]
-            if not active_pos or not active_neg:
-                return None
-            return cdh_utils.auc_from_bincounts(
-                active_pos,
-                active_neg,
-            )
-
-        def auc_ci_payload_field(pos, neg, idx_min, idx_max, field):
-            if idx_min is None or idx_max is None:
-                return {
-                    "variance": None,
-                    "ci_lower": None,
-                    "ci_upper": None,
-                    "ci_available": False,
-                    "ci_reason": "missing_score_range",
-                }[field]
-            active_pos = pos[idx_min:idx_max]
-            active_neg = neg[idx_min:idx_max]
-            if not active_pos or not active_neg:
-                return {
-                    "variance": None,
-                    "ci_lower": None,
-                    "ci_upper": None,
-                    "ci_available": False,
-                    "ci_reason": "empty_active_range",
-                }[field]
-            payload = cdh_utils.auc_ci_from_bincounts(
-                active_pos,
-                active_neg,
-                confidence_level=confidence_level,
-            )
-            return payload[field]
 
         if isinstance(model_ids, str):
             query = pl.col("ModelID") == model_ids
@@ -1254,169 +1199,143 @@ class ADMDatamart:
             allow_empty=True,
         )
 
-        classifier_info = (
+        scores = self._minMaxScoresPerModel(most_recent_binning_data)
+        classifier_bins = (
             most_recent_binning_data.filter(EntryType="Classifier")
-            .sort("BinIndex")
-            .group_by("ModelID", maintain_order=True)
-            .agg(
-                AUC_Datamart=pl.col("Performance").first(),
-                Bins=pl.len(),
-                classifierBounds=pl.col("BinLowerBound").cast(pl.Float64),
-                classifierPos=pl.col("BinPositives").cast(pl.Float64),
-                classifierNeg=pl.col("BinNegatives").cast(pl.Float64),
+            .select(
+                "ModelID",
+                "BinIndex",
+                AUC_Datamart=pl.col("Performance"),
+                _ClassifierBound=pl.col("BinLowerBound").cast(pl.Float64),
+                _ClassifierPositive=pl.col("BinPositives").cast(pl.Float64),
+                _ClassifierNegative=pl.col("BinNegatives").cast(pl.Float64),
+            )
+            .sort("ModelID", "BinIndex")
+            .join(scores, on="ModelID", how="left")
+            .with_columns(
+                Bins=pl.len().over("ModelID"),
+                _ValidBounds=pl.col("_ClassifierBound").is_not_null().sum().over("ModelID"),
+                _BinPosition=(pl.col("BinIndex").rank(method="ordinal").over("ModelID") - 1),
+                _MinInsertion=(
+                    pl.col("_ClassifierBound").is_not_null() & (pl.col("_ClassifierBound") <= pl.col("score_min"))
+                )
+                .sum()
+                .over("ModelID"),
+                _MaxInsertion=(
+                    pl.col("_ClassifierBound").is_not_null() & (pl.col("_ClassifierBound") <= pl.col("score_max"))
+                )
+                .sum()
+                .over("ModelID"),
+            )
+            .with_columns(
+                idx_min=pl.when(
+                    pl.col("score_min").is_null() | (pl.col("_ValidBounds") == 0),
+                )
+                .then(None)
+                .when(pl.col("_ValidBounds") == 1)
+                .then(-1)
+                .otherwise(
+                    pl.max_horizontal(
+                        1,
+                        pl.min_horizontal(
+                            "_MinInsertion",
+                            "_ValidBounds",
+                        ),
+                    )
+                    - 1,
+                )
+                .cast(pl.Int32),
+                idx_max=pl.when(
+                    pl.col("score_max").is_null() | (pl.col("_ValidBounds") == 0),
+                )
+                .then(None)
+                .when(pl.col("_ValidBounds") == 1)
+                .then(0)
+                .otherwise(
+                    pl.max_horizontal(
+                        1,
+                        pl.min_horizontal(
+                            "_MaxInsertion",
+                            "_ValidBounds",
+                        ),
+                    ),
+                )
+                .cast(pl.Int32),
             )
         )
 
-        scores = self._minMaxScoresPerModel(most_recent_binning_data)
+        classifier_info = classifier_bins.group_by("ModelID").agg(
+            AUC_Datamart=pl.col("AUC_Datamart").first(),
+            Bins=pl.col("Bins").first(),
+            nActivePredictors=pl.col("nActivePredictors").first(),
+            classifierLogOffset=pl.col("classifierLogOffset").first(),
+            sumMinLogOdds=pl.col("sumMinLogOdds").first(),
+            sumMaxLogOdds=pl.col("sumMaxLogOdds").first(),
+            score_min=pl.col("score_min").first(),
+            score_max=pl.col("score_max").first(),
+            idx_min=pl.col("idx_min").first(),
+            idx_max=pl.col("idx_max").first(),
+        )
+
+        full_range_auc = _auc_ci_from_binned_rows(
+            classifier_bins,
+            group_col="ModelID",
+            positive_col="_ClassifierPositive",
+            negative_col="_ClassifierNegative",
+            confidence_level=confidence_level,
+        ).select(
+            "ModelID",
+            AUC_FullRange=pl.col("AUC"),
+        )
+        active_range_auc = _auc_ci_from_binned_rows(
+            classifier_bins.filter(
+                (pl.col("_BinPosition") >= pl.col("idx_min")) & (pl.col("_BinPosition") < pl.col("idx_max")),
+            ),
+            group_col="ModelID",
+            positive_col="_ClassifierPositive",
+            negative_col="_ClassifierNegative",
+            confidence_level=confidence_level,
+        ).select(
+            "ModelID",
+            AUC_ActiveRange=pl.col("AUC"),
+            AUC_ActiveRange_CI_Variance=pl.col("AUC_CI_Variance"),
+            AUC_ActiveRange_CI_Lower=pl.col("AUC_CI_Lower"),
+            AUC_ActiveRange_CI_Upper=pl.col("AUC_CI_Upper"),
+            _ActivePositiveCount=pl.col("_PositiveCount"),
+            _ActiveNegativeCount=pl.col("_NegativeCount"),
+        )
 
         return (
-            classifier_info.join(scores, on="ModelID", how="left")
-            .with_columns(
-                AUC_FullRange=pl.map_groups(
-                    exprs=[
-                        pl.col("classifierPos").explode(empty_as_null=True),
-                        pl.col("classifierNeg").explode(empty_as_null=True),
-                    ],
-                    function=lambda data: cdh_utils.auc_from_bincounts(
-                        data[0],
-                        data[1],
-                    ),
-                    return_dtype=pl.Float64,
-                    returns_scalar=True,
-                ).over("ModelID"),
-                idx_min=(
-                    pl.map_groups(
-                        exprs=[
-                            pl.col("classifierBounds"),
-                            pl.col("score_min"),
-                        ],
-                        function=lambda data: find_binindex(
-                            data[0].to_list()[0],
-                            data[1].item(),
-                        ),
-                        return_dtype=pl.Int32,
-                        returns_scalar=True,
-                    )
-                    - 1
-                ).over("ModelID"),
-                idx_max=pl.map_groups(
-                    exprs=[
-                        pl.col("classifierBounds"),
-                        pl.col("score_max"),
-                    ],
-                    function=lambda data: find_binindex(
-                        data[0].to_list()[0],
-                        data[1].item(),
-                    ),
-                    return_dtype=pl.Int32,
-                    returns_scalar=True,
-                ).over("ModelID"),
+            classifier_info.join(
+                full_range_auc,
+                on="ModelID",
+                how="left",
+            )
+            .join(
+                active_range_auc,
+                on="ModelID",
+                how="left",
             )
             .with_columns(
-                AUC_ActiveRange=pl.map_groups(
-                    exprs=[
-                        pl.col("classifierPos"),
-                        pl.col("classifierNeg"),
-                        pl.col("idx_min"),
-                        pl.col("idx_max"),
-                    ],
-                    function=lambda data: auc_from_active_bins(
-                        data[0].to_list()[0],
-                        data[1].to_list()[0],
-                        data[2].item(),
-                        data[3].item(),
-                    ),
-                    return_dtype=pl.Float64,
-                    returns_scalar=True,
-                ).over("ModelID"),
-                AUC_ActiveRange_CI_Lower=pl.map_groups(
-                    exprs=[
-                        pl.col("classifierPos"),
-                        pl.col("classifierNeg"),
-                        pl.col("idx_min"),
-                        pl.col("idx_max"),
-                    ],
-                    function=lambda data: auc_ci_payload_field(
-                        data[0].to_list()[0],
-                        data[1].to_list()[0],
-                        data[2].item(),
-                        data[3].item(),
-                        "ci_lower",
-                    ),
-                    return_dtype=pl.Float64,
-                    returns_scalar=True,
-                ).over("ModelID"),
-                AUC_ActiveRange_CI_Variance=pl.map_groups(
-                    exprs=[
-                        pl.col("classifierPos"),
-                        pl.col("classifierNeg"),
-                        pl.col("idx_min"),
-                        pl.col("idx_max"),
-                    ],
-                    function=lambda data: auc_ci_payload_field(
-                        data[0].to_list()[0],
-                        data[1].to_list()[0],
-                        data[2].item(),
-                        data[3].item(),
-                        "variance",
-                    ),
-                    return_dtype=pl.Float64,
-                    returns_scalar=True,
-                ).over("ModelID"),
-                AUC_ActiveRange_CI_Upper=pl.map_groups(
-                    exprs=[
-                        pl.col("classifierPos"),
-                        pl.col("classifierNeg"),
-                        pl.col("idx_min"),
-                        pl.col("idx_max"),
-                    ],
-                    function=lambda data: auc_ci_payload_field(
-                        data[0].to_list()[0],
-                        data[1].to_list()[0],
-                        data[2].item(),
-                        data[3].item(),
-                        "ci_upper",
-                    ),
-                    return_dtype=pl.Float64,
-                    returns_scalar=True,
-                ).over("ModelID"),
-                AUC_ActiveRange_CI_Available=pl.map_groups(
-                    exprs=[
-                        pl.col("classifierPos"),
-                        pl.col("classifierNeg"),
-                        pl.col("idx_min"),
-                        pl.col("idx_max"),
-                    ],
-                    function=lambda data: auc_ci_payload_field(
-                        data[0].to_list()[0],
-                        data[1].to_list()[0],
-                        data[2].item(),
-                        data[3].item(),
-                        "ci_available",
-                    ),
-                    return_dtype=pl.Boolean,
-                    returns_scalar=True,
-                ).over("ModelID"),
-                AUC_ActiveRange_CI_Reason=pl.map_groups(
-                    exprs=[
-                        pl.col("classifierPos"),
-                        pl.col("classifierNeg"),
-                        pl.col("idx_min"),
-                        pl.col("idx_max"),
-                    ],
-                    function=lambda data: auc_ci_payload_field(
-                        data[0].to_list()[0],
-                        data[1].to_list()[0],
-                        data[2].item(),
-                        data[3].item(),
-                        "ci_reason",
-                    ),
-                    return_dtype=pl.Utf8,
-                    returns_scalar=True,
-                ).over("ModelID"),
+                AUC_ActiveRange_CI_Available=pl.col(
+                    "AUC_ActiveRange_CI_Variance",
+                ).is_not_null(),
+                AUC_ActiveRange_CI_Reason=pl.when(
+                    pl.col("idx_min").is_null() | pl.col("idx_max").is_null(),
+                )
+                .then(pl.lit("missing_score_range"))
+                .when(pl.col("AUC_ActiveRange").is_null())
+                .then(pl.lit("empty_active_range"))
+                .when(
+                    (pl.col("_ActivePositiveCount") <= 1) | (pl.col("_ActiveNegativeCount") <= 1),
+                )
+                .then(pl.lit("insufficient_class_volume"))
+                .when(pl.col("AUC_ActiveRange_CI_Variance").is_null())
+                .then(pl.lit("variance_unavailable"))
+                .otherwise(None),
             )
             .sort("ModelID")
-            .drop("classifierBounds", "classifierPos", "classifierNeg")
+            .drop("_ActivePositiveCount", "_ActiveNegativeCount")
             .select(cs.starts_with("AUC"), ~cs.starts_with("AUC"))
             .select("ModelID", ~cs.starts_with("ModelID"))
         )

--- a/python/pdstools/utils/cdh_utils/_metrics.py
+++ b/python/pdstools/utils/cdh_utils/_metrics.py
@@ -37,6 +37,130 @@ def validate_confidence_level(confidence_level: float) -> float:
     return confidence_level
 
 
+def _auc_ci_from_binned_rows(
+    data: pl.LazyFrame,
+    *,
+    group_col: str,
+    positive_col: str,
+    negative_col: str,
+    confidence_level: float,
+) -> pl.LazyFrame:
+    """Calculate grouped-bin AUC confidence intervals with Polars expressions.
+
+    Parameters
+    ----------
+    data : pl.LazyFrame
+        Long-form bin data with one row per score bin.
+    group_col : str
+        Column identifying the independently evaluated groups.
+    positive_col : str
+        Column containing positive response counts.
+    negative_col : str
+        Column containing negative response counts.
+    confidence_level : float
+        Two-sided confidence level used to derive the interval.
+
+    Returns
+    -------
+    pl.LazyFrame
+        One row per group with AUC, variance, confidence bounds, and class
+        counts.
+    """
+    validate_confidence_level(confidence_level)
+    z_score = NormalDist().inv_cdf(0.5 + confidence_level / 2.0)
+
+    sorted_bins = (
+        data.select(
+            pl.col(group_col),
+            pl.col(positive_col).cast(pl.Float64).alias("_Positive"),
+            pl.col(negative_col).cast(pl.Float64).alias("_Negative"),
+        )
+        .with_row_index("_BinOrder")
+        .with_columns(
+            _PositiveCount=pl.col("_Positive").sum().over(group_col),
+            _NegativeCount=pl.col("_Negative").sum().over(group_col),
+            _Probability=(pl.col("_Positive") / (pl.col("_Positive") + pl.col("_Negative")))
+            .fill_nan(0.0)
+            .fill_null(0.0),
+        )
+        .sort(
+            group_col,
+            "_Probability",
+            "_BinOrder",
+            descending=[False, True, True],
+        )
+        .with_columns(
+            _CumulativePositive=pl.col("_Positive").cum_sum().over(group_col),
+            _CumulativeNegative=pl.col("_Negative").cum_sum().over(group_col),
+        )
+        .with_columns(
+            _AUCArea=(
+                (pl.col("_Negative") / pl.col("_NegativeCount"))
+                * ((2.0 * pl.col("_CumulativePositive") - pl.col("_Positive")) / (2.0 * pl.col("_PositiveCount")))
+            ),
+            _V10=(
+                (pl.col("_CumulativeNegative") - pl.col("_Negative") + 0.5 * pl.col("_Negative"))
+                / pl.col("_NegativeCount")
+            ),
+            _V01=(
+                (pl.col("_CumulativePositive") - pl.col("_Positive") + 0.5 * pl.col("_Positive"))
+                / pl.col("_PositiveCount")
+            ),
+        )
+        .with_columns(
+            _MeanV10=(pl.col("_V10") * pl.col("_Positive")).sum().over(group_col) / pl.col("_PositiveCount"),
+            _MeanV01=(pl.col("_V01") * pl.col("_Negative")).sum().over(group_col) / pl.col("_NegativeCount"),
+        )
+    )
+
+    grouped = sorted_bins.group_by(group_col).agg(
+        _PositiveCount=pl.col("_PositiveCount").first(),
+        _NegativeCount=pl.col("_NegativeCount").first(),
+        _RawAUC=pl.col("_AUCArea").sum(),
+        _VarianceV10=(
+            ((pl.col("_V10") - pl.col("_MeanV10")).pow(2) * pl.col("_Positive")).sum()
+            / (pl.col("_PositiveCount").first() - 1.0)
+        ),
+        _VarianceV01=(
+            ((pl.col("_V01") - pl.col("_MeanV01")).pow(2) * pl.col("_Negative")).sum()
+            / (pl.col("_NegativeCount").first() - 1.0)
+        ),
+    )
+
+    return (
+        grouped.with_columns(
+            AUC=pl.when(
+                (pl.col("_PositiveCount") == 0) | (pl.col("_NegativeCount") == 0),
+            )
+            .then(0.5)
+            .otherwise(0.5 + (0.5 - pl.col("_RawAUC")).abs()),
+            AUC_CI_Variance=pl.when(
+                (pl.col("_PositiveCount") > 1) & (pl.col("_NegativeCount") > 1),
+            )
+            .then(
+                (
+                    pl.col("_VarianceV10") / pl.col("_PositiveCount")
+                    + pl.col("_VarianceV01") / pl.col("_NegativeCount")
+                ).clip(lower_bound=0.0),
+            )
+            .otherwise(None),
+        )
+        .with_columns(
+            AUC_CI_Lower=(pl.col("AUC") - z_score * pl.col("AUC_CI_Variance").sqrt()).clip(0.0, 1.0),
+            AUC_CI_Upper=(pl.col("AUC") + z_score * pl.col("AUC_CI_Variance").sqrt()).clip(0.0, 1.0),
+        )
+        .select(
+            group_col,
+            "AUC",
+            "AUC_CI_Variance",
+            "AUC_CI_Lower",
+            "AUC_CI_Upper",
+            "_PositiveCount",
+            "_NegativeCount",
+        )
+    )
+
+
 def _validate_grouped_auc_inputs(
     pos: Sequence[int] | pl.Series,
     neg: Sequence[int] | pl.Series,

--- a/python/tests/adm/test_active_ranges.py
+++ b/python/tests/adm/test_active_ranges.py
@@ -5,6 +5,7 @@ import pathlib
 import polars as pl
 import pytest
 from pdstools import ADMDatamart
+from polars.testing import assert_frame_equal
 
 basePath = pathlib.Path(__file__).parent.parent.parent.parent
 
@@ -60,6 +61,23 @@ def test_active_ranges_basic(sample):
     assert all(idx_min >= 0 for idx_min in ar["idx_min"])
     assert all(idx_max > 0 for idx_max in ar["idx_max"])
     assert all(idx_max >= idx_min for idx_min, idx_max in zip(ar["idx_min"], ar["idx_max"], strict=False))
+
+
+def test_active_ranges_uses_native_polars_expressions(sample):
+    """Keep active-range calculations visible to the Polars optimizer."""
+    assert "python_udf" not in sample.active_ranges().explain()
+
+
+def test_active_ranges_streaming_matches_default_engine(sample):
+    """Return identical values through the streaming engine."""
+    query = sample.active_ranges()
+
+    assert_frame_equal(
+        query.collect(engine="streaming"),
+        query.collect(),
+        check_row_order=True,
+        check_column_order=True,
+    )
 
 
 def test_active_ranges_single_model(sample):

--- a/python/tests/utils/test_cdh_utils.py
+++ b/python/tests/utils/test_cdh_utils.py
@@ -94,6 +94,41 @@ def test_auc_ci_from_bincounts_includes_auc_and_bounds():
     assert abs(payload["ci_upper"] - 0.7042163651423964) < 1e-12
 
 
+def test_native_auc_ci_expressions_match_series_calculation():
+    positives = [50, 70, 75, 80, 85, 90, 110, 130, 150, 160]
+    negatives = [1440, 1350, 1170, 990, 810, 765, 720, 675, 630, 450]
+    bins = pl.DataFrame(
+        {
+            "ModelID": ["model"] * len(positives),
+            "Positives": positives,
+            "Negatives": negatives,
+        },
+    ).lazy()
+
+    result = _metrics._auc_ci_from_binned_rows(
+        bins,
+        group_col="ModelID",
+        positive_col="Positives",
+        negative_col="Negatives",
+        confidence_level=0.95,
+    ).collect()
+    expected = cdh_utils.auc_ci_from_bincounts(positives, negatives)
+
+    assert result["AUC"].item() == pytest.approx(expected["auc"], abs=1e-12)
+    assert result["AUC_CI_Variance"].item() == pytest.approx(
+        expected["variance"],
+        abs=1e-12,
+    )
+    assert result["AUC_CI_Lower"].item() == pytest.approx(
+        expected["ci_lower"],
+        abs=1e-12,
+    )
+    assert result["AUC_CI_Upper"].item() == pytest.approx(
+        expected["ci_upper"],
+        abs=1e-12,
+    )
+
+
 def test_weighted_auc_ci_from_estimates_propagates_variance():
     payload = cdh_utils.weighted_auc_ci_from_estimates(
         [0.6, 0.8],


### PR DESCRIPTION
See https://github.com/pegasystems/pega-datascientist-tools/pull/921#issuecomment-5192341086 / #921 

Replace the grouped Python UDFs used by `active_ranges()` with native Polars
expressions.

The implementation keeps classifier bins in long form and calculates:

- active bin boundaries;
- full-range and active-range AUC;
- grouped DeLong variance;
- confidence interval bounds and availability metadata.

This removes all `map_groups` calls and `python_udf` nodes from the
`active_ranges()` logical plan. It also calculates the confidence interval once
per model rather than invoking the complete calculation separately for each
output field.

## Performance

Median end-to-end `active_ranges().collect()` timings on Polars 1.42.1:

| Models | Original UDF implementation | Native expressions | Speedup |
|---:|---:|---:|---:|
| 4 | 14.10 ms | 6.36 ms | 2.2x |
| 77 (Pega 7 fixture) | 162.67 ms | 10.62 ms | 15.3x |
| 200 | 473.30 ms | 12.71 ms | 37.2x |
| 400 | 956.59 ms | 17.68 ms | 54.1x |

The outputs match the original implementation within `1e-12`.

## Validation

- Added exact-value parity coverage between the Series and expression
  implementations.
- Added a regression check that the logical plan contains no `python_udf`.
- Added default-engine versus streaming-engine result parity coverage.
- Existing active-range edge cases remain covered.

Polars 1.42.1 still executes grouped rank and cumulative-window operations using
in-memory physical-plan nodes. The calculation is therefore expression-only and
compatible with streaming collection, but it is not yet fully out-of-core.
