### PR TITLE
Add AGB-aware active-range confidence intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `ADMDatamart.active_ranges()` now derives AGB ranges from occupied
+  classifier bins instead of Naive Bayes log odds, and reports one
+  configuration-pooled conditional DeLong interval for segments sharing the
+  same fitted ensemble. The result explicitly identifies its confidence
+  interval scope and exclusion of model-fit uncertainty.
 - Full-embed HealthCheck and Model Report HTML output no longer duplicates the
   embedded Plotly.js bundle once per chart. Because the Quarto renderer wasn't
   told which resource mode to use before figures were drawn, ``full_embed=True``

--- a/docs/adm/agb-active-range-confidence-intervals.md
+++ b/docs/adm/agb-active-range-confidence-intervals.md
@@ -1,0 +1,286 @@
+# AGB Active-Range AUC and Confidence Intervals
+
+**Status:** Implemented design
+**Updated:** August 26, 2026
+**Primary API:** `ADMDatamart.active_ranges()`
+
+This document defines the data-science contract for active classifier ranges,
+AUC reference values, and confidence intervals for Adaptive Gradient Boosting
+(AGB). It explains where AGB must differ from Naive Bayes (NB), which
+uncertainty is estimable from an ADM datamart export, and how consumers should
+interpret the resulting columns.
+
+## Problem
+
+ADM predictor exports contain classifier bins with positive and negative
+response counts. For NB, the reachable classifier range can be reconstructed
+from the additive model:
+
+1. calculate the minimum and maximum log odds for every active predictor;
+2. add the classifier offset;
+3. normalize the sum; and
+4. map the resulting score interval to classifier-bin boundaries.
+
+An AGB model is a tree ensemble. Its score is the sum of tree contributions,
+not the average of predictor-bin log odds. Applying the NB reconstruction to
+AGB data therefore produces a range with no valid model interpretation.
+
+AGB introduces a second distinction. One fitted ensemble is shared by the
+issue, group, action, and treatment segments within a model configuration.
+Treating each segment's AUC interval as an independent model interval
+duplicates evidence and ignores the common fitted model.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Preserve the established NB active-range and AUC behavior.
+- Derive an AGB range without using NB predictor arithmetic.
+- Produce one conditional AGB confidence interval per configuration.
+- Keep segment-level AUC values available for diagnostics.
+- Make the confidence-interval scope and uncertainty boundary explicit.
+- Remain robust to malformed duplicate AGB classifier rows that differ only
+  in `BinIndex`.
+
+### Non-goals
+
+- Reconstruct all reachable tree-ensemble scores from the serialized AGB
+  model.
+- Estimate uncertainty caused by fitting the tree ensemble.
+- Claim that binned counts recover row-level prediction information.
+- Treat issue/group/action segments from one configuration as independent
+  fitted models.
+
+## Statistical Estimands
+
+The API exposes two related AGB quantities.
+
+### Segment active-range AUC
+
+`AUC_ActiveRange` is calculated separately for each `ModelID` from that
+segment's occupied classifier range. It describes observed discrimination in
+the segment and remains useful when comparing segment behavior.
+
+### Configuration conditional AUC and interval
+
+`AUC_ActiveRange_CI_Estimate` is calculated after pooling classifier-bin
+counts across all selected `ModelID` values in the same `Configuration`. Its
+confidence interval describes validation-sample uncertainty for the shared
+configuration, conditional on the already-fitted ensemble.
+
+Consequently, an AGB row can have:
+
+```text
+AUC_ActiveRange != AUC_ActiveRange_CI_Estimate
+```
+
+This is intentional. The former is segment-level; the latter is the center of
+the configuration-level interval. Consumers must compare confidence bounds
+with `AUC_ActiveRange_CI_Estimate`, not assume they are centered on the
+segment AUC.
+
+## High-Level Data Flow
+
+```mermaid
+flowchart TD
+    P[Latest predictor snapshot per ModelID] --> C[Classifier rows]
+    M[Latest model metadata per ModelID] --> T{Model technique}
+    C --> T
+    T -->|NB or unknown| N[NB log-odds reachable range]
+    T -->|GradientBoost| D[Remove malformed duplicate bins]
+    D --> O[Observed occupied-bin range]
+    N --> S[Segment active bins]
+    O --> S
+    S --> A[Segment AUC]
+    S --> G{CI scope}
+    G -->|NB| I[Grouped DeLong by ModelID]
+    G -->|AGB| P2[Pool counts by Configuration and classifier bound]
+    P2 --> I2[Grouped DeLong by Configuration]
+    A --> R[active_ranges result]
+    I --> R
+    I2 --> R
+```
+
+## Active-Range Definition
+
+### Naive Bayes
+
+NB continues to use the reconstructed minimum and maximum additive score.
+Unknown model techniques retain this behavior for backward compatibility with
+exports created before `ModelTechnique` was available.
+
+### AGB
+
+For AGB, a classifier bin is occupied when:
+
+```text
+BinPositives + BinNegatives > 0
+```
+
+The active interval starts at the first occupied bin and ends immediately
+after the last occupied bin. Empty bins between those endpoints remain in the
+range because they lie inside an empirically reached score interval. Empty
+leading and trailing bins are excluded.
+
+This definition is empirical, not structural. It answers "which score region
+was observed in this validation data?" It does not prove that unoccupied
+scores are unreachable by the tree ensemble.
+
+## Grouped-Bin AUC and DeLong Variance
+
+For score bin \(k\), let \(p_k\) and \(n_k\) be positive and negative counts,
+and let \(P=\sum_k p_k\), \(N=\sum_k n_k\). Positives and negatives in the same
+bin are treated as tied scores and receive the corresponding midrank
+contribution.
+
+The grouped implementation computes the same pairwise AUC quantity that would
+result from expanding each bin into repeated tied observations. Its DeLong
+variance is:
+
+```text
+Var(AUC) = Var(V10) / P + Var(V01) / N
+```
+
+where the `V10` and `V01` sample variances are weighted by the positive and
+negative bin counts. A normal approximation supplies the requested two-sided
+confidence bounds. Bounds are clipped to `[0, 1]`; separate safe-range columns
+apply Pega's reflected `0.5`-to-`1.0` display convention.
+
+At least two positives and two negatives are required at the interval's
+actual scope.
+
+## Why AGB Counts Are Pooled by Configuration
+
+All segments in an AGB configuration use one fitted ensemble. Pooling their
+validation counts:
+
+- yields one reference estimate for the shared classifier;
+- prevents one interval from being counted repeatedly as independent
+  evidence; and
+- increases effective validation volume without pretending that the fits are
+  distinct.
+
+Bins are pooled by configuration and classifier bound before the grouped AUC
+calculation. This preserves tied score regions while summing their class
+counts.
+
+The pooled interval is copied onto each returned segment row so existing
+`ModelID`-based consumers remain compatible. The following columns make that
+repetition explicit:
+
+| Column | NB | AGB |
+|---|---|---|
+| `AUC_ActiveRange_CI_Scope` | `model` | `configuration` |
+| `AUC_ActiveRange_CI_Estimate` | Model AUC | Pooled configuration AUC |
+| `AUC_ActiveRange_CI_IncludesModelFitUncertainty` | `false` | `false` |
+
+Portfolio summaries must deduplicate AGB rows by configuration before
+counting intervals or aggregating interval widths.
+
+## Model-Fit Uncertainty Boundary
+
+The interval is conditional on the exported model. It does **not** include
+variation that would arise if AGB were retrained on another sample.
+
+A single datamart export contains one fitted ensemble and aggregated
+validation counts. It does not contain the repeated fits, bootstrap
+replicates, out-of-bag predictions, or row-level training data needed to
+estimate fit uncertainty. No variance formula can recover that missing
+information from classifier-bin counts alone.
+
+An unconditional AGB interval requires a separate input contract, such as:
+
+1. repeated model fits from bootstrap or cross-validation samples;
+2. out-of-fold row-level predictions with fit identifiers; or
+3. an externally estimated fit-variance/covariance component.
+
+Until such data exists, the API reports
+`AUC_ActiveRange_CI_IncludesModelFitUncertainty=false`. Consumers must not
+describe these bounds as total model uncertainty.
+
+## Data Quality and Failure Semantics
+
+- AGB classifier rows identical in all analytical fields but differing in
+  `BinIndex` are deduplicated before ranges, AUCs, or counts are calculated.
+- NB rows are not deduplicated by this workaround.
+- No occupied AGB bins produce `empty_active_range`.
+- Fewer than two pooled positives or negatives produce
+  `insufficient_class_volume`.
+- A missing NB reconstructed score produces `missing_score_range`.
+- Availability and reason are evaluated from counts at the same scope as the
+  interval, so a low-volume AGB segment can still use a valid
+  configuration-level interval.
+
+## Validation Strategy
+
+The implementation is validated with deterministic, exact-value tests:
+
+1. Existing NB fixtures retain their historical indices and AUC values.
+2. AGB processing excludes AGB rows from NB score reconstruction.
+3. Empty leading AGB bins move the active lower index to the first occupied
+   bin.
+4. Pooled AGB AUC, variance, and bounds match the public grouped-bin helper.
+5. Segments in one configuration receive identical interval estimates.
+6. Duplicate AGB classifier rows leave the complete result unchanged.
+7. A low-volume segment in a sufficiently large configuration has a
+   consistent available interval and null failure reason.
+8. Lazy and streaming Polars execution return the same values.
+
+Future validation against row-level predictions should compare:
+
+- binned AUC against exact row-level AUC;
+- grouped DeLong variance against row-level DeLong variance; and
+- coverage under repeated validation samples while holding the fit fixed.
+
+That exercise validates binning approximation and conditional coverage. It
+still cannot validate model-fit uncertainty without repeated fits.
+
+## Alternatives Considered
+
+### Reuse NB predictor-bin log odds
+
+Rejected because AGB scoring is not additive in those quantities. The result
+has no defensible tree-ensemble interpretation.
+
+### Decode the tree ensemble and enumerate all reachable scores
+
+Deferred. Exact enumeration can be combinatorial, depends on predictor-domain
+constraints absent from the export, and still does not estimate model-fit
+uncertainty. It has substantially higher implementation and runtime cost than
+the current validation use case justifies.
+
+### Compute one DeLong interval per segment
+
+Rejected as the primary AGB interval. It treats applications of one fitted
+ensemble as independent models and encourages downstream overcounting.
+Segment AUC remains available as a diagnostic point estimate.
+
+### Pool all AGB configurations
+
+Rejected because different configurations represent different fitted models,
+populations, and score scales. Pooling stops at `Configuration`.
+
+## Risks, Value, and Cost
+
+| Decision | Value | Risk | Mitigation / cost |
+|---|---|---|---|
+| Occupied-bin AGB range | Removes invalid NB arithmetic with low runtime cost | Unobserved but reachable tail scores are excluded | Name and document the range as empirical |
+| Configuration pooling | Matches the shared-fit deployment unit | Segment heterogeneity is hidden in the interval center | Retain segment AUC and explicit CI estimate/scope |
+| Conditional-only CI | Statistically identifiable from exported data | Users may overstate uncertainty coverage | Explicit boolean column and documentation |
+| Duplicate-bin workaround | Prevents inflated counts and narrow/shifted intervals | Could remove legitimate exact duplicate analytical bins | Apply only to known AGB rows and preserve NB behavior |
+| Lazy Polars pipeline | Scales to large datamarts without row expansion | Complex expressions can drift across engines | Streaming-equivalence and exact-value tests |
+
+## Architecture Principle Alignment
+
+- **Contextual design:** NB and AGB use technique-appropriate definitions
+  rather than forcing one scoring model onto both.
+- **API first:** existing `active_ranges()` rows remain keyed by `ModelID`;
+  new scope, estimate, and uncertainty columns define the changed contract
+  without hiding it.
+- **Software as an investment:** the design delivers a defensible conditional
+  interval from data already present in exports and explicitly defers the
+  expensive repeated-fit solution until its required data is available.
+- **Built-in resiliency:** data-quality defects and insufficient volume become
+  explicit reason codes rather than silent numerical fallbacks.
+- **Security and privacy:** all calculations use aggregate bin counts; no
+  customer-level or row-level observations are introduced or persisted.

