### PR TITLE
Fix AGB AUC confidence intervals

### DIFF
--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -1204,6 +1204,36 @@ class ADMDatamart:
             allow_empty=True,
         )
 
+        if self.model_data is not None:
+            agb_model_ids = (
+                self.model_data.filter(pl.col("ModelTechnique") == "GradientBoost").select("ModelID").unique()
+            )
+            bin_columns = most_recent_binning_data.collect_schema().names()
+            deduplication_columns = [column for column in bin_columns if column != "BinIndex"]
+            agb_binning_data = (
+                most_recent_binning_data.join(
+                    agb_model_ids,
+                    on="ModelID",
+                    how="semi",
+                )
+                .sort("BinIndex")
+                .unique(
+                    subset=deduplication_columns,
+                    keep="first",
+                    maintain_order=True,
+                )
+            )
+            most_recent_binning_data = pl.concat(
+                [
+                    most_recent_binning_data.join(
+                        agb_model_ids,
+                        on="ModelID",
+                        how="anti",
+                    ),
+                    agb_binning_data,
+                ],
+            )
+
         scores = self._minMaxScoresPerModel(most_recent_binning_data)
         classifier_bins = (
             most_recent_binning_data.filter(EntryType="Classifier")

--- a/python/tests/adm/test_active_ranges.py
+++ b/python/tests/adm/test_active_ranges.py
@@ -230,3 +230,47 @@ def test_active_ranges_missing_score_range_returns_unavailable_ci(sample, monkey
     assert result["AUC_ActiveRange"].item() is None
     assert result["AUC_ActiveRange_CI_Available"].item() is False
     assert result["AUC_ActiveRange_CI_Reason"].item() == "missing_score_range"
+
+
+@pytest.mark.parametrize(
+    ("model_technique", "expected_bin_multiplier"),
+    [
+        ("GradientBoost", 1),
+        ("NaiveBayes", 2),
+    ],
+)
+def test_active_ranges_deduplicates_rows_only_for_agb(
+    sample,
+    model_technique,
+    expected_bin_multiplier,
+):
+    """Ignore AGB rows that are identical except for their bin index."""
+    model_id = sample._require_predictor_data().select("ModelID").unique().collect()["ModelID"][0]
+    model_data = sample._require_model_data().with_columns(
+        ModelTechnique=pl.when(pl.col("ModelID") == model_id)
+        .then(pl.lit(model_technique))
+        .otherwise(pl.col("ModelTechnique")),
+    )
+    predictor_data = sample._require_predictor_data()
+    selected_model_rows = predictor_data.filter(pl.col("ModelID") == model_id)
+    duplicated_rows = selected_model_rows.with_columns(
+        BinIndex=pl.col("BinIndex") + 100,
+    )
+    predictor_data_with_duplicates = pl.concat(
+        [
+            predictor_data,
+            duplicated_rows,
+        ],
+    )
+    datamart = ADMDatamart(
+        model_df=model_data,
+        predictor_df=predictor_data_with_duplicates,
+        extract_pyname_keys=False,
+    )
+
+    baseline = sample.active_ranges(model_id).collect()
+    result = datamart.active_ranges(model_id).collect()
+
+    assert result["Bins"].item() == baseline["Bins"].item() * expected_bin_multiplier
+    if model_technique == "GradientBoost":
+        assert_frame_equal(result, baseline)


### PR DESCRIPTION
## Summary

- Deduplicate malformed AGB predictor-bin rows that differ only by `BinIndex` before active-range calculations.
- Works around https://agilestudio.pega.com/prweb/AgileStudio/app/agilestudio/bugs/BUG-1015669
- Preserve the original predictor data and Naive Bayes calculation path.
- Restore AGB active-range AUC and confidence intervals to the values produced by unduplicated data.

## Validation

- Added coverage for duplicated Gradient Boost and Naive Bayes rows.
- Confirmed the duplicated AGB fixture changed active-range AUC from `0.559777` to `0.566692` and narrowed the CI from `0.319280–0.800273` to `0.357353–0.776030` before the fix.

## Bug

- [BUG-1015669](https://agilestudio.pega.com/prweb/AgileStudio/app/agilestudio/bugs/BUG-1015669)