--- a/python/pdstools/adm/ADMDatamart.py
+++ b/python/pdstools/adm/ADMDatamart.py
@@ -1109,10 +1109,10 @@ class ADMDatamart:
     ) -> pl.LazyFrame:
         """Calculate the active, reachable bins in classifiers.
 
-        The classifiers exported by Pega contain (in certain product versions) more than
-        the bins that can be reached given the current state of the predictors. This method
-        first calculates the min and max score range from the predictor log odds, then maps
-        that to the interval boundaries of the classifier(s) to find the min and max index.
+        For Naive Bayes models, this method calculates the minimum and maximum
+        score from predictor-bin log odds and maps that interval to the classifier
+        bins. For AGB models, predictor-bin log odds do not represent the tree
+        ensemble, so the active range spans the occupied classifier bins instead.
 
         It returns a LazyFrame with the score min/max, the min/max index, as well as the
         AUC as reported in the datamart data, when calculated from the full range, and when
@@ -1132,6 +1132,13 @@ class ADMDatamart:
         endpoints before that safe-range transform.
         The confidence-interval variance is expressed on the corresponding squared
         0-to-1 scale.
+
+        Naive Bayes intervals are computed per model. AGB configurations share one
+        fitted tree ensemble across issue, group, and action segments, so their
+        occupied classifier-bin counts are pooled by configuration and a single
+        conditional interval is attached to each segment. This interval quantifies
+        validation-sample uncertainty conditional on the exported fitted ensemble;
+        a single export cannot identify model-fit uncertainty.
 
         Parameters
         ----------
@@ -1154,6 +1161,7 @@ class ADMDatamart:
             - AUC_Datamart - The AUC value as reported in the datamart
             - AUC_FullRange - The AUC calculated from the full range of bins in the classifier
             - AUC_ActiveRange - The AUC calculated from only the active/reachable bins
+            - AUC_ActiveRange_CI_Estimate - The AUC estimate at the CI scope
             - AUC_ActiveRange_CI_Variance - The variance of the active-range AUC estimate; null when unavailable
             - AUC_ActiveRange_CI_Lower - Lower CI bound for active-range AUC
             - AUC_ActiveRange_CI_Upper - Upper CI bound for active-range AUC
@@ -1161,6 +1169,8 @@ class ADMDatamart:
             - AUC_ActiveRange_CI_Safe_Upper - Upper CI bound after applying Pega's safe AUC convention
             - AUC_ActiveRange_CI_Available - Whether CI could be estimated
             - AUC_ActiveRange_CI_Reason - Unavailable reason when CI is missing
+            - AUC_ActiveRange_CI_Scope - ``model`` for Naive Bayes or ``configuration`` for AGB
+            - AUC_ActiveRange_CI_IncludesModelFitUncertainty - Always false for exported classifier-bin intervals
 
             Classifier Information:
             - Bins - The total number of bins in the classifier
@@ -1204,8 +1214,33 @@ class ADMDatamart:
             allow_empty=True,
         )
 
-        scores = self._minMaxScoresPerModel(most_recent_binning_data)
-        classifier_bins = (
+        if self.model_data is None:
+            model_metadata = pl.LazyFrame(
+                schema={
+                    "ModelID": pl.String,
+                    "Configuration": pl.String,
+                    "ModelTechnique": pl.String,
+                },
+            )
+        else:
+            model_metadata = (
+                self.model_data.sort("SnapshotTime")
+                .group_by("ModelID")
+                .agg(
+                    pl.col("Configuration").cast(pl.String).last(),
+                    pl.col("ModelTechnique").last(),
+                )
+            )
+        agb_model_ids = model_metadata.filter(pl.col("ModelTechnique") == "GradientBoost").select("ModelID")
+        scores = self._minMaxScoresPerModel(
+            most_recent_binning_data.join(
+                agb_model_ids,
+                on="ModelID",
+                how="anti",
+            ),
+        )
+
+        classifier_rows = (
             most_recent_binning_data.filter(EntryType="Classifier")
             .select(
                 "ModelID",
@@ -1216,7 +1251,33 @@ class ADMDatamart:
                 _ClassifierNegative=pl.col("BinNegatives").cast(pl.Float64),
             )
             .sort("ModelID", "BinIndex")
-            .join(scores, on="ModelID", how="left")
+            .join(model_metadata, on="ModelID", how="left", maintain_order="left")
+            .join(scores, on="ModelID", how="left", maintain_order="left")
+            .with_columns(
+                _IsAGB=(pl.col("ModelTechnique") == "GradientBoost").fill_null(False),
+            )
+        )
+        agb_classifier_rows = classifier_rows.filter(pl.col("_IsAGB")).unique(
+            subset=[
+                "ModelID",
+                "AUC_Datamart",
+                "_ClassifierBound",
+                "_ClassifierPositive",
+                "_ClassifierNegative",
+                "Configuration",
+                "ModelTechnique",
+            ],
+            keep="first",
+            maintain_order=True,
+        )
+        classifier_bins = (
+            pl.concat(
+                [
+                    classifier_rows.filter(~pl.col("_IsAGB")),
+                    agb_classifier_rows,
+                ],
+            )
+            .sort("ModelID", "BinIndex")
             .with_columns(
                 Bins=pl.len().over("ModelID"),
                 _ValidBounds=pl.col("_ClassifierBound").is_not_null().sum().over("ModelID"),
@@ -1231,9 +1292,16 @@ class ADMDatamart:
                 )
                 .sum()
                 .over("ModelID"),
+                _Occupied=(pl.col("_ClassifierPositive") + pl.col("_ClassifierNegative")) > 0,
             )
             .with_columns(
-                idx_min=pl.when(
+                _OccupiedMin=pl.col("_BinPosition").filter(pl.col("_Occupied")).min().over("ModelID"),
+                _OccupiedMax=pl.col("_BinPosition").filter(pl.col("_Occupied")).max().over("ModelID") + 1,
+            )
+            .with_columns(
+                idx_min=pl.when(pl.col("_IsAGB"))
+                .then(pl.col("_OccupiedMin"))
+                .when(
                     pl.col("score_min").is_null() | (pl.col("_ValidBounds") == 0),
                 )
                 .then(None)
@@ -1250,7 +1318,9 @@ class ADMDatamart:
                     - 1,
                 )
                 .cast(pl.Int32),
-                idx_max=pl.when(
+                idx_max=pl.when(pl.col("_IsAGB"))
+                .then(pl.col("_OccupiedMax"))
+                .when(
                     pl.col("score_max").is_null() | (pl.col("_ValidBounds") == 0),
                 )
                 .then(None)
@@ -1267,19 +1337,30 @@ class ADMDatamart:
                 )
                 .cast(pl.Int32),
             )
+            .with_columns(
+                _CIScopeKey=pl.when(pl.col("_IsAGB"))
+                .then(pl.coalesce("Configuration", "ModelID"))
+                .otherwise(pl.col("ModelID")),
+            )
         )
 
         classifier_info = classifier_bins.group_by("ModelID").agg(
             AUC_Datamart=pl.col("AUC_Datamart").first(),
+            Configuration=pl.col("Configuration").first(),
+            ModelTechnique=pl.col("ModelTechnique").first(),
             Bins=pl.col("Bins").first(),
             nActivePredictors=pl.col("nActivePredictors").first(),
-            classifierLogOffset=pl.col("classifierLogOffset").first(),
-            sumMinLogOdds=pl.col("sumMinLogOdds").first(),
-            sumMaxLogOdds=pl.col("sumMaxLogOdds").first(),
-            score_min=pl.col("score_min").first(),
-            score_max=pl.col("score_max").first(),
+            classifierLogOffset=pl.when(pl.col("_IsAGB").first())
+            .then(None)
+            .otherwise(pl.col("classifierLogOffset").first()),
+            sumMinLogOdds=pl.when(pl.col("_IsAGB").first()).then(None).otherwise(pl.col("sumMinLogOdds").first()),
+            sumMaxLogOdds=pl.when(pl.col("_IsAGB").first()).then(None).otherwise(pl.col("sumMaxLogOdds").first()),
+            score_min=pl.when(pl.col("_IsAGB").first()).then(None).otherwise(pl.col("score_min").first()),
+            score_max=pl.when(pl.col("_IsAGB").first()).then(None).otherwise(pl.col("score_max").first()),
             idx_min=pl.col("idx_min").first(),
             idx_max=pl.col("idx_max").first(),
+            _IsAGB=pl.col("_IsAGB").first(),
+            _CIScopeKey=pl.col("_CIScopeKey").first(),
         )
 
         full_range_auc = _auc_ci_from_binned_rows(
@@ -1292,10 +1373,11 @@ class ADMDatamart:
             "ModelID",
             AUC_FullRange=pl.col("AUC"),
         )
+        active_classifier_bins = classifier_bins.filter(
+            (pl.col("_BinPosition") >= pl.col("idx_min")) & (pl.col("_BinPosition") < pl.col("idx_max")),
+        )
         active_range_auc = _auc_ci_from_binned_rows(
-            classifier_bins.filter(
-                (pl.col("_BinPosition") >= pl.col("idx_min")) & (pl.col("_BinPosition") < pl.col("idx_max")),
-            ),
+            active_classifier_bins,
             group_col="ModelID",
             positive_col="_ClassifierPositive",
             negative_col="_ClassifierNegative",
@@ -1303,13 +1385,39 @@ class ADMDatamart:
         ).select(
             "ModelID",
             AUC_ActiveRange=pl.col("AUC"),
+            _ActivePositiveCount=pl.col("_PositiveCount"),
+            _ActiveNegativeCount=pl.col("_NegativeCount"),
+        )
+        agb_ci_bins = (
+            active_classifier_bins.filter(pl.col("_IsAGB"))
+            .group_by("_CIScopeKey", "_ClassifierBound")
+            .agg(
+                pl.col("_ClassifierPositive").sum(),
+                pl.col("_ClassifierNegative").sum(),
+            )
+        )
+        non_agb_ci_bins = active_classifier_bins.filter(~pl.col("_IsAGB")).select(
+            "_CIScopeKey",
+            "_ClassifierBound",
+            "_ClassifierPositive",
+            "_ClassifierNegative",
+        )
+        scoped_active_range_ci = _auc_ci_from_binned_rows(
+            pl.concat([non_agb_ci_bins, agb_ci_bins]),
+            group_col="_CIScopeKey",
+            positive_col="_ClassifierPositive",
+            negative_col="_ClassifierNegative",
+            confidence_level=confidence_level,
+        ).select(
+            "_CIScopeKey",
+            AUC_ActiveRange_CI_Estimate=pl.col("AUC"),
             AUC_ActiveRange_CI_Variance=pl.col("AUC_CI_Variance"),
             AUC_ActiveRange_CI_Lower=pl.col("AUC_CI_Lower"),
             AUC_ActiveRange_CI_Upper=pl.col("AUC_CI_Upper"),
             AUC_ActiveRange_CI_Safe_Lower=pl.col("AUC_CI_Safe_Lower"),
             AUC_ActiveRange_CI_Safe_Upper=pl.col("AUC_CI_Safe_Upper"),
-            _ActivePositiveCount=pl.col("_PositiveCount"),
-            _ActiveNegativeCount=pl.col("_NegativeCount"),
+            _CIPositiveCount=pl.col("_PositiveCount"),
+            _CINegativeCount=pl.col("_NegativeCount"),
         )
 
         return (
@@ -1323,18 +1431,31 @@ class ADMDatamart:
                 on="ModelID",
                 how="left",
             )
+            .join(
+                scoped_active_range_ci,
+                on="_CIScopeKey",
+                how="left",
+            )
             .with_columns(
+                AUC_ActiveRange_CI_Scope=pl.when(pl.col("_IsAGB"))
+                .then(pl.lit("configuration"))
+                .otherwise(pl.lit("model")),
+                AUC_ActiveRange_CI_IncludesModelFitUncertainty=pl.lit(False),
                 AUC_ActiveRange_CI_Available=pl.col(
                     "AUC_ActiveRange_CI_Variance",
                 ).is_not_null(),
                 AUC_ActiveRange_CI_Reason=pl.when(
+                    pl.col("_IsAGB") & (pl.col("idx_min").is_null() | pl.col("idx_max").is_null()),
+                )
+                .then(pl.lit("empty_active_range"))
+                .when(
                     pl.col("idx_min").is_null() | pl.col("idx_max").is_null(),
                 )
                 .then(pl.lit("missing_score_range"))
                 .when(pl.col("AUC_ActiveRange").is_null())
                 .then(pl.lit("empty_active_range"))
                 .when(
-                    (pl.col("_ActivePositiveCount") <= 1) | (pl.col("_ActiveNegativeCount") <= 1),
+                    (pl.col("_CIPositiveCount") <= 1) | (pl.col("_CINegativeCount") <= 1),
                 )
                 .then(pl.lit("insufficient_class_volume"))
                 .when(pl.col("AUC_ActiveRange_CI_Variance").is_null())
@@ -1342,7 +1463,14 @@ class ADMDatamart:
                 .otherwise(None),
             )
             .sort("ModelID")
-            .drop("_ActivePositiveCount", "_ActiveNegativeCount")
+            .drop(
+                "_ActivePositiveCount",
+                "_ActiveNegativeCount",
+                "_CIPositiveCount",
+                "_CINegativeCount",
+                "_IsAGB",
+                "_CIScopeKey",
+            )
             .select(cs.starts_with("AUC"), ~cs.starts_with("AUC"))
             .select("ModelID", ~cs.starts_with("ModelID"))
         )

--- a/python/tests/adm/test_active_ranges.py
+++ b/python/tests/adm/test_active_ranges.py
@@ -30,6 +30,7 @@ def test_active_ranges_basic(sample):
         "AUC_Datamart",
         "AUC_FullRange",
         "AUC_ActiveRange",
+        "AUC_ActiveRange_CI_Estimate",
         "AUC_ActiveRange_CI_Variance",
         "AUC_ActiveRange_CI_Lower",
         "AUC_ActiveRange_CI_Upper",
@@ -37,6 +38,8 @@ def test_active_ranges_basic(sample):
         "AUC_ActiveRange_CI_Safe_Upper",
         "AUC_ActiveRange_CI_Available",
         "AUC_ActiveRange_CI_Reason",
+        "AUC_ActiveRange_CI_Scope",
+        "AUC_ActiveRange_CI_IncludesModelFitUncertainty",
         "Bins",
         "nActivePredictors",
         "classifierLogOffset",
@@ -230,3 +233,138 @@ def test_active_ranges_missing_score_range_returns_unavailable_ci(sample, monkey
     assert result["AUC_ActiveRange"].item() is None
     assert result["AUC_ActiveRange_CI_Available"].item() is False
     assert result["AUC_ActiveRange_CI_Reason"].item() == "missing_score_range"
+
+
+def _agb_datamart(sample, *, duplicate_classifier_rows=False):
+    model_ids = (
+        sample._require_model_data()
+        .filter(pl.col("Configuration") == "OmniAdaptiveModel")
+        .select("ModelID")
+        .unique()
+        .collect()["ModelID"]
+        .to_list()
+    )
+    model_data = sample._require_model_data().with_columns(
+        ModelTechnique=pl.when(pl.col("ModelID").is_in(model_ids))
+        .then(pl.lit("GradientBoost"))
+        .otherwise(pl.col("ModelTechnique")),
+    )
+    predictor_data = sample._require_predictor_data().with_columns(
+        BinPositives=pl.when(
+            pl.col("ModelID").is_in(model_ids)
+            & (pl.col("EntryType") == "Classifier")
+            & (
+                pl.col("BinIndex")
+                == pl.col("BinIndex").filter(pl.col("EntryType") == "Classifier").min().over("ModelID")
+            ),
+        )
+        .then(0.0)
+        .otherwise(pl.col("BinPositives")),
+        BinNegatives=pl.when(
+            pl.col("ModelID").is_in(model_ids)
+            & (pl.col("EntryType") == "Classifier")
+            & (
+                pl.col("BinIndex")
+                == pl.col("BinIndex").filter(pl.col("EntryType") == "Classifier").min().over("ModelID")
+            ),
+        )
+        .then(0.0)
+        .otherwise(pl.col("BinNegatives")),
+    )
+    if duplicate_classifier_rows:
+        duplicates = predictor_data.filter(
+            pl.col("ModelID").is_in(model_ids),
+            pl.col("EntryType") == "Classifier",
+        ).with_columns(BinIndex=pl.col("BinIndex") + 100)
+        predictor_data = pl.concat([predictor_data, duplicates])
+
+    return (
+        ADMDatamart(
+            model_df=model_data,
+            predictor_df=predictor_data,
+            extract_pyname_keys=False,
+        ),
+        model_ids,
+    )
+
+
+def test_active_ranges_uses_occupied_bins_and_configuration_ci_for_agb(sample, monkeypatch):
+    """Pool AGB validation counts without applying Naive Bayes score math."""
+    datamart, model_ids = _agb_datamart(sample)
+    original_min_max_scores = ADMDatamart._minMaxScoresPerModel
+
+    def assert_agb_excluded(cls, data):
+        assert data.select("ModelID").unique().collect().height == 0
+        return original_min_max_scores(data)
+
+    monkeypatch.setattr(
+        ADMDatamart,
+        "_minMaxScoresPerModel",
+        classmethod(assert_agb_excluded),
+    )
+
+    result = datamart.active_ranges(model_ids).collect().sort("ModelID")
+    pooled_bins = (
+        datamart._require_predictor_data()
+        .filter(
+            pl.col("ModelID").is_in(model_ids),
+            pl.col("EntryType") == "Classifier",
+            (pl.col("BinPositives") + pl.col("BinNegatives")) > 0,
+        )
+        .group_by("BinLowerBound")
+        .agg(
+            pl.col("BinPositives").sum(),
+            pl.col("BinNegatives").sum(),
+        )
+        .collect()
+    )
+    expected_ci = cdh_utils.auc_ci_from_bincounts(
+        pooled_bins["BinPositives"],
+        pooled_bins["BinNegatives"],
+    )
+
+    assert result["idx_min"].to_list() == [1, 1]
+    assert result["score_min"].to_list() == [None, None]
+    assert result["score_max"].to_list() == [None, None]
+    assert result["AUC_ActiveRange_CI_Scope"].to_list() == ["configuration", "configuration"]
+    assert result["AUC_ActiveRange_CI_IncludesModelFitUncertainty"].to_list() == [False, False]
+    assert result["AUC_ActiveRange_CI_Estimate"].to_list() == pytest.approx([expected_ci["auc"]] * 2)
+    assert result["AUC_ActiveRange_CI_Variance"].to_list() == pytest.approx([expected_ci["variance"]] * 2)
+    assert result["AUC_ActiveRange_CI_Lower"].to_list() == pytest.approx([expected_ci["ci_lower"]] * 2)
+    assert result["AUC_ActiveRange_CI_Upper"].to_list() == pytest.approx([expected_ci["ci_upper"]] * 2)
+
+
+def test_active_ranges_ignores_malformed_duplicate_agb_classifier_rows(sample):
+    """Keep AGB occupied ranges and pooled intervals invariant to duplicate bins."""
+    baseline, model_ids = _agb_datamart(sample)
+    duplicated, _ = _agb_datamart(sample, duplicate_classifier_rows=True)
+
+    assert_frame_equal(
+        duplicated.active_ranges(model_ids).collect().sort("ModelID"),
+        baseline.active_ranges(model_ids).collect().sort("ModelID"),
+        check_row_order=True,
+        check_column_order=True,
+    )
+
+
+def test_active_ranges_uses_pooled_agb_volume_for_ci_availability(sample):
+    """Keep availability and reason consistent with configuration-level counts."""
+    datamart, model_ids = _agb_datamart(sample)
+    starved_model = model_ids[0]
+    datamart.predictor_data = datamart._require_predictor_data().with_columns(
+        BinPositives=pl.when(
+            (pl.col("ModelID") == starved_model) & (pl.col("EntryType") == "Classifier") & (pl.col("BinPositives") > 0),
+        )
+        .then(1.0 / pl.col("BinPositives").count().over("ModelID"))
+        .otherwise(pl.col("BinPositives")),
+        BinNegatives=pl.when(
+            (pl.col("ModelID") == starved_model) & (pl.col("EntryType") == "Classifier") & (pl.col("BinNegatives") > 0),
+        )
+        .then(1.0 / pl.col("BinNegatives").count().over("ModelID"))
+        .otherwise(pl.col("BinNegatives")),
+    )
+
+    result = datamart.active_ranges(model_ids).collect()
+
+    assert result["AUC_ActiveRange_CI_Available"].to_list() == [True, True]
+    assert result["AUC_ActiveRange_CI_Reason"].to_list() == [None, None]


### PR DESCRIPTION
## Summary

- Derive AGB active ranges from occupied classifier bins instead of Naive Bayes predictor-bin log odds.
- Pool AGB classifier-bin counts by configuration for one grouped DeLong interval across segments sharing a fitted ensemble.
- Preserve segment-level AUC diagnostics while exposing the configuration-level CI estimate, scope, and exclusion of model-fit uncertainty.
- Ignore malformed duplicate AGB classifier rows that differ only by bin index.
- Document the data-science design, assumptions, alternatives, risks, and validation contract.

## Statistical contract

The AGB interval quantifies validation-sample uncertainty conditional on the exported fitted ensemble. It does not include model-fit uncertainty, which cannot be identified from one datamart export. Segment AUC remains available in `AUC_ActiveRange`; the center of the pooled interval is exposed separately in `AUC_ActiveRange_CI_Estimate`.

## Validation

- 62 targeted ADM active-range tests pass.
- Repository pre-commit, Pyright, and Pyrefly checks pass.
- Exact-value coverage includes pooled variance and bounds, occupied-bin selection, insufficient segment volume within a valid pooled configuration, streaming equivalence, and duplicate-row invariance.

## Related

This supersedes the narrow duplicate-row correction proposed in #947 by introducing a technique-appropriate AGB design.
