### PR TITLE
Investigate AUC roll-up weighting and add comparison tooling to batch_healthcheck.py

### DIFF
--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -1,11 +1,6 @@
 # AUC roll-up weighting: statistical comparison of aggregation methods
 
-Priority: P2
-
-Files touched: `scripts/batch_healthcheck.py`,
-`python/tests/healthcheck/test_batch_healthcheck.py`, possibly
-`python/pdstools/utils/cdh_utils/_metrics.py` (no new library API
-expected — existing functions are sufficient, see below).
+Review various weighting techniques for roll up of AUC for both NB and AGB. No functional changes in scope, just reporting in the batch run over client data.
 
 ## Problem
 
@@ -90,7 +85,7 @@ the `Positives * Negatives` vs. `Positives + Negatives` weighting itself.
 
 ## Proposed approach
 
-### Phase 1 — implement the five-way comparison in `batch_healthcheck.py`
+### Phase 1 (done) — implement the five-way comparison in `batch_healthcheck.py`
 
 Add a new analysis step to `process_dataset()`, alongside the existing CI
 maturity analysis:
@@ -130,7 +125,7 @@ maturity analysis:
    changes the library default (`Aggregates.model_summary`,
    `HealthCheck.qmd`, etc.) — out of scope for this plan.
 
-### Phase 2 — run across the private multi-customer dataset
+### Phase 2 (done) — run across the private multi-customer dataset
 
 Run `scripts/batch_healthcheck.py` over the full private customer corpus,
 inspect `auc_rollup_comparison.csv`:
@@ -144,10 +139,33 @@ inspect `auc_rollup_comparison.csv`:
   under-weighted by (c)/(e) relative to (b), or vice versa for
   high-volume-but-skewed-classes models?
 
-### Phase 3 — decide and (if warranted) change the library default
+See "Conclusions from the private customer-data run" below for the
+results.
 
-Out of scope for this plan; file a follow-up plan item if the data
-supports changing `weighted_performance_polars`'s default weighting.
+### Decision: keep the current `ResponseCount`-weighted default for now
+
+`PosNeg` (and plain `Positives`) weighting track the DeLong reference
+much more closely than the current `ResponseCount` weighting (see
+Conclusions below), and are feasible drop-in replacements. **We are not
+changing the library default at this time** — `Aggregates.model_summary`,
+`HealthCheck.qmd`, and `weighted_performance_polars` keep
+`ResponseCount` weighting. Reasons:
+
+- The DeLong reference is still NB-only in terms of empirical validation
+  on real customer data (see the AGB caveat below) — the AGB-aware CI
+  computation landed in [PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
+  and `compute_auc_rollup_comparison` was updated to use it correctly,
+  but a fresh full-corpus run to confirm the conclusions hold for AGB
+  configurations hasn't happened yet.
+- `ResponseCount`-weighted and `PosNeg`/`Positives`-weighted answer
+  different questions (see "The two aggregates answer different
+  questions" below) — changing the default isn't just a precision
+  upgrade, it changes what the number means, which warrants a
+  deliberate, separately-reviewed decision rather than a side effect of
+  this investigation.
+
+If a future change is warranted, it stays tracked as a follow-up below,
+not decided here.
 
 ## Open questions / assumptions made
 
@@ -370,28 +388,27 @@ NaiveBayes model rows with a usable CI):
   `Analysis.health_check_maturity_criteria` and `Aggregates.py`. This
   touches library code (not just the batch script) and needs its own
   plan doc if pursued.
-- If the customer-data conclusions hold up, consider changing the
-  library default (`Aggregates.model_summary`, `HealthCheck.qmd`) from
-  `ResponseCount`- to `PosNeg`-weighted AUC roll-up — as a deliberate,
-  separately-reviewed change, not a silent side effect of this
-  investigation.
-- Build an AGB-aware active-range/CI computation, so the DeLong reference
-  and its agreement validation can be extended to AGB configurations,
-  not just NB. [PR #947](https://github.com/pegasystems/pega-datascientist-tools/pull/947)
+- Revisit the library default (`Aggregates.model_summary`,
+  `HealthCheck.qmd`) if a future need arises — see "Decision: keep the
+  current `ResponseCount`-weighted default for now" above. Not changing
+  it as part of this investigation.
+- **Resolved:** an AGB-aware active-range/CI computation was needed so
+  the DeLong reference and its agreement validation could extend to AGB
+  configurations, not just NB. [PR #947](https://github.com/pegasystems/pega-datascientist-tools/pull/947)
   fixed duplicate-row inflation in the existing calculation, but
   `active_ranges()` still derived reachable scores by summing
   predictor-bin log odds, which is specific to Naive Bayes and does not
-  represent an AGB tree ensemble. The grouped DeLong helper itself can
+  represent an AGB tree ensemble. The grouped DeLong helper itself could
   operate on valid classifier-bin counts, but it did not account for
   shared model-fit uncertainty across an AGB model's issue/group/action
   segments.
 
   [PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
-  (about to be merged) addresses this properly: it derives AGB active
-  ranges from occupied classifier bins instead of the NB log-odds
-  reconstruction, and pools classifier-bin counts by `Configuration` so
-  segments sharing one fitted ensemble get a single grouped DeLong
-  interval instead of independent-looking per-segment ones. It adds
+  (merged) addressed this properly: it derives AGB active ranges from
+  occupied classifier bins instead of the NB log-odds reconstruction,
+  and pools classifier-bin counts by `Configuration` so segments sharing
+  one fitted ensemble get a single grouped DeLong interval instead of
+  independent-looking per-segment ones. It adds
   `AUC_ActiveRange_CI_Estimate` (the pooled interval's center),
   `AUC_ActiveRange_CI_Scope`, and
   `AUC_ActiveRange_CI_IncludesModelFitUncertainty` (explicitly `False` —
@@ -400,14 +417,17 @@ NaiveBayes model rows with a usable CI):
   identified from a single datamart export), while `AUC_ActiveRange`
   keeps returning the segment-level AUC for diagnostics.
 
-  Once merged, `compute_auc_rollup_comparison` needs a follow-up change of
-  its own: it currently treats every `ModelID` row's
-  `AUC_ActiveRange_CI_Variance` as an independent estimate and
-  re-pools them per `Configuration` via
-  `weighted_auc_ci_from_estimates`. For AGB, that variance will now
-  already be the *pooled configuration-level* value repeated across every
-  segment row — re-pooling it again would double-count the same evidence
-  and understate the resulting uncertainty. The script should detect
-  already-pooled AGB rows (e.g. via `AUC_ActiveRange_CI_Scope`) and use
-  `AUC_ActiveRange_CI_Estimate`/its variance directly per `Configuration`
-  instead of running inverse-variance pooling across those rows again.
+  `compute_auc_rollup_comparison` was updated to match: it now detects
+  already-pooled AGB rows via `AUC_ActiveRange_CI_Scope ==
+  "configuration"` and uses `AUC_ActiveRange_CI_Estimate`/its variance
+  directly per `Configuration`, instead of re-pooling the same
+  configuration-level variance once per segment row (which would have
+  double-counted the same evidence and understated the resulting
+  uncertainty). Verified against a synthetic AGB configuration built from
+  the sample dataset.
+
+  **Still open:** the conclusions in this doc were validated on
+  customer data collected before PR #948 landed, so AGB configurations
+  are not yet represented in the empirical Bland-Altman/agreement
+  results above. A fresh full-corpus run is needed to confirm the
+  weighting-scheme conclusions hold for AGB too.

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -1,0 +1,393 @@
+# AUC roll-up weighting: statistical comparison of aggregation methods
+
+Priority: P2
+
+Files touched: `scripts/batch_healthcheck.py`,
+possibly `python/pdstools/utils/cdh_utils/_metrics.py` (no new library API
+expected — existing functions are sufficient, see below).
+
+## Problem
+
+`pdstools` currently rolls up per-model AUC into an aggregate (e.g. per
+`Configuration`) with `cdh_utils.weighted_average_polars("Performance",
+"ResponseCount")` — a response-count-weighted average
+(`Aggregates.model_summary`, `HealthCheck.qmd`, etc.).
+
+A data scientist reviewing this pushed back: weighting by
+`ResponseCount = Positives + Negatives` implicitly treats AUC like a
+proportion (e.g. a success rate), where precision scales with total trials.
+AUC is not a proportion — its sampling variance depends on *both* class
+counts multiplicatively, not their sum. His proposed fix: weight by
+`Positives * Negatives` instead.
+
+## Statistical grounding
+
+1. **Combining independent estimates.** The classical result for pooling
+   independent unbiased estimates (fixed-effect meta-analysis, Cochran
+   1954, "The Combination of Estimates from Different Experiments",
+   *Biometrics* 10(1)) is that the variance-minimizing weights are
+   proportional to `1 / Var(estimate)` — inverse-variance weighting. Any
+   other weighting scheme is a heuristic approximation to this.
+
+2. **AUC variance formula.** Hanley & McNeil (1982, "The Meaning and Use
+   of the Area under a ROC Curve", *Radiology* 143(1)) give the
+   approximate variance of an AUC/Wilcoxon estimate as
+
+   `Var(AUC) ≈ [AUC(1-AUC) + (n_pos - 1)(Q1 - AUC²) + (n_neg - 1)(Q2 - AUC²)] / (n_pos * n_neg)`
+
+   where `Q1 = AUC / (2 - AUC)` and `Q2 = 2*AUC² / (1 + AUC)`. The
+   denominator is `n_pos * n_neg`, not `n_pos + n_neg`. This is also the
+   basis of the exact nonparametric variance estimator used by DeLong,
+   DeLong & Clarke-Pearson (1988, "Comparing the Areas under Two or More
+   Correlated Receiver Operating Characteristic Curves: A Nonparametric
+   Approach", *Biometrics* 44(3), <https://doi.org/10.2307/2531595>),
+   which `pdstools` already implements in
+   `cdh_utils.auc_variance_delong_grouped` / `auc_ci_from_bincounts`.
+
+3. **Implication.** Since `Var(AUC) ∝ 1 / (n_pos * n_neg)` to first order,
+   weighting by `Positives * Negatives` is a much closer proxy to the
+   variance-optimal inverse-variance weight than weighting by
+   `Positives + Negatives`. The `ResponseCount`-weighted average is the
+   right choice for pooling *proportions* (e.g. `SuccessRate`), but is a
+   statistically weaker choice for pooling AUC.
+
+4. **The rigorous option already exists in-repo.** `pdstools` already
+   computes a DeLong-style AUC variance per model
+   (`ADMDatamart.active_ranges` returns `AUC_ActiveRange` and
+   `AUC_ActiveRange_CI_Variance` from classifier bin counts) and already
+   has a function to combine independent AUC + variance estimates with
+   inverse-variance weights: `cdh_utils.weighted_auc_ci_from_estimates`.
+   So the "gold standard" comparison point — true inverse-variance
+   weighting using DeLong variances — is a small amount of glue code away,
+   not new statistical machinery.
+
+Conclusion: there are five aggregation methods worth comparing head-to-head
+on real customer data, in increasing order of statistical rigor:
+
+| # | Method | Weight | Requires |
+|---|--------|--------|----------|
+| a | Naive average | 1 (equal weight per model) | `Performance`, `Configuration` |
+| b | Current (response-count-weighted) | `Positives + Negatives` | same |
+| c | Proposed (pos*neg-weighted) | `Positives * Negatives` | same |
+| e | Positives-only-weighted | `Positives` | same |
+| d | Inverse-variance (DeLong) | `1 / Var_DeLong(AUC)` | predictor/classifier bin data |
+
+(d) is the statistically correct pooling method; (c) and (e) are evaluated
+as cheap proxies that don't require classifier bin data — (e) because
+`Var(AUC) ~= (Q2 - AUC^2) / n_pos` once `Negatives >> Positives` (see
+below), making plain `Positives` weighting a candidate that may track (d)
+even more closely than (c) under heavy class imbalance; (a) and (b) are
+the naive/current baselines being challenged.
+
+Two supplementary diagnostic variants of (b) and (c) are also reported,
+restricted to models with `Positives > 0`: `AUC_Weighted_ResponseCount_PositivesOnly`
+and `AUC_Weighted_PosNeg_PositivesOnly`. Zero-positive models have an
+essentially undefined/uninformative AUC but can carry a large `ResponseCount`,
+so they can pull (b) away from (c)/(d) even though (c)/(d) already give them
+zero weight. Comparing (b) against its positives-only variant isolates how
+much of the gap to (c)/(d) is explained purely by that exclusion, versus by
+the `Positives * Negatives` vs. `Positives + Negatives` weighting itself.
+
+## Proposed approach
+
+### Phase 1 — implement the 4-way comparison in `batch_healthcheck.py`
+
+Add a new analysis step to `process_dataset()`, alongside the existing CI
+maturity analysis:
+
+1. Build a per-model frame from the latest snapshot
+   (`datamart.aggregates.last()`), with `ModelID`, `Configuration`,
+   `Performance`, `Positives`, `ResponseCount` (`Negatives = ResponseCount
+   - Positives`). Filter to `ResponseCount > 0`.
+2. Join in `datamart.active_ranges()` output (`AUC_ActiveRange`,
+   `AUC_ActiveRange_CI_Variance`, `AUC_ActiveRange_CI_Available`) for
+   models that have classifier bin data. This reuses the same call
+   already made for CI maturity — no duplicate computation of active
+   ranges.
+3. Group by `Configuration` (falling back to all-models-in-one-group if
+   `Configuration` isn't present) and compute, per group:
+   - `AUC_Naive_Mean` — `pl.col("Performance").mean()`
+   - `AUC_Weighted_ResponseCount` — `cdh_utils.weighted_performance_polars()`
+     (existing / current behavior)
+   - `AUC_Weighted_PosNeg` — `weighted_average_polars("Performance",
+     Positives * Negatives)`
+   - `AUC_Weighted_Positives` — `weighted_average_polars("Performance",
+     Positives)`
+   - `AUC_Weighted_InverseVariance_DeLong` — via
+     `cdh_utils.weighted_auc_ci_from_estimates(auc=AUC_ActiveRange,
+     variance=AUC_ActiveRange_CI_Variance, weights=1/variance)`, restricted
+     to models with `AUC_ActiveRange_CI_Available`. Also report the
+     resulting CI bounds and `N_Models_With_DeLong_CI`.
+4. Collect one row per `(Dataset, Configuration)` into a list (same
+   collector pattern as `ci_maturity_dataset_rows`), write to
+   `auc_rollup_comparison.csv` next to the other batch summary outputs at
+   the end of `main()`.
+5. No changes to `python/pdstools` library code are anticipated — this is
+   analysis/tooling in the batch script only. If the comparison proves the
+   pos*neg or inverse-variance approach is superior, a follow-up PR
+   changes the library default (`Aggregates.model_summary`,
+   `HealthCheck.qmd`, etc.) — out of scope for this plan.
+
+### Phase 2 — run across the private multi-customer dataset
+
+Run `scripts/batch_healthcheck.py` over the full private customer corpus,
+inspect `auc_rollup_comparison.csv`:
+
+- How much do (b), (c), (d) disagree from each other and from (a),
+  in absolute AUC points, across configurations?
+- Does (c) (cheap proxy) track (d) (rigorous) closely? If yes, (c) is a
+  good practical default even without classifier bin data.
+- Are there configurations where (b) meaningfully diverges from (c)/(d) —
+  e.g. because a low-volume-but-balanced-classes model would be
+  under-weighted by (c)/(d) relative to (b), or vice versa for
+  high-volume-but-skewed-classes models?
+
+### Phase 3 — decide and (if warranted) change the library default
+
+Out of scope for this plan; file a follow-up plan item if the data
+supports changing `weighted_performance_polars`'s default weighting.
+
+## Open questions / assumptions made
+
+- Grouping level: `Configuration` (matches `Aggregates.model_summary`
+  convention). Not grouping by `Channel`/`Direction` as well, to keep the
+  comparison table small; can be revisited.
+- Only the latest snapshot per model is used (consistent with
+  `aggregates.last()` elsewhere in the codebase), not a time-weighted
+  roll-up across snapshots.
+- The DeLong/inverse-variance metric is computed on the *active-range*
+  AUC (`AUC_ActiveRange`), which is what `active_ranges()` already
+  provides variance for. This is what the existing CI maturity analysis
+  uses too, so it's consistent within the script — but note it's not
+  exactly the same point estimate as `Performance` (datamart-reported
+  AUC from the full classifier range) used for (a)/(b)/(c). Both figures
+  are reported so the disagreement is visible rather than hidden.
+
+## Conclusions from the private customer-data run
+
+Ran `scripts/batch_healthcheck.py` across the full private customer
+corpus and analyzed `auc_rollup_comparison.csv` (320 configurations, 234
+with a DeLong estimate pooling >= 5 models) with
+`print_auc_rollup_agreement_table` / `generate_auc_rollup_bland_altman_plot`.
+Agreement with the DeLong reference, on the 0-1 AUC scale:
+
+| Method | Bias | MAE | RMSE | Pearson r | Lin's CCC |
+|---|---|---|---|---|---|
+| Naive mean | -0.078 | 0.091 | 0.122 | 0.61 | 0.40 |
+| **Current**: ResponseCount-weighted | -0.027 | 0.052 | 0.088 | 0.71 | 0.65 |
+| **Proposed**: PosNeg-weighted | -0.006 | 0.036 | 0.059 | 0.87 | 0.86 |
+
+Plain Pearson r is misleading for this comparison (two methods can
+correlate highly while being systematically offset), so Bias/MAE/RMSE and
+Lin's CCC (which penalizes offset/scale mismatch as well as weak
+correlation) are the metrics that matter. **Conclusion: `Positives *
+Negatives` weighting roughly halves the error against the DeLong
+reference compared to the current `ResponseCount` weighting** (MAE 0.036
+vs. 0.052; CCC 0.86 vs. 0.65), and is a feasible drop-in replacement that
+needs no classifier/predictor bin data.
+
+### Caveat: the DeLong reference is currently NB-only, and pooling assumptions differ by technique
+
+NB and AGB models are architecturally different in a way that matters
+for this whole analysis: **for NB, each action/treatment is a completely
+separate model**, fit independently — the "pool k independent AUC
+estimates" assumption behind Cochran/DeLong inverse-variance weighting
+holds naturally. **For AGB, there is typically one shared model per
+`Configuration` (usually per channel), with issue/group/action splits
+scored from that same shared model** — so the per-`ModelID` rows being
+pooled are correlated segment-level scores of one model, not independent
+models. Per-row DeLong variance (computed from each row's own classifier
+bin counts) captures sampling noise in that segment's outcomes, but not
+the shared model-fit uncertainty common across all of that model's
+segments — so even where available, it likely understates true
+uncertainty for AGB.
+
+In practice it usually isn't even available: **every AGB/GradientBoost
+configuration observed in the private customer-data run had
+`N_Models_With_DeLong_CI = 0`** (`*_AGB` configs, `BoostingModel_*`,
+etc.). Root cause: `ADMDatamart._minMaxScoresPerModel` (which
+`active_ranges()` and therefore the DeLong CI machinery depends on)
+computes a model's reachable score range as the sum of each active
+predictor's log-odds min/max — the Naive Bayes score formula. AGB's
+score isn't a sum of independent per-predictor log-odds contributions
+(tree splits interact nonlinearly), so this computation structurally
+cannot produce a meaningful active range for AGB models; `AUC_ActiveRange`
+and its CI end up null.
+
+**Consequence: the agreement table and Bland-Altman plot above are
+implicitly NB-only.** AGB configurations contribute nothing to the
+"eligible" (DeLong-available) comparison set — not because AGB agrees or
+disagrees with the DeLong reference, but because DeLong currently can't
+be computed for AGB at all with `active_ranges()`. Whether `PosNeg`
+weighting is a good DeLong proxy for AGB models remains unvalidated.
+
+This does **not** affect the `Positives > 200` maturity discussion below:
+that reasoning is about the precision of a single AUC estimate from its
+own bin counts, which applies the same way whether the row is a
+standalone NB model or a correlated segment of a shared AGB model.
+
+A genuine fix (an AGB-aware active-range/CI computation, or a different
+variance model that accounts for shared model-fit uncertainty across
+segments) is out of scope for this plan — noted as a follow-up.
+
+Restricting either weighting to models with `Positives > 0`
+(`*_PositivesOnly` columns) made no measurable difference in this data —
+zero-positive models are not the main driver of the gap; the weighting
+scheme itself (multiplicative vs. additive combination of class counts)
+is.
+
+### The two aggregates answer different questions — keep both
+
+`AUC_Weighted_ResponseCount` has a clean operational interpretation:
+weighting by `ResponseCount` (= number of decisions) means the result is
+*the average AUC experienced by a randomly picked decision/interaction*.
+That's the right number for "what discriminative power did our deployed
+decisioning actually run at."
+
+`AUC_Weighted_PosNeg` (and `AUC_Weighted_InverseVariance_DeLong`) answer a
+different question: *what's the lowest-noise estimate of typical model
+quality*, by upweighting statistically reliable models and downweighting
+models whose AUC estimate is noisy (regardless of how many decisions they
+served). A model with 10,000 decisions but only 3 positives contributes
+almost nothing to this number, because its AUC estimate is unreliable —
+not because it's operationally unimportant.
+
+Recommendation: report both, explicitly labeled by purpose.
+`ResponseCount`-weighted for business/operational reporting ("what AUC are
+our decisions running at"); `PosNeg`/DeLong-weighted for health-check-style
+diagnostics, trend monitoring, and cross-configuration comparison, where a
+handful of immature models shouldn't swing the number.
+
+### Class imbalance changes which weight is theoretically optimal
+
+The customer data has a strong, consistent class imbalance: `Negatives`
+is typically ~100x `Positives`. Splitting the Hanley-McNeil variance
+formula's three terms by `n_pos * n_neg` and taking `n_neg -> infinity`
+with `n_pos` fixed:
+
+`Var(AUC) -> (Q2 - AUC^2) / n_pos`
+
+i.e. **once negatives are abundant relative to positives, the variance is
+governed almost entirely by `Positives` alone; extra negatives barely
+reduce it further.** This means:
+
+- If the pos:neg ratio is roughly similar across a customer's models,
+  `Positives * Negatives ~ constant * Positives^2`, which weights more
+  aggressively (quadratically) than the theoretically optimal weight
+  (`1/Var ~ Positives`, i.e. linear). `PosNeg` still beats `ResponseCount`
+  by a wide margin empirically (see table above), but a plain
+  **`Positives`-weighted** aggregate is a candidate to test as an even
+  closer, and simpler, DeLong approximation under heavy imbalance.
+- For model **maturity**: this partially vindicates positives-count as
+  the primary signal (matching the existing crude `Positives > 200`
+  heuristic in `Analysis.health_check_maturity_criteria` /
+  `Aggregates.py`'s `isValid` checks), but the threshold itself is
+  arbitrary. A calibrated version would derive the required `Positives`
+  from a target CI half-width `w` via
+  `n_pos ~ (Q2 - AUC^2) / (w / 1.96)^2`, rather than a fixed 200 for
+  every model regardless of its AUC or desired precision.
+
+### Retrofit justification for the existing `Positives > 200` threshold
+
+`Positives > 200` is used widely across Pega (`Analysis.health_check_
+maturity_criteria`, `Aggregates.py`'s `isValid` checks, this batch
+script's `positives_maturity_threshold`) and would be difficult to
+change. Given the class-imbalance finding above, there are two
+independent statistical arguments that retrofit-justify keeping it:
+
+1. **It buys a roughly constant AUC confidence interval, regardless of
+   model quality.** Under `Negatives >> Positives`, `Var(AUC) ~= (Q2 -
+   AUC^2) / n_pos`. Evaluating this at `n_pos = 200` across the AUC range
+   CDH models typically produce:
+
+   | AUC | Var(AUC) | 95% CI half-width (pts) | Full CI width (pts) |
+   |---|---|---|---|
+   | 0.55 | 0.00044 | 4.1 | 8.2 |
+   | 0.65 | 0.00045 | 4.2 | 8.3 |
+   | 0.75 | 0.00040 | 3.9 | 7.9 |
+   | 0.85 | 0.00029 | 3.4 | 6.7 |
+
+   The precision this threshold buys (~+/-4 AUC points, ~8-point full
+   95% CI width) is nearly independent of how good the model actually
+   is — a useful property for a single portfolio-wide threshold. `200`
+   can be presented as "the point count that buys ~+/-4 AUC points of
+   certainty," not an arbitrary round number.
+
+2. **It independently matches the classical "events per variable" rule
+   for stable model fitting.** Peduzzi, Concato, Kemper, Holford &
+   Feinstein (1996, "A simulation study of the number of events per
+   variable in logistic regression analysis", *Journal of Clinical
+   Epidemiology* 49(12)) found that ~10 events per predictor are needed
+   for stable coefficient/log-odds estimates in a binary classifier. A
+   typical NBAD Naive Bayes model with ~15-20 active predictors gives
+   `10 x ~20 = ~200` — the same number, from an entirely different
+   angle (parameter stability rather than AUC estimation precision).
+
+Caveats to state alongside this, so it isn't oversold:
+
+- The "flat across AUC" result specifically depends on `Negatives >>
+  Positives` holding. With a much less extreme imbalance (e.g. 10:1),
+  the negatives term stops being negligible and 200 positives would
+  actually buy *more* precision than the table above — so `200` is a
+  conservative, not overly lax, threshold under less extreme imbalance.
+- It's still a single fixed threshold, not adaptive to a chosen
+  confidence level or a specific model's AUC/predictor count — defensible
+  as "a good round number with real statistical backing," not "the
+  provably optimal choice" (see the calibrated-threshold follow-up
+  above).
+
+### Assessing a prior empirical rule of thumb: `CI ≈ 3.79 / sqrt(Positives)`
+
+A previous internal analysis (also based on DeLong estimators) arrived at
+a rule of thumb `AUC CI ≈ 3.79 * 1/sqrt(Positives)`. The *functional
+form* — inverse-square-root of `Positives` — is exactly what this plan
+derives independently from `Var(AUC) -> (Q2 - AUC^2) / n_pos` under heavy
+imbalance: that's a strong cross-check that the earlier analysis picked
+up the same imbalance-driven effect. The constant `3.79` can't be
+verified from the number alone, though, since it depends on choices not
+recorded alongside it: full- vs. half-width, 0-1 fraction vs. 50-100
+points scale, confidence level, and the AUC value assumed for `Q2 -
+AUC^2` (the true constant is `z * sqrt(Q2 - AUC^2)`, which is fairly
+flat but not literally constant across the 0.55-0.85 AUC range — same
+caveat as the `200` threshold above).
+
+To make this testable rather than guessed at, `_generate_ci_width_plot`
+(shared by the per-dataset and pooled cross-dataset CI plots in
+`batch_healthcheck.py`) now also fits a version of the power law
+constrained to the theoretical slope of `-0.5`, and prints the
+resulting constant on both the 0-1 and Pega points scales. On the next
+full customer-corpus run, check:
+
+1. The free-fit `slope` printed alongside the cross-dataset CI plot —
+   close to `-0.5` confirms the imbalance-driven story empirically.
+2. The constrained `1/sqrt(Positives)` constant — compare it to `3.79`
+   on whichever scale the original rule used. Validated against
+   synthetic data generated with a known slope/constant, this fit
+   recovers the ground truth exactly (slope -0.500, constant recovered
+   to 3 decimal places, R²=1.00), so any mismatch on real data reflects
+   the real customer data, not a fitting artifact.
+
+## Follow-ups (not implemented in this plan)
+
+- Empirically validate `AUC_Weighted_Positives` against the DeLong
+  reference on a fresh full private-customer-corpus run (the Conclusions
+  section above reflects a run from before this column existed). Expect
+  it to track DeLong at least as well as `AUC_Weighted_PosNeg` given the
+  observed ~100x class imbalance; update the Conclusions table once
+  confirmed.
+- Design a CI-width- or `Positives`-derived maturity metric to replace/
+  complement the `Positives > 200` heuristic in
+  `Analysis.health_check_maturity_criteria` and `Aggregates.py`. This
+  touches library code (not just the batch script) and needs its own
+  plan doc if pursued.
+- If the customer-data conclusions hold up, consider changing the
+  library default (`Aggregates.model_summary`, `HealthCheck.qmd`) from
+  `ResponseCount`- to `PosNeg`-weighted AUC roll-up — as a deliberate,
+  separately-reviewed change, not a silent side effect of this
+  investigation.
+- Build an AGB-aware active-range/CI computation (or an alternative
+  variance model that accounts for shared model-fit uncertainty across
+  an AGB model's issue/group/action segments), so the DeLong reference
+  and its agreement validation can be extended to AGB configurations,
+  not just NB. Needs its own design/plan doc — `active_ranges()`'s
+  current log-odds-sum approach is fundamentally NB-specific.

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -1,6 +1,8 @@
 # AUC roll-up weighting: statistical comparison of aggregation methods
 
-Review various weighting techniques for roll up of AUC for both NB and AGB. No functional changes in scope, just reporting in the batch run over client data.
+Review various weighting techniques for roll up of AUC for both NB and AGB.
+No production-library default changes are in scope; the batch run provides
+diagnostic comparisons and the assumptions behind them.
 
 ## Problem
 
@@ -9,20 +11,33 @@ Review various weighting techniques for roll up of AUC for both NB and AGB. No f
 "ResponseCount")` — a response-count-weighted average
 (`Aggregates.model_summary`, `HealthCheck.qmd`, etc.).
 
-Weighting by `ResponseCount = Positives + Negatives` implicitly treats AUC
-like a proportion (e.g. a success rate), where precision scales with
-total trials. AUC is not a proportion — its sampling variance depends on
-*both* class counts multiplicatively, not their sum. A proposed
-alternative is to weight by `Positives * Negatives` instead.
+Weighting by `ResponseCount = Positives + Negatives` treats AUC like a
+proportion (e.g. a success rate), where precision is expected to scale with
+total trials. There is a more direct reason to consider the product. For
+model `i`, let `C_i` be its concordance score (counting tied pairs as
+one-half), and let `n_pos_i` and `n_neg_i` be its class counts. Conventional
+empirical AUC is `AUC_i = C_i / (n_pos_i * n_neg_i)`. Therefore:
+
+`sum(C_i) / sum(n_pos_i * n_neg_i)`
+`= sum((n_pos_i * n_neg_i) * AUC_i) / sum(n_pos_i * n_neg_i)`.
+
+Thus `Positives * Negatives` weighting is exactly the ratio of total
+concordant positive-negative pairs to total eligible positive-negative pairs:
+the AUC of the pooled set of within-model pairs. This is a particularly
+transparent estimand, not merely a heuristic sample-size weight. It is still
+not universally variance-optimal; that depends on the target, independence,
+and the class-count-dependent AUC variance.
 
 ## Statistical grounding
 
-1. **Combining independent estimates.** The classical result for pooling
-   independent unbiased estimates (fixed-effect meta-analysis, Cochran
+1. **Combining independent estimates.** For independent unbiased estimates
+   of one common quantity (the fixed-effect meta-analysis setting, Cochran
    1954, "The Combination of Estimates from Different Experiments",
-   *Biometrics* 10(1)) is that the variance-minimizing weights are
-   proportional to `1 / Var(estimate)` — inverse-variance weighting. Any
-   other weighting scheme is a heuristic approximation to this.
+   *Biometrics* 10(1)), the variance-minimizing weights are proportional to
+   `1 / Var(estimate)` — inverse-variance weighting. If the estimates have
+   different underlying AUCs, the same calculation defines a
+   precision-weighted blend, not an estimate of one shared AUC. Correlation
+   between estimates also changes the optimal weighting and uncertainty.
 
 2. **AUC variance formula.** Hanley & McNeil (1982, "The Meaning and Use
    of the Area under a ROC Curve", *Radiology* 143(1)) give the
@@ -31,48 +46,64 @@ alternative is to weight by `Positives * Negatives` instead.
    `Var(AUC) ≈ [AUC(1-AUC) + (n_pos - 1)(Q1 - AUC²) + (n_neg - 1)(Q2 - AUC²)] / (n_pos * n_neg)`
 
    where `Q1 = AUC / (2 - AUC)` and `Q2 = 2*AUC² / (1 + AUC)`. The
-   denominator is `n_pos * n_neg`, not `n_pos + n_neg`. This is also the
-   basis of the exact nonparametric variance estimator used by DeLong,
+   denominator is `n_pos * n_neg`, but the numerator also grows with the
+   class counts. After expansion, the leading terms are
+   `(Q2 - AUC^2) / n_pos` and `(Q1 - AUC^2) / n_neg`; the residual
+   `1 / (n_pos * n_neg)` term is not generally dominant. `pdstools`
+   implements a grouped-bin DeLong-style variance estimate based on
    DeLong & Clarke-Pearson (1988, "Comparing the Areas under Two or More
    Correlated Receiver Operating Characteristic Curves: A Nonparametric
-   Approach", *Biometrics* 44(3), <https://doi.org/10.2307/2531595>),
-   which `pdstools` already implements in
-   `cdh_utils.auc_variance_delong_grouped` / `auc_ci_from_bincounts`.
+   Approach", *Biometrics* 44(3), <https://doi.org/10.2307/2531595>).
+   Because the inputs are classifier-bin counts, it is an uncertainty
+   estimate for the binned active-range AUC, not a perfect substitute for
+   row-level scores.
 
-3. **Implication.** Since `Var(AUC) ∝ 1 / (n_pos * n_neg)` to first order,
-   weighting by `Positives * Negatives` is a much closer proxy to the
-   variance-optimal inverse-variance weight than weighting by
-   `Positives + Negatives`. The `ResponseCount`-weighted average is the
-   right choice for pooling *proportions* (e.g. `SuccessRate`), but is a
-   statistically weaker choice for pooling AUC.
+3. **Pair-count interpretation.** For conventional empirical AUC in a common
+   score direction, the identity above makes `Positives * Negatives` weighting
+   the exact pair-pooled AUC estimand. It gives each eligible positive-negative
+   pair equal influence, rather than giving each model equal influence or
+   weighting each decision equally. `ResponseCount` remains a valid
+   operational estimand when the desired question is the decision-volume-
+   weighted average of model AUCs; it is not simply an incorrect AUC aggregate.
 
-4. **The rigorous option already exists in-repo.** `pdstools` already
-   computes a DeLong-style AUC variance per model
-   (`ADMDatamart.active_ranges` returns `AUC_ActiveRange` and
-   `AUC_ActiveRange_CI_Variance` from classifier bin counts) and already
-   has a function to combine independent AUC + variance estimates with
-   inverse-variance weights: `cdh_utils.weighted_auc_ci_from_estimates`.
-   So the "gold standard" comparison point — true inverse-variance
-   weighting using DeLong variances — is a small amount of glue code away,
-   not new statistical machinery.
+4. **Variance implication.** `Positives * Negatives` can be a closer proxy to
+   inverse-variance weighting than `Positives + Negatives`, especially when
+   both class counts vary materially. Under strong class imbalance, however,
+   the `1 / n_pos` term dominates and plain `Positives` weighting may be
+   closer. The pair-pooled estimand and the fixed-effect inverse-variance
+   estimand are therefore interpretable but different targets.
+
+5. **A conditional reference already exists in-repo.** `pdstools` computes
+   a grouped-bin DeLong-style variance from classifier counts
+   (`ADMDatamart.active_ranges`) and combines AUC plus variance estimates
+   with inverse-variance weights through
+   `cdh_utils.weighted_auc_ci_from_estimates`. This gives a useful
+   conditional fixed-effect benchmark, not a ground-truth AUC for every
+   configuration. The reference uses the active-range CI estimate, whereas
+   the other methods aggregate the datamart's full-range `Performance`
+   value; that scope difference is part of the observed disagreement.
 
 Conclusion: there are five aggregation methods worth comparing head-to-head
-on real customer data, in increasing order of statistical rigor:
+on the available data, representing different weighting assumptions and data
+requirements:
 
 | # | Method | Weight | Requires |
 |---|--------|--------|----------|
 | a | Naive average | 1 (equal weight per model) | `Performance`, `Configuration` |
 | b | Current (response-count-weighted) | `Positives + Negatives` | same |
-| c | Proposed (pos*neg-weighted) | `Positives * Negatives` | same |
+| c | Pair-pooled (pos*neg-weighted) | `Positives * Negatives` | same |
 | d | Positives-only-weighted | `Positives` | same |
-| e | Inverse-variance (DeLong) | `1 / Var_DeLong(AUC)` | predictor/classifier bin data |
+| e | Conditional inverse-variance (DeLong-style) | `1 / Var_DeLong(AUC)` | predictor/classifier bin data |
 
-(e) is the statistically correct pooling method; (c) and (d) are evaluated
-as cheap proxies that don't require classifier bin data — (d) because
-`Var(AUC) ~= (Q2 - AUC^2) / n_pos` once `Negatives >> Positives` (see
-below), making plain `Positives` weighting a candidate that may track (e)
-even more closely than (c) under heavy class imbalance; (a) and (b) are
-the naive/current baselines being challenged.
+(e) is the minimum-variance fixed-effect combination when the estimates are
+independent and share one target AUC. It is used here as a conditional
+benchmark, not as a universally correct pooling method. Method (c) is the
+exact pair-pooled estimand under the stated conventional-AUC assumptions;
+method (d) is a positive-count-weighted alternative that does not require
+classifier-bin data. Method (d) may track (e) more closely than (c) when
+`Negatives >> Positives` because `Var(AUC) ~= (Q2 - AUC^2) / n_pos` (see
+below). Numerical agreement with (e) does not make the estimands
+interchangeable.
 
 Two supplementary diagnostic variants of (b) and (c) are also reported,
 restricted to models with `Positives > 0`: `AUC_Weighted_ResponseCount_PositivesOnly`
@@ -96,67 +127,69 @@ maturity analysis:
    - Positives`). Filter to `ResponseCount > 0`.
 2. Join in `datamart.active_ranges()` output (`AUC_ActiveRange`,
    `AUC_ActiveRange_CI_Variance`, `AUC_ActiveRange_CI_Available`) for
-   models that have classifier bin data. This reuses the same call
-   already made for CI maturity — no duplicate computation of active
-   ranges.
+   models that have classifier bin data. The call is batched across model
+   IDs, avoiding the much more expensive per-model loop used by the original
+   implementation.
 3. Group by `Configuration` (falling back to all-models-in-one-group if
    `Configuration` isn't present) and compute, per group:
    - `AUC_Naive_Mean` — `pl.col("Performance").mean()`
    - `AUC_Weighted_ResponseCount` — `cdh_utils.weighted_performance_polars()`
      (existing / current behavior)
    - `AUC_Weighted_PosNeg` — `weighted_average_polars("Performance",
-     Positives * Negatives)`
+     Positives * Negatives)`, the pair-pooled AUC estimand when
+     `Performance` is conventional empirical AUC.
    - `AUC_Weighted_Positives` — `weighted_average_polars("Performance",
      Positives)`
    - `AUC_Weighted_InverseVariance_DeLong` — via
      `cdh_utils.weighted_auc_ci_from_estimates(auc=AUC_ActiveRange,
      variance=AUC_ActiveRange_CI_Variance, weights=1/variance)`, restricted
-     to models with `AUC_ActiveRange_CI_Available`. Also report the
-     resulting CI bounds and `N_Models_With_DeLong_CI`.
+     to rows with `AUC_ActiveRange_CI_Available`, taking a configuration-
+     scoped AGB interval only once. Also report the resulting CI bounds and
+     `N_DeLong_Estimates`.
    Also compute the two `_PositivesOnly` diagnostic variants of (b) and
    (c) described above, restricted to models with `Positives > 0`.
 4. Collect one row per `(Dataset, Configuration)` into a list (same
    collector pattern as `ci_maturity_dataset_rows`), write to
    `auc_rollup_comparison.csv` next to the other batch summary outputs at
    the end of `main()`.
-5. No changes to `python/pdstools` library code are anticipated — this is
+5. No production-library behavior changes are anticipated — this is
    analysis/tooling in the batch script only. If the comparison proves the
    pos*neg or inverse-variance approach is superior, a follow-up PR
    changes the library default (`Aggregates.model_summary`,
    `HealthCheck.qmd`, etc.) — out of scope for this plan.
 
-### Phase 2 (done) — run across the private multi-customer dataset
+### Phase 2 (done) — run across the available multi-dataset corpus
 
-Run `scripts/batch_healthcheck.py` over the full private customer corpus,
+Run `scripts/batch_healthcheck.py` over the available corpus,
 inspect `auc_rollup_comparison.csv`:
 
 - How much do (b), (c), (e) disagree from each other and from (a),
   in absolute AUC points, across configurations?
-- Does (c) (cheap proxy) track (e) (rigorous) closely? If yes, (c) is a
-  good practical default even without classifier bin data.
+- Does (c) track (e) closely? If yes, (c) may be a practical alternative
+  even without classifier-bin data.
 - Are there configurations where (b) meaningfully diverges from (c)/(e) —
   e.g. because a low-volume-but-balanced-classes model would be
   under-weighted by (c)/(e) relative to (b), or vice versa for
   high-volume-but-skewed-classes models?
 
-See "Conclusions from the private customer-data run" below for the
+See "Conclusions from the available-corpus run" below for the
 results.
 
 ### Decision: keep the current `ResponseCount`-weighted default for now
 
-`PosNeg` (and plain `Positives`) weighting track the DeLong reference
-much more closely than the current `ResponseCount` weighting (see
-Conclusions below), and are feasible drop-in replacements. **We are not
-changing the library default at this time** — `Aggregates.model_summary`,
-`HealthCheck.qmd`, and `weighted_performance_polars` keep
-`ResponseCount` weighting. Reasons:
+`PosNeg` (and plain `Positives`) weighting track the conditional
+inverse-variance benchmark much more closely than the current
+`ResponseCount` weighting in the available comparison (see Conclusions
+below), and are feasible drop-in replacements. **We are not changing the
+library default at this time** — `Aggregates.model_summary`, `HealthCheck.qmd`,
+and `weighted_performance_polars` keep `ResponseCount` weighting. Reasons:
 
-- The DeLong reference is still NB-only in terms of empirical validation
-  on real customer data (see the AGB caveat below) — the AGB-aware CI
-  computation landed in [PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
-  and `compute_auc_rollup_comparison` was updated to use it correctly,
-  but a fresh full-corpus run to confirm the conclusions hold for AGB
-  configurations hasn't happened yet.
+- The latest run now includes 17 AGB configurations, but that sample is
+  small and the AGB interval still excludes shared model-fit uncertainty
+  (see the AGB caveat below). The AGB-aware CI computation landed in
+  [PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
+  and `compute_auc_rollup_comparison` uses its configuration-scoped estimate
+  once.
 - `ResponseCount`-weighted and `PosNeg`/`Positives`-weighted answer
   different questions (see "The two aggregates answer different
   questions" below) — changing the default isn't just a precision
@@ -176,36 +209,44 @@ not decided here.
   `aggregates.last()` elsewhere in the codebase), not a time-weighted
   roll-up across snapshots.
 - The DeLong/inverse-variance metric is computed on the *active-range*
-  AUC (`AUC_ActiveRange`), which is what `active_ranges()` already
+  AUC (`AUC_ActiveRange_CI_Estimate`), which is what `active_ranges()`
   provides variance for. This is what the existing CI maturity analysis
-  uses too, so it's consistent within the script — but note it's not
-  exactly the same point estimate as `Performance` (datamart-reported
-  AUC from the full classifier range) used for (a)/(b)/(c). Both figures
-  are reported so the disagreement is visible rather than hidden.
+  uses too, so it is consistent within the script — but it is not exactly
+  the same point estimate as `Performance` (datamart-reported AUC from the
+  full classifier range) used for (a)/(b)/(c). Both figures are reported so
+  the disagreement is visible rather than hidden.
+- The pair-count and positive-count identities below apply to conventional
+  raw AUC in a common score direction. Pega's safe-AUC convention reflects
+  values below 0.5, so these are interpretations of the current aggregates
+  rather than algebraic identities for every possible input.
 
-## Conclusions from the private customer-data run
+## Conclusions from the available-corpus run
 
-Ran `scripts/batch_healthcheck.py` across the full private customer
-corpus and analyzed `auc_rollup_comparison.csv` (320 configurations, 234
-with a DeLong estimate pooling >= 5 models) with
+Ran `scripts/batch_healthcheck.py` across the available corpus and analyzed
+`auc_rollup_comparison.csv` (320 configurations, 234
+with a conditional inverse-variance estimate combining >= 5 estimates) with
 `print_auc_rollup_agreement_table` / `generate_auc_rollup_bland_altman_plot`.
-Agreement with the DeLong reference, on the 0-1 AUC scale:
+Agreement with the conditional inverse-variance benchmark, on the 0-1 AUC scale:
 
 | Method | Bias | MAE | RMSE | Pearson r | Lin's CCC |
 |---|---|---|---|---|---|
 | Naive mean | -0.078 | 0.091 | 0.122 | 0.61 | 0.40 |
 | **Current**: ResponseCount-weighted | -0.027 | 0.052 | 0.088 | 0.71 | 0.65 |
-| **Proposed**: PosNeg-weighted | -0.006 | 0.036 | 0.059 | 0.87 | 0.86 |
+| **Pair-pooled**: PosNeg-weighted | -0.006 | 0.036 | 0.059 | 0.87 | 0.86 |
 | Positives-only-weighted | -0.014 | 0.033 | 0.057 | 0.89 | 0.86 |
 
 Plain Pearson r is misleading for this comparison (two methods can
 correlate highly while being systematically offset), so Bias/MAE/RMSE and
 Lin's CCC (which penalizes offset/scale mismatch as well as weak
 correlation) are the metrics that matter. **Conclusion: `Positives *
-Negatives` weighting roughly halves the error against the DeLong
-reference compared to the current `ResponseCount` weighting** (MAE 0.036
-vs. 0.052; CCC 0.86 vs. 0.65), and is a feasible drop-in replacement that
-needs no classifier/predictor bin data.
+Negatives` weighting roughly halves the error against the conditional
+benchmark compared to the current `ResponseCount` weighting** (MAE 0.036
+vs. 0.052; CCC 0.86 vs. 0.65). In addition to this empirical agreement, it
+has a clear interpretation: under conventional common-direction AUC, it is
+the ratio of total concordant pairs to total positive-negative pairs. It is
+therefore a feasible, interpretable pair-pooled alternative that needs no
+classifier/predictor bin data. This is not evidence that `PosNeg` is the
+universally correct aggregate for every operational or statistical target.
 
 **Update from a later full-corpus run (with `AUC_Weighted_Positives`
 added):** plain `Positives` weighting matches `PosNeg` weighting almost
@@ -217,9 +258,10 @@ means the variance-optimal weight is governed almost entirely by
 `Positives`, and multiplying by `Negatives` on top (as `PosNeg` does)
 adds little further discriminative value between models. Either `PosNeg`
 or plain `Positives` weighting is a solid, feasible-to-implement upgrade
-over the current `ResponseCount` weighting; the choice between the two
-comes down to preference for a simpler formula (`Positives` alone) versus
-one that degrades gracefully if the imbalance ratio varies (`PosNeg`).
+over the current `ResponseCount` weighting. `PosNeg` has the more direct
+pair-pooled interpretation; `Positives` is simpler and may approximate the
+conditional inverse-variance weights more closely under stable extreme
+imbalance.
 
 **Update from the fresh full-corpus run following [PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
 (AGB-aware active ranges):** this run is the first where AGB
@@ -228,18 +270,19 @@ now reports a usable CI for 4,588 of 4,611 AGB/GradientBoost model rows
 in the corpus (~99.5%), versus 0 previously. Of the 250
 configurations with a DeLong estimate pooling >= 5 models (up from 234),
 17 are AGB by name heuristic (`*AGB*`/`*Boosting*` in the configuration
-name). Agreement with the DeLong reference, split out:
+name). Agreement with the conditional DeLong-style inverse-variance
+benchmark, split out:
 
 | Method | Scope | Bias | MAE | RMSE | Pearson r | Lin's CCC |
 |---|---|---|---|---|---|---|
 | Naive mean | All (n=250) | -0.082 | 0.094 | 0.125 | 0.62 | 0.40 |
 | ResponseCount-weighted (current) | All (n=250) | -0.032 | 0.055 | 0.091 | 0.71 | 0.64 |
-| PosNeg-weighted (proposed) | All (n=250) | -0.009 | 0.036 | 0.060 | 0.87 | 0.86 |
+| **Pair-pooled**: PosNeg-weighted | All (n=250) | -0.009 | 0.036 | 0.060 | 0.87 | 0.86 |
 | Positives-only-weighted | All (n=250) | -0.019 | 0.037 | 0.065 | 0.86 | 0.83 |
 | ResponseCount-weighted (current) | NB-only (n=233) | -0.029 | 0.054 | 0.091 | 0.69 | 0.62 |
-| PosNeg-weighted (proposed) | NB-only (n=233) | -0.006 | 0.035 | 0.059 | 0.87 | 0.86 |
+| **Pair-pooled**: PosNeg-weighted | NB-only (n=233) | -0.006 | 0.035 | 0.059 | 0.87 | 0.86 |
 | ResponseCount-weighted (current) | AGB-only (n=17) | -0.071 | 0.071 | 0.087 | 0.84 | 0.64 |
-| PosNeg-weighted (proposed) | AGB-only (n=17) | -0.051 | 0.051 | 0.073 | 0.85 | 0.74 |
+| **Pair-pooled**: PosNeg-weighted | AGB-only (n=17) | -0.051 | 0.051 | 0.073 | 0.85 | 0.74 |
 
 The NB-only figures are essentially unchanged from the earlier run
 (same corpus, same 48,105-row NB CI-maturity dataset underneath). The
@@ -247,7 +290,7 @@ new information is the AGB-only row: `PosNeg` still beats
 `ResponseCount` by a wide margin on AGB configurations too (CCC 0.74 vs.
 0.64, smaller bias/MAE/RMSE throughout), consistent with the NB finding,
 but the AGB sample is small (17 configurations) and its agreement with
-the DeLong reference is looser than NB's across every method (e.g. CCC
+the conditional benchmark is looser than NB's across every method (e.g. CCC
 0.74 vs. 0.86 for `PosNeg`) — plausibly reflecting the model-fit
 uncertainty caveat below, which the per-row DeLong variance still does
 not capture even now that a CI is computable.
@@ -255,18 +298,12 @@ not capture even now that a CI is computable.
 ### Caveat: pooling assumptions differ by technique, and the AGB CI still doesn't capture shared model-fit uncertainty
 
 NB and AGB models are architecturally different in a way that matters
-for this whole analysis: **for NB, each action/treatment is a completely
-separate model**, fit independently — the "pool k independent AUC
-estimates" assumption behind Cochran/DeLong inverse-variance weighting
-holds naturally. **For AGB, there is typically one shared model per
-`Configuration` (usually per channel), with issue/group/action splits
-scored from that same shared model** — so the per-`ModelID` rows being
-pooled are correlated segment-level scores of one model, not independent
-models. Per-row DeLong variance (computed from each row's own classifier
-bin counts) captures sampling noise in that segment's outcomes, but not
-the shared model-fit uncertainty common across all of that model's
-segments — so even where available, it likely understates true
-uncertainty for AGB.
+for this analysis. **For NB, each action/treatment is typically a separate
+model**, so the independent-estimate assumption is more plausible, although
+overlapping evaluation data can still induce correlation. **For AGB, there
+is typically one shared model per `Configuration`**, with issue/group/action
+splits scored from that same model. The per-`ModelID` rows are therefore
+correlated segment-level scores, not independent model fits.
 
 In the earlier run analyzed above, this was compounded by a separate
 issue: **every AGB/GradientBoost configuration then observed had
@@ -307,17 +344,21 @@ is.
 
 `AUC_Weighted_ResponseCount` has a clean operational interpretation:
 weighting by `ResponseCount` (= number of decisions) means the result is
-*the average AUC experienced by a randomly picked decision/interaction*.
-That's the right number for "what discriminative power did our deployed
-decisioning actually run at."
+the decision-volume-weighted average of the model AUCs. That's the right
+number for "what discriminative power did our deployed decisioning actually
+run at"; it should not be confused with a row-level AUC recomputed after
+pooling all observations.
 
-`AUC_Weighted_PosNeg` (and `AUC_Weighted_InverseVariance_DeLong`) answer a
-different question: *what's the lowest-noise estimate of typical model
-quality*, by upweighting statistically reliable models and downweighting
-models whose AUC estimate is noisy (regardless of how many decisions they
-served). A model with 10,000 decisions but only 3 positives contributes
-almost nothing to this number, because its AUC estimate is unreliable —
-not because it's operationally unimportant.
+`AUC_Weighted_PosNeg` answers a different question: what is the AUC when all
+eligible within-model positive-negative pairs are pooled, so each pair has
+equal influence? A model contributes in proportion to the number of pairs it
+provides. This is a natural statistical estimand, but it can differ from the
+decision-volume-weighted operational quantity. The conditional
+inverse-variance benchmark answers yet another question: how should
+independent estimates of one common AUC be combined when their uncertainty is
+known? A model with 10,000 decisions but only 3 positives contributes few
+positive-negative pairs and little inverse-variance information — not because
+it is operationally unimportant.
 
 Observation: the two numbers serve different purposes and neither
 supersedes the other. `ResponseCount`-weighted maps to business/operational
@@ -327,9 +368,9 @@ cross-configuration comparison, where a handful of immature models
 shouldn't swing the number. Whether/how to surface both in practice is
 left for a future, separately-scoped decision.
 
-### Class imbalance changes which weight is theoretically optimal
+### Class imbalance changes which proxy is useful
 
-The customer data has a strong, consistent class imbalance: `Negatives`
+The observed data has a strong, consistent class imbalance: `Negatives`
 is typically ~100x `Positives`. Splitting the Hanley-McNeil variance
 formula's three terms by `n_pos * n_neg` and taking `n_neg -> infinity`
 with `n_pos` fixed:
@@ -340,13 +381,15 @@ i.e. **once negatives are abundant relative to positives, the variance is
 governed almost entirely by `Positives` alone; extra negatives barely
 reduce it further.** This means:
 
-- If the pos:neg ratio is roughly similar across a customer's models,
+- If the pos:neg ratio is roughly similar across a deployment's models,
   `Positives * Negatives ~ constant * Positives^2`, which weights more
-  aggressively (quadratically) than the theoretically optimal weight
-  (`1/Var ~ Positives`, i.e. linear). `PosNeg` still beats `ResponseCount`
-  by a wide margin empirically (see table above), but a plain
+  aggressively (quadratically) than the fixed-effect approximation to the
+  inverse-variance weight (`1/Var ~ Positives`, i.e. linear, when AUC is
+  roughly comparable across models). `PosNeg` still beats `ResponseCount`
+  by a wide margin empirically (see table above), while retaining the
+  especially clear pair-pooled interpretation. A plain
   **`Positives`-weighted** aggregate is a candidate to test as an even
-  closer, and simpler, DeLong approximation under heavy imbalance.
+  closer, and simpler, DeLong-style approximation under heavy imbalance.
 - For model **maturity**: this partially vindicates positives-count as
   the primary signal (matching the existing crude `Positives > 200`
   heuristic in `Analysis.health_check_maturity_criteria` /
@@ -413,6 +456,24 @@ NaiveBayes model rows with a usable CI):
 `CI_Width ≈ 2.52 / sqrt(Positives)` (0-1 AUC scale), i.e.
 `CI_Width ≈ 252 / sqrt(Positives)` on Pega's 50-100 points scale.
 
+## Suggested follow-up experiments
+
+- **Common-target simulation:** generate independent model estimates with one
+  known AUC and vary positive/negative counts. Compare mean squared error and
+  confidence-interval coverage for inverse-variance, `PosNeg`, `Positives`,
+  and `ResponseCount` weights.
+- **Heterogeneous-target simulation:** vary the true AUC by model and score
+  each method against its intended estimand: equal-model mean,
+  response-weighted mean, pair-pooled AUC, and precision-weighted mean. This
+  separates numerical agreement from correctness for a stated target.
+- **Correlated-segment simulation:** add a shared model-fit component to AGB
+  segment estimates, then compare naive inverse-variance intervals with
+  configuration-level pooling and cluster/bootstrap intervals. Measure
+  coverage and effective sample size.
+- **Scope-sensitivity analysis:** quantify the gap between full-range
+  `Performance`, segment-level active-range AUC, and configuration-scoped
+  active-range estimates before attributing differences to weighting.
+
 ## Follow-ups (not implemented in this plan)
 
 - Design a CI-width- or `Positives`-derived maturity metric to replace/
@@ -425,7 +486,7 @@ NaiveBayes model rows with a usable CI):
   current `ResponseCount`-weighted default for now" above. Not changing
   it as part of this investigation.
 - **Resolved:** an AGB-aware active-range/CI computation was needed so
-  the DeLong reference and its agreement validation could extend to AGB
+  the conditional inverse-variance benchmark and its agreement validation could extend to AGB
   configurations, not just NB. [PR #947](https://github.com/pegasystems/pega-datascientist-tools/pull/947)
   fixed duplicate-row inflation in the existing calculation, but
   `active_ranges()` still derived reachable scores by summing
@@ -455,8 +516,10 @@ NaiveBayes model rows with a usable CI):
   directly per `Configuration`, instead of re-pooling the same
   configuration-level variance once per segment row (which would have
   double-counted the same evidence and understated the resulting
-  uncertainty). Verified against a synthetic AGB configuration built from
-  the sample dataset.
+  uncertainty). The CSV now reports the number of distinct
+  `N_DeLong_Estimates`, rather than counting repeated AGB segment rows.
+  Verified against a synthetic AGB configuration built from the sample
+  dataset.
 
   **Resolved:** a fresh full-corpus run was performed after PR #948
   landed. AGB configurations are now represented in the empirical
@@ -464,5 +527,5 @@ NaiveBayes model rows with a usable CI):
   agreement table above) — the pos*neg/positives weighting advantage
   over `ResponseCount` observed for NB also holds for AGB in this run,
   though the AGB sample is small (17 configurations) and its overall
-  agreement with the DeLong reference is looser than NB's, consistent
+  agreement with the conditional benchmark is looser than NB's, consistent
   with the still-unresolved shared model-fit-uncertainty caveat.

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -387,9 +387,14 @@ full customer-corpus run, check:
   `ResponseCount`- to `PosNeg`-weighted AUC roll-up — as a deliberate,
   separately-reviewed change, not a silent side effect of this
   investigation.
-- Build an AGB-aware active-range/CI computation (or an alternative
-  variance model that accounts for shared model-fit uncertainty across
-  an AGB model's issue/group/action segments), so the DeLong reference
+- Build an AGB-aware active-range/CI computation, so the DeLong reference
   and its agreement validation can be extended to AGB configurations,
-  not just NB. Needs its own design/plan doc — `active_ranges()`'s
-  current log-odds-sum approach is fundamentally NB-specific.
+  not just NB. [PR #947](https://github.com/pegasystems/pega-datascientist-tools/pull/947)
+  fixed duplicate-row inflation in the existing calculation, but
+  `active_ranges()` still derives reachable scores by summing
+  predictor-bin log odds, which is specific to Naive Bayes and does not
+  represent an AGB tree ensemble. The grouped DeLong helper itself can
+  operate on valid classifier-bin counts, but it does not account for
+  shared model-fit uncertainty across an AGB model's issue/group/action
+  segments. Enabling validated AGB confidence intervals requires a
+  separate design and implementation.

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -355,14 +355,14 @@ Caveats to state alongside this, so it isn't oversold:
   provably optimal choice" (see the calibrated-threshold follow-up
   above).
 
-### Assessing a prior empirical rule of thumb: `CI ≈ 3.79 / sqrt(Positives)`
+### Updating a prior empirical rule of thumb: `CI ≈ 3.79 / sqrt(Positives)`
 
 A previous internal analysis (also based on DeLong estimators) arrived at
 a rule of thumb `AUC CI ≈ 3.79 * 1/sqrt(Positives)`. The *functional
 form* — inverse-square-root of `Positives` — is exactly what this plan
 derives independently from `Var(AUC) -> (Q2 - AUC^2) / n_pos` under heavy
 imbalance: that's a strong cross-check that the earlier analysis picked
-up the same imbalance-driven effect. The constant `3.79` can't be
+up the same imbalance-driven effect. The constant `3.79` couldn't be
 verified from the number alone, though, since it depends on choices not
 recorded alongside it: full- vs. half-width, 0-1 fraction vs. 50-100
 points scale, confidence level, and the AUC value assumed for `Q2 -
@@ -370,21 +370,44 @@ AUC^2` (the true constant is `z * sqrt(Q2 - AUC^2)`, which is fairly
 flat but not literally constant across the 0.55-0.85 AUC range — same
 caveat as the `200` threshold above).
 
-To make this testable rather than guessed at, `_generate_ci_width_plot`
-(shared by the per-dataset and pooled cross-dataset CI plots in
-`batch_healthcheck.py`) now also fits a version of the power law
-constrained to the theoretical slope of `-0.5`, and prints the
-resulting constant on both the 0-1 and Pega points scales. On the next
-full customer-corpus run, check:
+`_generate_ci_width_plot` (shared by the per-dataset and pooled
+cross-dataset CI plots in `batch_healthcheck.py`) fits a version of the
+power law constrained to the theoretical slope of `-0.5`, so this is now
+directly testable rather than guessed at. Validated against synthetic
+data generated with a known slope/constant, this fit recovers the ground
+truth exactly (slope -0.500, constant recovered to 3 decimal places,
+R²=1.00), so any mismatch on real data reflects the real customer data,
+not a fitting artifact.
 
-1. The free-fit `slope` printed alongside the cross-dataset CI plot —
-   close to `-0.5` confirms the imbalance-driven story empirically.
-2. The constrained `1/sqrt(Positives)` constant — compare it to `3.79`
-   on whichever scale the original rule used. Validated against
-   synthetic data generated with a known slope/constant, this fit
-   recovers the ground truth exactly (slope -0.500, constant recovered
-   to 3 decimal places, R²=1.00), so any mismatch on real data reflects
-   the real customer data, not a fitting artifact.
+**Result from `ci_maturity_model_level.csv` (98,160 model rows; 48,105
+NaiveBayes rows with a usable CI — GradientBoost rows currently
+contribute none, see the AGB caveat above):**
+
+- **Free-fit slope: `-0.393` (R²=0.78).** Notably shallower than the
+  theoretical `-0.5` — real CI width shrinks somewhat more slowly than
+  the idealized `1/sqrt(Positives)` law as `Positives` grows, likely
+  because the theory assumes one clean model/AUC value while the real
+  portfolio mixes heterogeneous models, classifier-bin coarseness, and
+  temporal drift. The imbalance-driven direction of the relationship is
+  confirmed; the exact exponent is not a perfect match.
+- **Constrained (`slope = -0.5`) fit constant: `2.520`** on the 0-1 AUC
+  scale, i.e. `CI_Width ≈ 2.520 / sqrt(Positives)` (full width), which is
+  `≈ 252 / sqrt(Positives)` on Pega's 50-100 points scale. At
+  `Positives = 200` that's a ≈17.8-point full CI width — roughly 2x the
+  ≈8-point width the idealized single-model formula predicts (see the
+  retrofit-justification table above), consistent with real portfolios
+  being noisier than the idealized theory.
+
+**Recommendation: replace `3.79` with `2.52`** (0-1 scale) as the current
+best empirical estimate of the constant in `CI ≈ C / sqrt(Positives)` —
+same order of magnitude as the old number (both plausible under the
+scale/definition ambiguity above), but grounded in this corpus and this
+codebase's DeLong CI computation. Given the free-fit slope of `-0.393`,
+though, treat any single-constant `1/sqrt(Positives)` rule as an
+approximation: it will understate uncertainty for very mature
+(high-`Positives`) models and slightly overstate it for less mature ones,
+since the real relationship decays a bit more slowly than the pure
+square-root law.
 
 ## Follow-ups (not implemented in this plan)
 

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -230,7 +230,9 @@ standalone NB model or a correlated segment of a shared AGB model.
 
 A genuine fix (an AGB-aware active-range/CI computation, or a different
 variance model that accounts for shared model-fit uncertainty across
-segments) is out of scope for this plan — noted as a follow-up.
+segments) is out of scope for this plan — see the
+[PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
+follow-up below, which addresses this at the `active_ranges()` level.
 
 Restricting either weighting to models with `Positives > 0`
 (`*_PositivesOnly` columns) made no measurable difference in this data —
@@ -391,10 +393,35 @@ full customer-corpus run, check:
   and its agreement validation can be extended to AGB configurations,
   not just NB. [PR #947](https://github.com/pegasystems/pega-datascientist-tools/pull/947)
   fixed duplicate-row inflation in the existing calculation, but
-  `active_ranges()` still derives reachable scores by summing
+  `active_ranges()` still derived reachable scores by summing
   predictor-bin log odds, which is specific to Naive Bayes and does not
   represent an AGB tree ensemble. The grouped DeLong helper itself can
-  operate on valid classifier-bin counts, but it does not account for
+  operate on valid classifier-bin counts, but it did not account for
   shared model-fit uncertainty across an AGB model's issue/group/action
-  segments. Enabling validated AGB confidence intervals requires a
-  separate design and implementation.
+  segments.
+
+  [PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
+  (about to be merged) addresses this properly: it derives AGB active
+  ranges from occupied classifier bins instead of the NB log-odds
+  reconstruction, and pools classifier-bin counts by `Configuration` so
+  segments sharing one fitted ensemble get a single grouped DeLong
+  interval instead of independent-looking per-segment ones. It adds
+  `AUC_ActiveRange_CI_Estimate` (the pooled interval's center),
+  `AUC_ActiveRange_CI_Scope`, and
+  `AUC_ActiveRange_CI_IncludesModelFitUncertainty` (explicitly `False` —
+  the interval quantifies validation-sample uncertainty conditional on
+  the exported fitted ensemble, not model-fit uncertainty, which can't be
+  identified from a single datamart export), while `AUC_ActiveRange`
+  keeps returning the segment-level AUC for diagnostics.
+
+  Once merged, `compute_auc_rollup_comparison` needs a follow-up change of
+  its own: it currently treats every `ModelID` row's
+  `AUC_ActiveRange_CI_Variance` as an independent estimate and
+  re-pools them per `Configuration` via
+  `weighted_auc_ci_from_estimates`. For AGB, that variance will now
+  already be the *pooled configuration-level* value repeated across every
+  segment row — re-pooling it again would double-count the same evidence
+  and understate the resulting uncertainty. The script should detect
+  already-pooled AGB rows (e.g. via `AUC_ActiveRange_CI_Scope`) and use
+  `AUC_ActiveRange_CI_Estimate`/its variance directly per `Configuration`
+  instead of running inverse-variance pooling across those rows again.

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -3,7 +3,8 @@
 Priority: P2
 
 Files touched: `scripts/batch_healthcheck.py`,
-possibly `python/pdstools/utils/cdh_utils/_metrics.py` (no new library API
+`python/tests/healthcheck/test_batch_healthcheck.py`, possibly
+`python/pdstools/utils/cdh_utils/_metrics.py` (no new library API
 expected — existing functions are sufficient, see below).
 
 ## Problem
@@ -13,12 +14,11 @@ expected — existing functions are sufficient, see below).
 "ResponseCount")` — a response-count-weighted average
 (`Aggregates.model_summary`, `HealthCheck.qmd`, etc.).
 
-A data scientist reviewing this pushed back: weighting by
-`ResponseCount = Positives + Negatives` implicitly treats AUC like a
-proportion (e.g. a success rate), where precision scales with total trials.
-AUC is not a proportion — its sampling variance depends on *both* class
-counts multiplicatively, not their sum. His proposed fix: weight by
-`Positives * Negatives` instead.
+Weighting by `ResponseCount = Positives + Negatives` implicitly treats AUC
+like a proportion (e.g. a success rate), where precision scales with
+total trials. AUC is not a proportion — its sampling variance depends on
+*both* class counts multiplicatively, not their sum. A proposed
+alternative is to weight by `Positives * Negatives` instead.
 
 ## Statistical grounding
 
@@ -69,13 +69,13 @@ on real customer data, in increasing order of statistical rigor:
 | a | Naive average | 1 (equal weight per model) | `Performance`, `Configuration` |
 | b | Current (response-count-weighted) | `Positives + Negatives` | same |
 | c | Proposed (pos*neg-weighted) | `Positives * Negatives` | same |
-| e | Positives-only-weighted | `Positives` | same |
-| d | Inverse-variance (DeLong) | `1 / Var_DeLong(AUC)` | predictor/classifier bin data |
+| d | Positives-only-weighted | `Positives` | same |
+| e | Inverse-variance (DeLong) | `1 / Var_DeLong(AUC)` | predictor/classifier bin data |
 
-(d) is the statistically correct pooling method; (c) and (e) are evaluated
-as cheap proxies that don't require classifier bin data — (e) because
+(e) is the statistically correct pooling method; (c) and (d) are evaluated
+as cheap proxies that don't require classifier bin data — (d) because
 `Var(AUC) ~= (Q2 - AUC^2) / n_pos` once `Negatives >> Positives` (see
-below), making plain `Positives` weighting a candidate that may track (d)
+below), making plain `Positives` weighting a candidate that may track (e)
 even more closely than (c) under heavy class imbalance; (a) and (b) are
 the naive/current baselines being challenged.
 
@@ -83,14 +83,14 @@ Two supplementary diagnostic variants of (b) and (c) are also reported,
 restricted to models with `Positives > 0`: `AUC_Weighted_ResponseCount_PositivesOnly`
 and `AUC_Weighted_PosNeg_PositivesOnly`. Zero-positive models have an
 essentially undefined/uninformative AUC but can carry a large `ResponseCount`,
-so they can pull (b) away from (c)/(d) even though (c)/(d) already give them
+so they can pull (b) away from (c)/(e) even though (c)/(e) already give them
 zero weight. Comparing (b) against its positives-only variant isolates how
-much of the gap to (c)/(d) is explained purely by that exclusion, versus by
+much of the gap to (c)/(e) is explained purely by that exclusion, versus by
 the `Positives * Negatives` vs. `Positives + Negatives` weighting itself.
 
 ## Proposed approach
 
-### Phase 1 — implement the 4-way comparison in `batch_healthcheck.py`
+### Phase 1 — implement the five-way comparison in `batch_healthcheck.py`
 
 Add a new analysis step to `process_dataset()`, alongside the existing CI
 maturity analysis:
@@ -118,6 +118,8 @@ maturity analysis:
      variance=AUC_ActiveRange_CI_Variance, weights=1/variance)`, restricted
      to models with `AUC_ActiveRange_CI_Available`. Also report the
      resulting CI bounds and `N_Models_With_DeLong_CI`.
+   Also compute the two `_PositivesOnly` diagnostic variants of (b) and
+   (c) described above, restricted to models with `Positives > 0`.
 4. Collect one row per `(Dataset, Configuration)` into a list (same
    collector pattern as `ci_maturity_dataset_rows`), write to
    `auc_rollup_comparison.csv` next to the other batch summary outputs at
@@ -133,13 +135,13 @@ maturity analysis:
 Run `scripts/batch_healthcheck.py` over the full private customer corpus,
 inspect `auc_rollup_comparison.csv`:
 
-- How much do (b), (c), (d) disagree from each other and from (a),
+- How much do (b), (c), (e) disagree from each other and from (a),
   in absolute AUC points, across configurations?
-- Does (c) (cheap proxy) track (d) (rigorous) closely? If yes, (c) is a
+- Does (c) (cheap proxy) track (e) (rigorous) closely? If yes, (c) is a
   good practical default even without classifier bin data.
-- Are there configurations where (b) meaningfully diverges from (c)/(d) —
+- Are there configurations where (b) meaningfully diverges from (c)/(e) —
   e.g. because a low-volume-but-balanced-classes model would be
-  under-weighted by (c)/(d) relative to (b), or vice versa for
+  under-weighted by (c)/(e) relative to (b), or vice versa for
   high-volume-but-skewed-classes models?
 
 ### Phase 3 — decide and (if warranted) change the library default

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -178,6 +178,7 @@ Agreement with the DeLong reference, on the 0-1 AUC scale:
 | Naive mean | -0.078 | 0.091 | 0.122 | 0.61 | 0.40 |
 | **Current**: ResponseCount-weighted | -0.027 | 0.052 | 0.088 | 0.71 | 0.65 |
 | **Proposed**: PosNeg-weighted | -0.006 | 0.036 | 0.059 | 0.87 | 0.86 |
+| Positives-only-weighted | -0.014 | 0.033 | 0.057 | 0.89 | 0.86 |
 
 Plain Pearson r is misleading for this comparison (two methods can
 correlate highly while being systematically offset), so Bias/MAE/RMSE and
@@ -187,6 +188,20 @@ Negatives` weighting roughly halves the error against the DeLong
 reference compared to the current `ResponseCount` weighting** (MAE 0.036
 vs. 0.052; CCC 0.86 vs. 0.65), and is a feasible drop-in replacement that
 needs no classifier/predictor bin data.
+
+**Update from a later full-corpus run (with `AUC_Weighted_Positives`
+added):** plain `Positives` weighting matches `PosNeg` weighting almost
+exactly (MAE 0.033 vs. 0.036, CCC 0.86 vs. 0.86 — Positives-only is
+marginally tighter on MAE/RMSE, `PosNeg` has a smaller Bias magnitude).
+This confirms the imbalance-driven prediction above: since
+`Negatives >> Positives` in this data, `Var(AUC) ~= (Q2 - AUC^2) / n_pos`
+means the variance-optimal weight is governed almost entirely by
+`Positives`, and multiplying by `Negatives` on top (as `PosNeg` does)
+adds little further discriminative value between models. Either `PosNeg`
+or plain `Positives` weighting is a solid, feasible-to-implement upgrade
+over the current `ResponseCount` weighting; the choice between the two
+comes down to preference for a simpler formula (`Positives` alone) versus
+one that degrades gracefully if the imbalance ratio varies (`PosNeg`).
 
 ### Caveat: the DeLong reference is currently NB-only, and pooling assumptions differ by technique
 
@@ -373,12 +388,6 @@ full customer-corpus run, check:
 
 ## Follow-ups (not implemented in this plan)
 
-- Empirically validate `AUC_Weighted_Positives` against the DeLong
-  reference on a fresh full private-customer-corpus run (the Conclusions
-  section above reflects a run from before this column existed). Expect
-  it to track DeLong at least as well as `AUC_Weighted_PosNeg` given the
-  observed ~100x class imbalance; update the Conclusions table once
-  confirmed.
 - Design a CI-width- or `Positives`-derived maturity metric to replace/
   complement the `Positives > 200` heuristic in
   `Analysis.health_check_maturity_criteria` and `Aggregates.py`. This

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -221,7 +221,38 @@ over the current `ResponseCount` weighting; the choice between the two
 comes down to preference for a simpler formula (`Positives` alone) versus
 one that degrades gracefully if the imbalance ratio varies (`PosNeg`).
 
-### Caveat: the DeLong reference is currently NB-only, and pooling assumptions differ by technique
+**Update from the fresh full-corpus run following [PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
+(AGB-aware active ranges):** this run is the first where AGB
+configurations contribute a DeLong estimate at all — `active_ranges()`
+now reports a usable CI for 4,588 of 4,611 AGB/GradientBoost model rows
+in the corpus (~99.5%), versus 0 previously. Of the 250
+configurations with a DeLong estimate pooling >= 5 models (up from 234),
+17 are AGB by name heuristic (`*AGB*`/`*Boosting*` in the configuration
+name). Agreement with the DeLong reference, split out:
+
+| Method | Scope | Bias | MAE | RMSE | Pearson r | Lin's CCC |
+|---|---|---|---|---|---|---|
+| Naive mean | All (n=250) | -0.082 | 0.094 | 0.125 | 0.62 | 0.40 |
+| ResponseCount-weighted (current) | All (n=250) | -0.032 | 0.055 | 0.091 | 0.71 | 0.64 |
+| PosNeg-weighted (proposed) | All (n=250) | -0.009 | 0.036 | 0.060 | 0.87 | 0.86 |
+| Positives-only-weighted | All (n=250) | -0.019 | 0.037 | 0.065 | 0.86 | 0.83 |
+| ResponseCount-weighted (current) | NB-only (n=233) | -0.029 | 0.054 | 0.091 | 0.69 | 0.62 |
+| PosNeg-weighted (proposed) | NB-only (n=233) | -0.006 | 0.035 | 0.059 | 0.87 | 0.86 |
+| ResponseCount-weighted (current) | AGB-only (n=17) | -0.071 | 0.071 | 0.087 | 0.84 | 0.64 |
+| PosNeg-weighted (proposed) | AGB-only (n=17) | -0.051 | 0.051 | 0.073 | 0.85 | 0.74 |
+
+The NB-only figures are essentially unchanged from the earlier run
+(same corpus, same 48,105-row NB CI-maturity dataset underneath). The
+new information is the AGB-only row: `PosNeg` still beats
+`ResponseCount` by a wide margin on AGB configurations too (CCC 0.74 vs.
+0.64, smaller bias/MAE/RMSE throughout), consistent with the NB finding,
+but the AGB sample is small (17 configurations) and its agreement with
+the DeLong reference is looser than NB's across every method (e.g. CCC
+0.74 vs. 0.86 for `PosNeg`) — plausibly reflecting the model-fit
+uncertainty caveat below, which the per-row DeLong variance still does
+not capture even now that a CI is computable.
+
+### Caveat: pooling assumptions differ by technique, and the AGB CI still doesn't capture shared model-fit uncertainty
 
 NB and AGB models are architecturally different in a way that matters
 for this whole analysis: **for NB, each action/treatment is a completely
@@ -237,35 +268,34 @@ the shared model-fit uncertainty common across all of that model's
 segments — so even where available, it likely understates true
 uncertainty for AGB.
 
-In practice it usually isn't even available: **every AGB/GradientBoost
-configuration observed in the private customer-data run had
-`N_Models_With_DeLong_CI = 0`** (`*_AGB` configs, `BoostingModel_*`,
-etc.). Root cause: `ADMDatamart._minMaxScoresPerModel` (which
-`active_ranges()` and therefore the DeLong CI machinery depends on)
-computes a model's reachable score range as the sum of each active
-predictor's log-odds min/max — the Naive Bayes score formula. AGB's
-score isn't a sum of independent per-predictor log-odds contributions
-(tree splits interact nonlinearly), so this computation structurally
-cannot produce a meaningful active range for AGB models; `AUC_ActiveRange`
-and its CI end up null.
+In the earlier run analyzed above, this was compounded by a separate
+issue: **every AGB/GradientBoost configuration then observed had
+`N_Models_With_DeLong_CI = 0`**, because `ADMDatamart._minMaxScoresPerModel`
+(which `active_ranges()` depended on) computed a model's reachable score
+range as the sum of each active predictor's log-odds min/max — the
+Naive Bayes score formula, which doesn't apply to AGB's tree ensemble.
+[PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
+fixed this by deriving AGB active ranges from occupied classifier bins
+instead, and pooling classifier-bin counts by `Configuration` so that
+segments sharing one fitted ensemble get a single grouped DeLong interval.
+The fresh full-corpus run above confirms the fix works at scale (~99.5%
+of AGB rows now get a usable CI), which is what makes the AGB-only
+agreement row above possible for the first time.
 
-**Consequence: the agreement table and Bland-Altman plot above are
-implicitly NB-only.** AGB configurations contribute nothing to the
-"eligible" (DeLong-available) comparison set — not because AGB agrees or
-disagrees with the DeLong reference, but because DeLong currently can't
-be computed for AGB at all with `active_ranges()`. Whether `PosNeg`
-weighting is a good DeLong proxy for AGB models remains unvalidated.
+What PR #948 does **not** resolve is the shared model-fit uncertainty
+issue: the pooled AGB interval (`AUC_ActiveRange_CI_Estimate`) quantifies
+validation-sample uncertainty conditional on the exported fitted
+ensemble, not model-fit uncertainty, which can't be identified from a
+single datamart export (`AUC_ActiveRange_CI_IncludesModelFitUncertainty`
+is explicitly `False`). So even with a computable CI, the AGB DeLong
+reference likely still understates true uncertainty relative to NB's,
+which may partly explain why every method's agreement with the DeLong
+reference is looser on AGB than on NB in the table above.
 
 This does **not** affect the `Positives > 200` maturity discussion below:
 that reasoning is about the precision of a single AUC estimate from its
 own bin counts, which applies the same way whether the row is a
 standalone NB model or a correlated segment of a shared AGB model.
-
-A genuine fix (an AGB-aware active-range/CI computation, or a different
-variance model that accounts for shared model-fit uncertainty across
-segments) is out of scope for this plan — see the
-[PR #948](https://github.com/pegasystems/pega-datascientist-tools/pull/948)
-follow-up below, which addresses this at the `active_ranges()` level.
 
 Restricting either weighting to models with `Positives > 0`
 (`*_PositivesOnly` columns) made no measurable difference in this data —
@@ -428,8 +458,11 @@ NaiveBayes model rows with a usable CI):
   uncertainty). Verified against a synthetic AGB configuration built from
   the sample dataset.
 
-  **Still open:** the conclusions in this doc were validated on
-  customer data collected before PR #948 landed, so AGB configurations
-  are not yet represented in the empirical Bland-Altman/agreement
-  results above. A fresh full-corpus run is needed to confirm the
-  weighting-scheme conclusions hold for AGB too.
+  **Resolved:** a fresh full-corpus run was performed after PR #948
+  landed. AGB configurations are now represented in the empirical
+  Bland-Altman/agreement results (see the AGB-only row in the updated
+  agreement table above) — the pos*neg/positives weighting advantage
+  over `ResponseCount` observed for NB also holds for AGB in this run,
+  though the AGB sample is small (17 configurations) and its overall
+  agreement with the DeLong reference is looser than NB's, consistent
+  with the still-unresolved shared model-fit-uncertainty caveat.

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -355,59 +355,17 @@ Caveats to state alongside this, so it isn't oversold:
   provably optimal choice" (see the calibrated-threshold follow-up
   above).
 
-### Updating a prior empirical rule of thumb: `CI ≈ 3.79 / sqrt(Positives)`
+### Simple CI-vs-Positives formula
 
-A previous internal analysis (also based on DeLong estimators) arrived at
-a rule of thumb `AUC CI ≈ 3.79 * 1/sqrt(Positives)`. The *functional
-form* — inverse-square-root of `Positives` — is exactly what this plan
-derives independently from `Var(AUC) -> (Q2 - AUC^2) / n_pos` under heavy
-imbalance: that's a strong cross-check that the earlier analysis picked
-up the same imbalance-driven effect. The constant `3.79` couldn't be
-verified from the number alone, though, since it depends on choices not
-recorded alongside it: full- vs. half-width, 0-1 fraction vs. 50-100
-points scale, confidence level, and the AUC value assumed for `Q2 -
-AUC^2` (the true constant is `z * sqrt(Q2 - AUC^2)`, which is fairly
-flat but not literally constant across the 0.55-0.85 AUC range — same
-caveat as the `200` threshold above).
+Empirically, on this corpus (`ci_maturity_model_level.csv`, 48,105
+NaiveBayes model rows with a usable CI):
 
-`_generate_ci_width_plot` (shared by the per-dataset and pooled
-cross-dataset CI plots in `batch_healthcheck.py`) fits a version of the
-power law constrained to the theoretical slope of `-0.5`, so this is now
-directly testable rather than guessed at. Validated against synthetic
-data generated with a known slope/constant, this fit recovers the ground
-truth exactly (slope -0.500, constant recovered to 3 decimal places,
-R²=1.00), so any mismatch on real data reflects the real customer data,
-not a fitting artifact.
+`CI_Width ≈ 2.52 / sqrt(Positives)` (0-1 AUC scale), i.e.
+`CI_Width ≈ 252 / sqrt(Positives)` on Pega's 50-100 points scale.
 
-**Result from `ci_maturity_model_level.csv` (98,160 model rows; 48,105
-NaiveBayes rows with a usable CI — GradientBoost rows currently
-contribute none, see the AGB caveat above):**
-
-- **Free-fit slope: `-0.393` (R²=0.78).** Notably shallower than the
-  theoretical `-0.5` — real CI width shrinks somewhat more slowly than
-  the idealized `1/sqrt(Positives)` law as `Positives` grows, likely
-  because the theory assumes one clean model/AUC value while the real
-  portfolio mixes heterogeneous models, classifier-bin coarseness, and
-  temporal drift. The imbalance-driven direction of the relationship is
-  confirmed; the exact exponent is not a perfect match.
-- **Constrained (`slope = -0.5`) fit constant: `2.520`** on the 0-1 AUC
-  scale, i.e. `CI_Width ≈ 2.520 / sqrt(Positives)` (full width), which is
-  `≈ 252 / sqrt(Positives)` on Pega's 50-100 points scale. At
-  `Positives = 200` that's a ≈17.8-point full CI width — roughly 2x the
-  ≈8-point width the idealized single-model formula predicts (see the
-  retrofit-justification table above), consistent with real portfolios
-  being noisier than the idealized theory.
-
-**Recommendation: replace `3.79` with `2.52`** (0-1 scale) as the current
-best empirical estimate of the constant in `CI ≈ C / sqrt(Positives)` —
-same order of magnitude as the old number (both plausible under the
-scale/definition ambiguity above), but grounded in this corpus and this
-codebase's DeLong CI computation. Given the free-fit slope of `-0.393`,
-though, treat any single-constant `1/sqrt(Positives)` rule as an
-approximation: it will understate uncertainty for very mature
-(high-`Positives`) models and slightly overstate it for less mature ones,
-since the real relationship decays a bit more slowly than the pure
-square-root law.
+This replaces an earlier rule of thumb of `3.79 / sqrt(Positives)` with a
+constant fit directly from this codebase's DeLong CI computation. Same
+`1/sqrt(Positives)` functional form as before, just an updated constant.
 
 ## Follow-ups (not implemented in this plan)
 

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -363,10 +363,6 @@ NaiveBayes model rows with a usable CI):
 `CI_Width ≈ 2.52 / sqrt(Positives)` (0-1 AUC scale), i.e.
 `CI_Width ≈ 252 / sqrt(Positives)` on Pega's 50-100 points scale.
 
-This replaces an earlier rule of thumb of `3.79 / sqrt(Positives)` with a
-constant fit directly from this codebase's DeLong CI computation. Same
-`1/sqrt(Positives)` functional form as before, just an updated constant.
-
 ## Follow-ups (not implemented in this plan)
 
 - Design a CI-width- or `Positives`-derived maturity metric to replace/

--- a/docs/plans/adm/auc-rollup-weighting.md
+++ b/docs/plans/adm/auc-rollup-weighting.md
@@ -273,7 +273,7 @@ zero-positive models are not the main driver of the gap; the weighting
 scheme itself (multiplicative vs. additive combination of class counts)
 is.
 
-### The two aggregates answer different questions — keep both
+### The two aggregates answer different questions
 
 `AUC_Weighted_ResponseCount` has a clean operational interpretation:
 weighting by `ResponseCount` (= number of decisions) means the result is
@@ -289,11 +289,13 @@ served). A model with 10,000 decisions but only 3 positives contributes
 almost nothing to this number, because its AUC estimate is unreliable —
 not because it's operationally unimportant.
 
-Recommendation: report both, explicitly labeled by purpose.
-`ResponseCount`-weighted for business/operational reporting ("what AUC are
-our decisions running at"); `PosNeg`/DeLong-weighted for health-check-style
-diagnostics, trend monitoring, and cross-configuration comparison, where a
-handful of immature models shouldn't swing the number.
+Observation: the two numbers serve different purposes and neither
+supersedes the other. `ResponseCount`-weighted maps to business/operational
+reporting ("what AUC are our decisions running at"); `PosNeg`/DeLong-weighted
+maps to health-check-style diagnostics, trend monitoring, and
+cross-configuration comparison, where a handful of immature models
+shouldn't swing the number. Whether/how to surface both in practice is
+left for a future, separately-scoped decision.
 
 ### Class imbalance changes which weight is theoretically optimal
 

--- a/python/pdstools/data_quality/_compute.py
+++ b/python/pdstools/data_quality/_compute.py
@@ -217,7 +217,10 @@ class Compute(LazyNamespace):
 
         # Out-of-sample predicted probabilities via cross-validation
         model = LogisticRegression(max_iter=400)
-        pred_probs = cross_val_predict(model, embeddings, labels, cv=cv, method="predict_proba")
+        pred_probs = cast(
+            "np.ndarray[Any, Any]",
+            cross_val_predict(model, embeddings, labels, cv=cv, method="predict_proba"),
+        )
 
         # Cleanlab Datalab audit
         data_dict = {"texts": texts, "labels": labels}

--- a/python/pdstools/utils/cdh_utils/_metrics.py
+++ b/python/pdstools/utils/cdh_utils/_metrics.py
@@ -456,17 +456,17 @@ def weighted_auc_ci_from_estimates(
     *,
     confidence_level: float = 0.95,
 ) -> dict[str, float | bool | str | None]:
-    """Combine independent model-level AUC estimates with response weights.
+    """Combine independent model-level AUC estimates with supplied weights.
 
     The returned interval describes the uncertainty of a weighted average of
     model-level estimates. It is not a confidence interval for AUC computed
     from pooled observations.
 
-    The weighted estimate uses normalized response-count-style weights. Under
-    the independence assumption, its variance is the sum of each model
-    variance multiplied by the square of its normalized weight. AUC and
-    confidence bounds are returned on the conventional 0-to-1 scale. The
-    point estimates have already been normalized with ``safe_range_auc``.
+    The weighted estimate uses normalized supplied weights. Under the
+    independence assumption, its variance is the sum of each model variance
+    multiplied by the square of its normalized weight. AUC and confidence
+    bounds are returned on the conventional 0-to-1 scale. The point estimates
+    have already been normalized with ``safe_range_auc``.
     The ``safe_ci_lower`` and ``safe_ci_upper`` fields apply the same safe
     AUC convention to the confidence interval for Pega-style display.
 

--- a/python/tests/healthcheck/test_batch_healthcheck.py
+++ b/python/tests/healthcheck/test_batch_healthcheck.py
@@ -86,6 +86,48 @@ def test_select_interesting_models_excludes_empty_active_ranges():
     assert batch.select_interesting_models(datamart) == ["valid"]
 
 
+def test_compute_auc_rollup_comparison_counts_one_estimate_for_pooled_agb_ci():
+    datamart = MagicMock()
+    datamart.model_data = pl.LazyFrame({"ModelID": ["m1", "m2", "m3"]})
+    datamart.predictor_data = pl.LazyFrame(
+        {
+            "ModelID": ["m1", "m2", "m3"],
+            "EntryType": ["Classifier", "Classifier", "Classifier"],
+        }
+    )
+    datamart.aggregates.last.return_value = pl.LazyFrame(
+        {
+            "ModelID": ["m1", "m2", "m3"],
+            "Configuration": ["config"] * 3,
+            "Performance": [0.61, 0.72, 0.83],
+            "Positives": [100, 200, 300],
+            "ResponseCount": [1000, 2000, 3000],
+        }
+    )
+    datamart.active_ranges.return_value = pl.LazyFrame(
+        {
+            "ModelID": ["m1", "m2", "m3"],
+            "AUC_ActiveRange": [0.61, 0.72, 0.83],
+            "AUC_ActiveRange_CI_Variance": [0.01, 0.02, 0.03],
+            "AUC_ActiveRange_CI_Estimate": [0.74, 0.74, 0.74],
+            "AUC_ActiveRange_CI_Scope": ["configuration"] * 3,
+            "AUC_ActiveRange_CI_Available": [True, True, True],
+        }
+    )
+
+    result = batch.compute_auc_rollup_comparison(datamart)
+
+    assert result.select("Configuration", "N_DeLong_Estimates").to_dicts() == [
+        {"Configuration": "config", "N_DeLong_Estimates": 1}
+    ]
+    pair_counts = [100 * 900, 200 * 1800, 300 * 2700]
+    expected_pair_pooled_auc = sum(
+        auc * pair_count for auc, pair_count in zip([0.61, 0.72, 0.83], pair_counts, strict=True)
+    ) / sum(pair_counts)
+    assert result["AUC_Weighted_PosNeg"][0] == pytest.approx(expected_pair_pooled_auc)
+    assert result["AUC_Weighted_InverseVariance_DeLong"][0] == pytest.approx(0.74)
+
+
 def test_print_dataset_paths_omits_missing_optional_files(capsys):
     batch._print_dataset_paths(
         {

--- a/python/tests/healthcheck/test_batch_healthcheck.py
+++ b/python/tests/healthcheck/test_batch_healthcheck.py
@@ -413,19 +413,30 @@ def test_compute_ci_maturity_analysis_retains_rows_when_ci_fails_for_some_models
         }
     )
 
-    def active_ranges_side_effect(model_id):
-        if model_id == "m1":
-            return pl.LazyFrame(
-                {
-                    "ModelID": ["m1"],
-                    "AUC_ActiveRange": [0.72],
-                    "AUC_ActiveRange_CI_Lower": [0.69],
-                    "AUC_ActiveRange_CI_Upper": [0.75],
-                    "AUC_ActiveRange_CI_Available": [True],
-                    "AUC_ActiveRange_CI_Reason": [None],
-                }
-            )
-        raise ValueError("pos and neg must be non-empty")
+    def active_ranges_side_effect(model_ids):
+        rows = {
+            "m1": {
+                "AUC_ActiveRange": 0.72,
+                "AUC_ActiveRange_CI_Lower": 0.69,
+                "AUC_ActiveRange_CI_Upper": 0.75,
+                "AUC_ActiveRange_CI_Available": True,
+                "AUC_ActiveRange_CI_Reason": None,
+            },
+            "m2": {
+                "AUC_ActiveRange": None,
+                "AUC_ActiveRange_CI_Lower": None,
+                "AUC_ActiveRange_CI_Upper": None,
+                "AUC_ActiveRange_CI_Available": False,
+                "AUC_ActiveRange_CI_Reason": "analysis_error",
+            },
+        }
+        selected = [rows[model_id] for model_id in model_ids]
+        return pl.LazyFrame(
+            {
+                "ModelID": list(model_ids),
+                **{key: [row[key] for row in selected] for key in rows["m1"]},
+            }
+        )
 
     datamart.active_ranges.side_effect = active_ranges_side_effect
 
@@ -463,15 +474,15 @@ def test_compute_ci_maturity_analysis_splits_agb_and_defaults_missing_technique(
         }
     )
 
-    def active_ranges(model_id):
+    def active_ranges(model_ids):
         return pl.LazyFrame(
             {
-                "ModelID": [model_id],
-                "AUC_ActiveRange": [0.7],
-                "AUC_ActiveRange_CI_Lower": [0.65],
-                "AUC_ActiveRange_CI_Upper": [0.75],
-                "AUC_ActiveRange_CI_Available": [True],
-                "AUC_ActiveRange_CI_Reason": [None],
+                "ModelID": list(model_ids),
+                "AUC_ActiveRange": [0.7] * len(model_ids),
+                "AUC_ActiveRange_CI_Lower": [0.65] * len(model_ids),
+                "AUC_ActiveRange_CI_Upper": [0.75] * len(model_ids),
+                "AUC_ActiveRange_CI_Available": [True] * len(model_ids),
+                "AUC_ActiveRange_CI_Reason": [None] * len(model_ids),
             }
         )
 

--- a/python/tests/healthcheck/test_batch_healthcheck.py
+++ b/python/tests/healthcheck/test_batch_healthcheck.py
@@ -218,6 +218,7 @@ def test_main_defaults_to_per_dataset_output(tmp_path, monkeypatch):
         positives_maturity_threshold=200,
         ci_maturity_dataset_rows=[],
         ci_maturity_model_rows=[],
+        auc_rollup_rows=[],
     )
     assert (tmp_path / "summary.csv").exists()
 

--- a/scripts/batch_healthcheck.py
+++ b/scripts/batch_healthcheck.py
@@ -46,9 +46,11 @@ import traceback
 import zipfile
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import cast
 
 import polars as pl
 from pdstools import ADMDatamart, Prediction
+from pdstools.utils import cdh_utils
 from pdstools.utils.report_utils import check_report_for_errors, is_esbuild_available
 
 # Default file name patterns
@@ -444,7 +446,10 @@ def _compute_ci_maturity_analysis(
         corr_df = ci_non_null.select("Positives", "CI_Width")
         spearman = None
         if corr_df.height >= 2:
-            corr = np.corrcoef(corr_df["Positives"].rank().to_numpy(), corr_df["CI_Width"].rank().to_numpy())[0, 1]
+            # A constant column (zero stddev) makes corrcoef divide by zero and
+            # return NaN, which is already handled below via np.isfinite.
+            with np.errstate(invalid="ignore", divide="ignore"):
+                corr = np.corrcoef(corr_df["Positives"].rank().to_numpy(), corr_df["CI_Width"].rank().to_numpy())[0, 1]
             if np.isfinite(corr):
                 spearman = float(corr)
         metrics.update(
@@ -493,6 +498,321 @@ def _compute_ci_maturity_analysis(
     )
 
     return metrics, model_level
+
+
+def compute_auc_rollup_comparison(datamart: ADMDatamart) -> pl.DataFrame:
+    """Compare AUC roll-up weighting schemes per model configuration.
+
+    Reports, for each ``Configuration``, the per-model AUC aggregated with
+    seven weighting schemes: an unweighted (naive) average, the current
+    ResponseCount-weighted average, a Positives*Negatives-weighted average,
+    a Positives-only-weighted average (a closer DeLong approximation than
+    Positives*Negatives when Negatives >> Positives, since AUC variance is
+    then governed almost entirely by Positives; see
+    docs/plans/adm/auc-rollup-weighting.md), the same weighted averages
+    restricted to models with at least one positive (a cheap way to check
+    whether zero-positive models are what drives the response-count-weighted
+    average away from the others), and a DeLong inverse-variance-weighted
+    average (the statistically optimal way to pool independent AUC
+    estimates).
+
+    Parameters
+    ----------
+    datamart : ADMDatamart
+        The loaded datamart
+
+    Returns
+    -------
+    pl.DataFrame
+        One row per Configuration with the aggregated AUC values.
+    """
+    if datamart.model_data is None:
+        return pl.DataFrame()
+
+    per_model = (
+        datamart.aggregates.last()
+        .filter(pl.col("ResponseCount") > 0)
+        .select(
+            "ModelID",
+            "Configuration",
+            "Performance",
+            "Positives",
+            "ResponseCount",
+        )
+        .with_columns(Negatives=pl.col("ResponseCount") - pl.col("Positives"))
+        .collect()
+    )
+    if per_model.height == 0:
+        return pl.DataFrame()
+
+    if datamart.predictor_data is not None:
+        classifier_model_ids = _active_classifier_model_ids(datamart)
+        variance_model_ids = list(set(per_model["ModelID"]) & classifier_model_ids)
+    else:
+        variance_model_ids = []
+
+    if variance_model_ids:
+        active_range = (
+            datamart.active_ranges(variance_model_ids)
+            .filter(pl.col("AUC_ActiveRange_CI_Available"))
+            .select("ModelID", "AUC_ActiveRange", "AUC_ActiveRange_CI_Variance")
+            .collect()
+        )
+        per_model = per_model.join(active_range, on="ModelID", how="left")
+    else:
+        per_model = per_model.with_columns(
+            pl.lit(None, dtype=pl.Float64).alias("AUC_ActiveRange"),
+            pl.lit(None, dtype=pl.Float64).alias("AUC_ActiveRange_CI_Variance"),
+        )
+
+    rows = []
+    for (configuration,), group in per_model.group_by("Configuration", maintain_order=True):
+        naive_mean = cast(float, group.select(pl.col("Performance").cast(pl.Float64).mean()).item())
+        weighted_response_count = float(group.select(cdh_utils.weighted_performance_polars()).item())
+        weighted_pos_neg = float(
+            group.select(
+                cdh_utils.weighted_average_polars("Performance", pl.col("Positives") * pl.col("Negatives"))
+            ).item()
+        )
+        weighted_positives = float(group.select(cdh_utils.weighted_average_polars("Performance", "Positives")).item())
+
+        positives_group = group.filter(pl.col("Positives") > 0)
+        if positives_group.height > 0:
+            weighted_response_count_pos_only = float(
+                positives_group.select(cdh_utils.weighted_performance_polars()).item()
+            )
+            weighted_pos_neg_pos_only = float(
+                positives_group.select(
+                    cdh_utils.weighted_average_polars("Performance", pl.col("Positives") * pl.col("Negatives"))
+                ).item()
+            )
+        else:
+            weighted_response_count_pos_only = None
+            weighted_pos_neg_pos_only = None
+
+        variance_group = group.filter(
+            pl.col("AUC_ActiveRange_CI_Variance").is_not_null() & (pl.col("AUC_ActiveRange_CI_Variance") > 0)
+        )
+        inverse_variance_result = (
+            cdh_utils.weighted_auc_ci_from_estimates(
+                auc=variance_group["AUC_ActiveRange"],
+                variance=variance_group["AUC_ActiveRange_CI_Variance"],
+                weights=1.0 / variance_group["AUC_ActiveRange_CI_Variance"],
+            )
+            if variance_group.height > 0
+            else {"auc": None, "ci_lower": None, "ci_upper": None}
+        )
+
+        rows.append(
+            {
+                "Configuration": configuration,
+                "N_Models": group.height,
+                "AUC_Naive_Mean": naive_mean,
+                "AUC_Weighted_ResponseCount": weighted_response_count,
+                "AUC_Weighted_PosNeg": weighted_pos_neg,
+                "AUC_Weighted_Positives": weighted_positives,
+                "N_Models_With_Positives": positives_group.height,
+                "AUC_Weighted_ResponseCount_PositivesOnly": weighted_response_count_pos_only,
+                "AUC_Weighted_PosNeg_PositivesOnly": weighted_pos_neg_pos_only,
+                "N_Models_With_DeLong_CI": variance_group.height,
+                "AUC_Weighted_InverseVariance_DeLong": inverse_variance_result["auc"],
+                "AUC_InverseVariance_DeLong_CI_Lower": inverse_variance_result["ci_lower"],
+                "AUC_InverseVariance_DeLong_CI_Upper": inverse_variance_result["ci_upper"],
+            }
+        )
+
+    return pl.DataFrame(rows)
+
+
+def _print_auc_rollup_table(df: pl.DataFrame) -> None:
+    """Print a compact per-configuration AUC roll-up comparison table."""
+    if df.height == 0:
+        return
+    print("  AUC roll-up comparison (Pega 50-100 scale):")
+    display_df = df.sort("Configuration").select(
+        pl.col("Configuration"),
+        pl.col("N_Models").alias("N"),
+        pl.col("N_Models_With_Positives").alias("N_pos"),
+        (pl.col("AUC_Naive_Mean") * 100).round(1).alias("Naive"),
+        (pl.col("AUC_Weighted_ResponseCount") * 100).round(1).alias("RespCnt"),
+        (pl.col("AUC_Weighted_PosNeg") * 100).round(1).alias("PosNeg"),
+        (pl.col("AUC_Weighted_Positives") * 100).round(1).alias("Positives"),
+        (pl.col("AUC_Weighted_ResponseCount_PositivesOnly") * 100).round(1).alias("RespCnt+"),
+        (pl.col("AUC_Weighted_PosNeg_PositivesOnly") * 100).round(1).alias("PosNeg+"),
+        (pl.col("AUC_Weighted_InverseVariance_DeLong") * 100).round(1).alias("DeLong"),
+        pl.col("N_Models_With_DeLong_CI").alias("N_DeLong"),
+    )
+    with pl.Config(tbl_rows=-1, tbl_cols=-1, tbl_width_chars=-1, fmt_str_lengths=40):
+        print(display_df)
+
+
+# Reference method: the statistically correct pooling of independent AUC
+# estimates (see docs/plans/adm/auc-rollup-weighting.md). All other
+# aggregation methods are compared against it below.
+AUC_ROLLUP_REFERENCE_COLUMN = "AUC_Weighted_InverseVariance_DeLong"
+AUC_ROLLUP_CANDIDATE_COLUMNS = [
+    "AUC_Weighted_ResponseCount",
+    "AUC_Weighted_PosNeg",
+    "AUC_Weighted_Positives",
+    "AUC_Weighted_ResponseCount_PositivesOnly",
+    "AUC_Weighted_PosNeg_PositivesOnly",
+    "AUC_Naive_Mean",
+]
+
+
+def _lin_ccc(x, y) -> float:
+    """Lin's concordance correlation coefficient between x and y.
+
+    Unlike Pearson r, this drops when two series are highly correlated but
+    systematically offset or differently scaled, which is what "how good an
+    approximation" actually requires here.
+    """
+    mean_x, mean_y = x.mean(), y.mean()
+    var_x, var_y = x.var(), y.var()
+    covariance = ((x - mean_x) * (y - mean_y)).mean()
+    return float((2 * covariance) / (var_x + var_y + (mean_x - mean_y) ** 2))
+
+
+def _compare_auc_rollup_to_reference(df: pl.DataFrame, candidate_column: str) -> dict[str, float | int | str]:
+    """Compute agreement statistics between a candidate column and the DeLong reference."""
+    import numpy as np
+
+    pair = df.select(candidate_column, AUC_ROLLUP_REFERENCE_COLUMN).drop_nulls()
+    empty_stats = {"Bias": None, "MAE": None, "RMSE": None, "Pearson_r": None, "Lin_CCC": None}
+    if pair.height < 2:
+        return {"Metric": candidate_column, "N": pair.height, **empty_stats}
+
+    candidate = pair[candidate_column].to_numpy()
+    reference = pair[AUC_ROLLUP_REFERENCE_COLUMN].to_numpy()
+    diff = candidate - reference
+
+    return {
+        "Metric": candidate_column,
+        "N": pair.height,
+        "Bias": float(diff.mean()),
+        "MAE": float(np.abs(diff).mean()),
+        "RMSE": float(np.sqrt((diff**2).mean())),
+        "Pearson_r": float(np.corrcoef(candidate, reference)[0, 1]),
+        "Lin_CCC": _lin_ccc(candidate, reference),
+    }
+
+
+def print_auc_rollup_agreement_table(df: pl.DataFrame, *, min_delong_models: int) -> pl.DataFrame:
+    """Print how closely each AUC roll-up method agrees with the DeLong reference.
+
+    Only configurations whose DeLong estimate pools at least
+    ``min_delong_models`` models are included, since the DeLong reference
+    itself is unstable with very few models. See
+    docs/plans/adm/auc-rollup-weighting.md for the statistical rationale.
+
+    Parameters
+    ----------
+    df : pl.DataFrame
+        Rows from ``compute_auc_rollup_comparison`` across all datasets.
+    min_delong_models : int
+        Minimum ``N_Models_With_DeLong_CI`` for a configuration to be
+        included in the comparison.
+
+    Returns
+    -------
+    pl.DataFrame
+        The eligible subset of rows used for the comparison (for reuse by
+        the Bland-Altman plot).
+    """
+    eligible = df.filter(pl.col("N_Models_With_DeLong_CI") >= min_delong_models)
+    print(
+        f"\n{eligible.height} of {df.height} configurations have a DeLong estimate "
+        f"pooling >= {min_delong_models} models."
+    )
+    if eligible.height == 0:
+        return eligible
+
+    results = [_compare_auc_rollup_to_reference(eligible, column) for column in AUC_ROLLUP_CANDIDATE_COLUMNS]
+    results_df = pl.DataFrame(results).select(
+        "Metric",
+        "N",
+        pl.col("Bias").cast(pl.Float64).round(4),
+        pl.col("MAE").cast(pl.Float64).round(4),
+        pl.col("RMSE").cast(pl.Float64).round(4),
+        pl.col("Pearson_r").cast(pl.Float64).round(4),
+        pl.col("Lin_CCC").cast(pl.Float64).round(4),
+    )
+    print(f"Agreement with {AUC_ROLLUP_REFERENCE_COLUMN} (Bias/MAE/RMSE on the 0-1 AUC scale):")
+    print(results_df)
+    return eligible
+
+
+def generate_auc_rollup_bland_altman_plot(
+    eligible_df: pl.DataFrame,
+    *,
+    output_dir: Path,
+) -> Path | None:
+    """Render a Bland-Altman plot comparing RespCnt/PosNeg weighting against DeLong.
+
+    For each candidate method, plots (mean of candidate & reference) on the
+    x-axis against (candidate - reference) on the y-axis, with the mean
+    bias and +/-1.96 SD limits of agreement annotated. This makes any
+    systematic offset or scale-dependent disagreement visible directly,
+    which plain scatter/correlation plots do not.
+
+    Parameters
+    ----------
+    eligible_df : pl.DataFrame
+        Rows already filtered to configurations with a reliable DeLong
+        estimate (see ``print_auc_rollup_agreement_table``).
+    output_dir : Path
+        Directory to write the plot to.
+
+    Returns
+    -------
+    Path | None
+        The written plot path, or None if there wasn't enough data.
+    """
+    if eligible_df.height < 2:
+        return None
+
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("  ℹ matplotlib not installed — skipping AUC roll-up Bland-Altman plot")
+        return None
+
+    candidates = [
+        ("AUC_Weighted_ResponseCount", "#e11d48", "RespCnt (current)"),
+        ("AUC_Weighted_PosNeg", "#2563eb", "PosNeg (proposed)"),
+        ("AUC_Weighted_Positives", "#16a34a", "Positives-only"),
+    ]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "auc_rollup_bland_altman.png"
+    fig, axes = plt.subplots(1, len(candidates), figsize=(6 * len(candidates), 5), dpi=160, sharey=True)
+    for ax, (column, color, label) in zip(axes, candidates, strict=True):
+        pair = eligible_df.select(column, AUC_ROLLUP_REFERENCE_COLUMN).drop_nulls()
+        if pair.height < 2:
+            continue
+        candidate = pair[column].to_numpy()
+        reference = pair[AUC_ROLLUP_REFERENCE_COLUMN].to_numpy()
+        mean_of_pair = (candidate + reference) / 2
+        diff = candidate - reference
+        bias = diff.mean()
+        limit = 1.96 * diff.std()
+
+        ax.scatter(mean_of_pair, diff, s=16, alpha=0.5, color=color)
+        ax.axhline(bias, color="black", linewidth=1.5, label=f"Bias={bias:.3f}")
+        ax.axhline(bias + limit, color="black", linestyle="--", linewidth=1, label=f"+-1.96 SD={limit:.3f}")
+        ax.axhline(bias - limit, color="black", linestyle="--", linewidth=1)
+        ax.axhline(0, color="grey", linewidth=0.8)
+        ax.set_xlabel(f"Mean of ({label}, DeLong)")
+        ax.set_title(label)
+        ax.legend(frameon=False, fontsize=8)
+        ax.grid(alpha=0.2)
+    axes[0].set_ylabel("Difference (candidate - DeLong)")
+    fig.suptitle("AUC roll-up agreement with DeLong inverse-variance reference")
+    fig.tight_layout()
+    fig.savefig(output_path)
+    plt.close(fig)
+    print(f"✓ AUC roll-up Bland-Altman plot: {output_path}")
+    return output_path
 
 
 def _generate_ci_maturity_plots(
@@ -567,6 +887,11 @@ def _generate_ci_width_plot(
     fitted = slope * log_positives + intercept
     r_squared = 1 - np.sum((log_ci_width - fitted) ** 2) / np.sum((log_ci_width - log_ci_width.mean()) ** 2)
 
+    # Constrained fit assuming the theoretical Var(AUC) ~ 1/Positives law
+    # (slope = -0.5, see docs/plans/adm/auc-rollup-weighting.md), to compare
+    # directly against a historical "CI ~= C / sqrt(Positives)" rule of thumb.
+    constrained_constant = 10 ** (log_ci_width + 0.5 * log_positives).mean()
+
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / output_filename
     fig, ax = plt.subplots(figsize=(10, 6), dpi=160)
@@ -624,6 +949,12 @@ def _generate_ci_width_plot(
     fig.savefig(output_path)
     plt.close(fig)
     print(f"  ✓ Cross-dataset CI plot: {output_path} (n={plot_df.height}, slope={slope:.3f}, R²={r_squared:.2f})")
+    print(
+        f"  ℹ 1/sqrt(Positives)-constrained fit: CI_Width ≈ {constrained_constant:.3f}/sqrt(Positives) "
+        f"(0-1 scale) ≈ {constrained_constant * 100:.2f}/sqrt(Positives) (Pega points scale); "
+        "compare to any historical CI ≈ C/sqrt(Positives) rule of thumb (free-fit slope above "
+        "should be close to -0.5 for that comparison to be meaningful)."
+    )
     return output_path
 
 
@@ -711,6 +1042,7 @@ def process_dataset(
     positives_maturity_threshold: int = 200,
     ci_maturity_dataset_rows: list[dict] | None = None,
     ci_maturity_model_rows: list[dict] | None = None,
+    auc_rollup_rows: list[dict] | None = None,
 ) -> dict:
     """Process a single dataset and generate all reports.
 
@@ -734,6 +1066,9 @@ def process_dataset(
         Optional collector receiving one dataset-level maturity metrics row.
     ci_maturity_model_rows : list[dict] | None, optional
         Optional collector receiving per-model maturity analysis rows.
+    auc_rollup_rows : list[dict] | None, optional
+        Optional collector receiving per-configuration AUC roll-up
+        weighting comparison rows (see docs/plans/adm/auc-rollup-weighting.md).
 
     Returns
     -------
@@ -898,6 +1233,12 @@ def process_dataset(
         for plot_path in dataset_plot_paths:
             print(f"  ✓ CI maturity plot: {plot_path}")
 
+        print("  → Computing AUC roll-up weighting comparison...")
+        auc_rollup_df = compute_auc_rollup_comparison(datamart)
+        _print_auc_rollup_table(auc_rollup_df)
+        if auc_rollup_rows is not None and auc_rollup_df.height > 0:
+            auc_rollup_rows.extend(auc_rollup_df.with_columns(Dataset=pl.lit(name)).to_dicts())
+
         # ── Excel export ────────────────────────────────────────────
         print("  → Generating Excel export...")
         try:
@@ -983,6 +1324,15 @@ For more information, see:
         default=200,
         help="Positives threshold for maturity segmentation (default: 200)",
     )
+    parser.add_argument(
+        "--min-delong-models",
+        type=int,
+        default=5,
+        help=(
+            "Minimum models pooled into a configuration's DeLong estimate for it to be "
+            "included in the AUC roll-up agreement analysis (default: 5)"
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1054,6 +1404,7 @@ For more information, see:
     results = []
     ci_maturity_dataset_rows: list[dict] | None = []
     ci_maturity_model_rows: list[dict] | None = []
+    auc_rollup_rows: list[dict] | None = []
     summary_dir = args.output if args.output is not None else args.data_path
     summary_dir.mkdir(parents=True, exist_ok=True)
     summary_file = summary_dir / "summary.csv"
@@ -1067,6 +1418,7 @@ For more information, see:
             positives_maturity_threshold=args.positives_maturity_threshold,
             ci_maturity_dataset_rows=ci_maturity_dataset_rows,
             ci_maturity_model_rows=ci_maturity_model_rows,
+            auc_rollup_rows=auc_rollup_rows,
         )
         results.append(result)
 
@@ -1131,6 +1483,15 @@ For more information, see:
             ci_model_df,
             output_dir=summary_dir,
         )
+
+    auc_rollup_file = summary_dir / "auc_rollup_comparison.csv"
+    if auc_rollup_rows:
+        auc_rollup_df = pl.DataFrame(auc_rollup_rows)
+        auc_rollup_df.write_csv(auc_rollup_file)
+        print(f"✓ AUC roll-up weighting comparison: {auc_rollup_file}")
+
+        eligible_df = print_auc_rollup_agreement_table(auc_rollup_df, min_delong_models=args.min_delong_models)
+        generate_auc_rollup_bland_altman_plot(eligible_df, output_dir=summary_dir)
 
     # Print statistics
     print(f"\n{'=' * 60}")

--- a/scripts/batch_healthcheck.py
+++ b/scripts/batch_healthcheck.py
@@ -555,7 +555,13 @@ def compute_auc_rollup_comparison(datamart: ADMDatamart) -> pl.DataFrame:
         active_range = (
             datamart.active_ranges(variance_model_ids)
             .filter(pl.col("AUC_ActiveRange_CI_Available"))
-            .select("ModelID", "AUC_ActiveRange", "AUC_ActiveRange_CI_Variance")
+            .select(
+                "ModelID",
+                "AUC_ActiveRange",
+                "AUC_ActiveRange_CI_Variance",
+                "AUC_ActiveRange_CI_Estimate",
+                "AUC_ActiveRange_CI_Scope",
+            )
             .collect()
         )
         per_model = per_model.join(active_range, on="ModelID", how="left")
@@ -563,6 +569,8 @@ def compute_auc_rollup_comparison(datamart: ADMDatamart) -> pl.DataFrame:
         per_model = per_model.with_columns(
             pl.lit(None, dtype=pl.Float64).alias("AUC_ActiveRange"),
             pl.lit(None, dtype=pl.Float64).alias("AUC_ActiveRange_CI_Variance"),
+            pl.lit(None, dtype=pl.Float64).alias("AUC_ActiveRange_CI_Estimate"),
+            pl.lit(None, dtype=pl.String).alias("AUC_ActiveRange_CI_Scope"),
         )
 
     rows = []
@@ -593,15 +601,27 @@ def compute_auc_rollup_comparison(datamart: ADMDatamart) -> pl.DataFrame:
         variance_group = group.filter(
             pl.col("AUC_ActiveRange_CI_Variance").is_not_null() & (pl.col("AUC_ActiveRange_CI_Variance") > 0)
         )
-        inverse_variance_result = (
-            cdh_utils.weighted_auc_ci_from_estimates(
-                auc=variance_group["AUC_ActiveRange"],
-                variance=variance_group["AUC_ActiveRange_CI_Variance"],
-                weights=1.0 / variance_group["AUC_ActiveRange_CI_Variance"],
+        if variance_group.height > 0:
+            # AGB segments sharing one fitted ensemble already carry the same
+            # pooled configuration-level CI (AUC_ActiveRange_CI_Scope ==
+            # "configuration"); take it once instead of re-pooling it once per
+            # segment row, which would double-count the same evidence and
+            # understate the resulting uncertainty. NB rows (scope == "model")
+            # are independent per-model estimates and are pooled as before.
+            configuration_scoped = variance_group.filter(pl.col("AUC_ActiveRange_CI_Scope") == "configuration")
+            model_scoped = variance_group.filter(pl.col("AUC_ActiveRange_CI_Scope") != "configuration")
+            estimate_auc = model_scoped["AUC_ActiveRange"].to_list()
+            estimate_variance = model_scoped["AUC_ActiveRange_CI_Variance"].to_list()
+            if configuration_scoped.height > 0:
+                estimate_auc.append(configuration_scoped["AUC_ActiveRange_CI_Estimate"][0])
+                estimate_variance.append(configuration_scoped["AUC_ActiveRange_CI_Variance"][0])
+            inverse_variance_result = cdh_utils.weighted_auc_ci_from_estimates(
+                auc=estimate_auc,
+                variance=estimate_variance,
+                weights=[1.0 / v for v in estimate_variance],
             )
-            if variance_group.height > 0
-            else {"auc": None, "ci_lower": None, "ci_upper": None}
-        )
+        else:
+            inverse_variance_result = {"auc": None, "ci_lower": None, "ci_upper": None}
 
         rows.append(
             {

--- a/scripts/batch_healthcheck.py
+++ b/scripts/batch_healthcheck.py
@@ -500,16 +500,21 @@ def compute_auc_rollup_comparison(datamart: ADMDatamart) -> pl.DataFrame:
 
     Reports, for each ``Configuration``, the per-model AUC aggregated with
     seven weighting schemes: an unweighted (naive) average, the current
-    ResponseCount-weighted average, a Positives*Negatives-weighted average,
-    a Positives-only-weighted average (a closer DeLong approximation than
-    Positives*Negatives when Negatives >> Positives, since AUC variance is
-    then governed almost entirely by Positives; see
+    ResponseCount-weighted average, a pair-count Positives*Negatives-weighted
+    average (the ratio of total concordant positive-negative pairs to total
+    eligible pairs under conventional empirical AUC), a Positives-only-weighted
+    average (a potentially closer approximation to the conditional
+    inverse-variance benchmark than Positives*Negatives when Negatives >>
+    Positives, since AUC variance is then governed almost entirely by
+    Positives; see
     docs/plans/adm/auc-rollup-weighting.md), the same weighted averages
     restricted to models with at least one positive (a cheap way to check
     whether zero-positive models are what drives the response-count-weighted
     average away from the others), and a DeLong inverse-variance-weighted
-    average (the statistically optimal way to pool independent AUC
-    estimates).
+    average based on grouped-bin variance estimates. The latter is a
+    conditional fixed-effect benchmark for independent estimates of one
+    common AUC, not a universally correct target for heterogeneous or
+    correlated model rows.
 
     Parameters
     ----------
@@ -602,7 +607,8 @@ def compute_auc_rollup_comparison(datamart: ADMDatamart) -> pl.DataFrame:
             # "configuration"); take it once instead of re-pooling it once per
             # segment row, which would double-count the same evidence and
             # understate the resulting uncertainty. NB rows (scope == "model")
-            # are independent per-model estimates and are pooled as before.
+            # are treated as independent per-model estimates by this
+            # conditional benchmark and are pooled as before.
             configuration_scoped = variance_group.filter(pl.col("AUC_ActiveRange_CI_Scope") == "configuration")
             model_scoped = variance_group.filter(pl.col("AUC_ActiveRange_CI_Scope") != "configuration")
             estimate_auc = model_scoped["AUC_ActiveRange"].to_list()
@@ -615,8 +621,10 @@ def compute_auc_rollup_comparison(datamart: ADMDatamart) -> pl.DataFrame:
                 variance=estimate_variance,
                 weights=[1.0 / v for v in estimate_variance],
             )
+            n_delong_estimates = model_scoped.height + int(configuration_scoped.height > 0)
         else:
             inverse_variance_result = {"auc": None, "ci_lower": None, "ci_upper": None}
+            n_delong_estimates = 0
 
         rows.append(
             {
@@ -629,7 +637,7 @@ def compute_auc_rollup_comparison(datamart: ADMDatamart) -> pl.DataFrame:
                 "N_Models_With_Positives": positives_group.height,
                 "AUC_Weighted_ResponseCount_PositivesOnly": weighted_response_count_pos_only,
                 "AUC_Weighted_PosNeg_PositivesOnly": weighted_pos_neg_pos_only,
-                "N_Models_With_DeLong_CI": variance_group.height,
+                "N_DeLong_Estimates": n_delong_estimates,
                 "AUC_Weighted_InverseVariance_DeLong": inverse_variance_result["auc"],
                 "AUC_InverseVariance_DeLong_CI_Lower": inverse_variance_result["ci_lower"],
                 "AUC_InverseVariance_DeLong_CI_Upper": inverse_variance_result["ci_upper"],
@@ -655,15 +663,16 @@ def _print_auc_rollup_table(df: pl.DataFrame) -> None:
         (pl.col("AUC_Weighted_ResponseCount_PositivesOnly") * 100).round(1).alias("RespCnt+"),
         (pl.col("AUC_Weighted_PosNeg_PositivesOnly") * 100).round(1).alias("PosNeg+"),
         (pl.col("AUC_Weighted_InverseVariance_DeLong") * 100).round(1).alias("DeLong"),
-        pl.col("N_Models_With_DeLong_CI").alias("N_DeLong"),
+        pl.col("N_DeLong_Estimates").alias("N_DeLong"),
     )
     with pl.Config(tbl_rows=-1, tbl_cols=-1, tbl_width_chars=-1, fmt_str_lengths=40):
         print(display_df)
 
 
-# Reference method: the statistically correct pooling of independent AUC
-# estimates (see docs/plans/adm/auc-rollup-weighting.md). All other
-# aggregation methods are compared against it below.
+# Conditional comparison benchmark: inverse-variance pooling of eligible
+# model- or configuration-scoped AUC estimates (see
+# docs/plans/adm/auc-rollup-weighting.md). All other aggregation methods are
+# compared against it below.
 AUC_ROLLUP_REFERENCE_COLUMN = "AUC_Weighted_InverseVariance_DeLong"
 AUC_ROLLUP_CANDIDATE_COLUMNS = [
     "AUC_Weighted_ResponseCount",
@@ -689,7 +698,7 @@ def _lin_ccc(x, y) -> float:
 
 
 def _compare_auc_rollup_to_reference(df: pl.DataFrame, candidate_column: str) -> dict[str, float | int | str]:
-    """Compute agreement statistics between a candidate column and the DeLong reference."""
+    """Compute agreement statistics against the inverse-variance benchmark."""
     import numpy as np
 
     pair = df.select(candidate_column, AUC_ROLLUP_REFERENCE_COLUMN).drop_nulls()
@@ -712,21 +721,21 @@ def _compare_auc_rollup_to_reference(df: pl.DataFrame, candidate_column: str) ->
     }
 
 
-def print_auc_rollup_agreement_table(df: pl.DataFrame, *, min_delong_models: int) -> pl.DataFrame:
-    """Print how closely each AUC roll-up method agrees with the DeLong reference.
+def print_auc_rollup_agreement_table(df: pl.DataFrame, *, min_delong_estimates: int) -> pl.DataFrame:
+    """Print how closely each AUC roll-up method agrees with the benchmark.
 
-    Only configurations whose DeLong estimate pools at least
-    ``min_delong_models`` models are included, since the DeLong reference
-    itself is unstable with very few models. See
+    Only configurations whose benchmark combines at least
+    ``min_delong_estimates`` estimates are included, since the comparison
+    is unstable with very few estimates. See
     docs/plans/adm/auc-rollup-weighting.md for the statistical rationale.
 
     Parameters
     ----------
     df : pl.DataFrame
         Rows from ``compute_auc_rollup_comparison`` across all datasets.
-    min_delong_models : int
-        Minimum ``N_Models_With_DeLong_CI`` for a configuration to be
-        included in the comparison.
+    min_delong_estimates : int
+        Minimum ``N_DeLong_Estimates`` for a configuration to be included in
+        the comparison.
 
     Returns
     -------
@@ -734,10 +743,10 @@ def print_auc_rollup_agreement_table(df: pl.DataFrame, *, min_delong_models: int
         The eligible subset of rows used for the comparison (for reuse by
         the Bland-Altman plot).
     """
-    eligible = df.filter(pl.col("N_Models_With_DeLong_CI") >= min_delong_models)
+    eligible = df.filter(pl.col("N_DeLong_Estimates") >= min_delong_estimates)
     print(
-        f"\n{eligible.height} of {df.height} configurations have a DeLong estimate "
-        f"pooling >= {min_delong_models} models."
+        f"\n{eligible.height} of {df.height} configurations have an inverse-variance "
+        f"estimate combining >= {min_delong_estimates} estimates."
     )
     if eligible.height == 0:
         return eligible
@@ -752,7 +761,10 @@ def print_auc_rollup_agreement_table(df: pl.DataFrame, *, min_delong_models: int
         pl.col("Pearson_r").cast(pl.Float64).round(4),
         pl.col("Lin_CCC").cast(pl.Float64).round(4),
     )
-    print(f"Agreement with {AUC_ROLLUP_REFERENCE_COLUMN} (Bias/MAE/RMSE on the 0-1 AUC scale):")
+    print(
+        f"Agreement with {AUC_ROLLUP_REFERENCE_COLUMN} "
+        "(conditional DeLong-style inverse-variance benchmark; Bias/MAE/RMSE on the 0-1 AUC scale):"
+    )
     print(results_df)
     return eligible
 
@@ -762,7 +774,7 @@ def generate_auc_rollup_bland_altman_plot(
     *,
     output_dir: Path,
 ) -> Path | None:
-    """Render a Bland-Altman plot comparing RespCnt/PosNeg weighting against DeLong.
+    """Render a Bland-Altman plot against the conditional inverse-variance benchmark.
 
     For each candidate method, plots (mean of candidate & reference) on the
     x-axis against (candidate - reference) on the y-axis, with the mean
@@ -773,7 +785,7 @@ def generate_auc_rollup_bland_altman_plot(
     Parameters
     ----------
     eligible_df : pl.DataFrame
-        Rows already filtered to configurations with a reliable DeLong
+        Rows already filtered to configurations with an eligible benchmark
         estimate (see ``print_auc_rollup_agreement_table``).
     output_dir : Path
         Directory to write the plot to.
@@ -794,7 +806,7 @@ def generate_auc_rollup_bland_altman_plot(
 
     candidates = [
         ("AUC_Weighted_ResponseCount", "#e11d48", "RespCnt (current)"),
-        ("AUC_Weighted_PosNeg", "#2563eb", "PosNeg (proposed)"),
+        ("AUC_Weighted_PosNeg", "#2563eb", "PosNeg (pair-pooled)"),
         ("AUC_Weighted_Positives", "#16a34a", "Positives-only"),
     ]
 
@@ -817,12 +829,12 @@ def generate_auc_rollup_bland_altman_plot(
         ax.axhline(bias + limit, color="black", linestyle="--", linewidth=1, label=f"+-1.96 SD={limit:.3f}")
         ax.axhline(bias - limit, color="black", linestyle="--", linewidth=1)
         ax.axhline(0, color="grey", linewidth=0.8)
-        ax.set_xlabel(f"Mean of ({label}, DeLong)")
+        ax.set_xlabel(f"Mean of ({label}, DeLong-style IVW)")
         ax.set_title(label)
         ax.legend(frameon=False, fontsize=8)
         ax.grid(alpha=0.2)
-    axes[0].set_ylabel("Difference (candidate - DeLong)")
-    fig.suptitle("AUC roll-up agreement with DeLong inverse-variance reference")
+    axes[0].set_ylabel("Difference (candidate - DeLong-style IVW)")
+    fig.suptitle("AUC roll-up agreement with conditional DeLong-style IVW benchmark")
     fig.tight_layout()
     fig.savefig(output_path)
     plt.close(fig)
@@ -1340,11 +1352,13 @@ For more information, see:
         help="Positives threshold for maturity segmentation (default: 200)",
     )
     parser.add_argument(
+        "--min-delong-estimates",
         "--min-delong-models",
+        dest="min_delong_estimates",
         type=int,
         default=5,
         help=(
-            "Minimum models pooled into a configuration's DeLong estimate for it to be "
+            "Minimum inverse-variance estimates combined for a configuration to be "
             "included in the AUC roll-up agreement analysis (default: 5)"
         ),
     )
@@ -1505,7 +1519,10 @@ For more information, see:
         auc_rollup_df.write_csv(auc_rollup_file)
         print(f"✓ AUC roll-up weighting comparison: {auc_rollup_file}")
 
-        eligible_df = print_auc_rollup_agreement_table(auc_rollup_df, min_delong_models=args.min_delong_models)
+        eligible_df = print_auc_rollup_agreement_table(
+            auc_rollup_df,
+            min_delong_estimates=args.min_delong_estimates,
+        )
         generate_auc_rollup_bland_altman_plot(eligible_df, output_dir=summary_dir)
 
     # Print statistics

--- a/scripts/batch_healthcheck.py
+++ b/scripts/batch_healthcheck.py
@@ -373,57 +373,52 @@ def _compute_ci_maturity_analysis(
             key: value for technique in techniques for key, value in _empty_ci_metrics(technique).items()
         }, pl.DataFrame()
 
-    analysis_rows: list[dict] = []
-    for row in active_agg.iter_rows(named=True):
-        model_id = row["ModelID"]
-        ci_data = {
-            "AUC_ActiveRange": None,
-            "AUC_ActiveRange_CI_Lower": None,
-            "AUC_ActiveRange_CI_Upper": None,
-            "AUC_ActiveRange_CI_Available": False,
-            "AUC_ActiveRange_CI_Reason": "analysis_error",
-        }
-        try:
-            ar = (
-                datamart.active_ranges(model_id)
-                .collect()
-                .select(
-                    "AUC_ActiveRange",
-                    "AUC_ActiveRange_CI_Lower",
-                    "AUC_ActiveRange_CI_Upper",
-                    "AUC_ActiveRange_CI_Available",
-                    "AUC_ActiveRange_CI_Reason",
-                )
+    model_ids_needing_ci = active_agg["ModelID"].to_list()
+    empty_ci_columns = {
+        "AUC_ActiveRange": pl.Series([], dtype=pl.Float64),
+        "AUC_ActiveRange_CI_Lower": pl.Series([], dtype=pl.Float64),
+        "AUC_ActiveRange_CI_Upper": pl.Series([], dtype=pl.Float64),
+        "AUC_ActiveRange_CI_Available": pl.Series([], dtype=pl.Boolean),
+        "AUC_ActiveRange_CI_Reason": pl.Series([], dtype=pl.Utf8),
+    }
+    try:
+        # Compute active ranges for every model in one batched call instead of
+        # once per model: active_ranges() re-scans the (potentially huge)
+        # predictor data on every invocation, so calling it per model in a
+        # Python loop makes this step scale with model count times predictor
+        # size rather than just predictor size, and can take hours on large
+        # customer exports.
+        active_ranges_df = (
+            datamart.active_ranges(model_ids_needing_ci)
+            .select(
+                "ModelID",
+                "AUC_ActiveRange",
+                "AUC_ActiveRange_CI_Lower",
+                "AUC_ActiveRange_CI_Upper",
+                "AUC_ActiveRange_CI_Available",
+                "AUC_ActiveRange_CI_Reason",
             )
-            if ar.height > 0:
-                ci_data = {
-                    "AUC_ActiveRange": ar["AUC_ActiveRange"][0],
-                    "AUC_ActiveRange_CI_Lower": ar["AUC_ActiveRange_CI_Lower"][0],
-                    "AUC_ActiveRange_CI_Upper": ar["AUC_ActiveRange_CI_Upper"][0],
-                    "AUC_ActiveRange_CI_Available": ar["AUC_ActiveRange_CI_Available"][0],
-                    "AUC_ActiveRange_CI_Reason": ar["AUC_ActiveRange_CI_Reason"][0],
-                }
-        except Exception:
-            # Keep model-level maturity rows even when CI cannot be computed.
-            pass
-
-        analysis_rows.append(
-            {
-                "ModelID": model_id,
-                "ModelTechnique": row["ModelTechnique"],
-                "Positives": row["Positives"],
-                "ResponseCount": row["ResponseCount"],
-                "IsActiveLast30Days": True,
-                **ci_data,
-            }
+            .collect()
+        )
+    except Exception:
+        active_ranges_df = pl.DataFrame(
+            {"ModelID": pl.Series([], dtype=active_agg["ModelID"].dtype), **empty_ci_columns}
         )
 
-    model_level = pl.DataFrame(analysis_rows).with_columns(
-        CI_Width=(pl.col("AUC_ActiveRange_CI_Upper") - pl.col("AUC_ActiveRange_CI_Lower")),
-        PositivesSegment=pl.when(pl.col("Positives") > positives_maturity_threshold)
-        .then(pl.lit(f">{positives_maturity_threshold}"))
-        .otherwise(pl.lit(f"<={positives_maturity_threshold}")),
-        MaturitySegmentAboveThreshold=pl.col("Positives") > positives_maturity_threshold,
+    model_level = (
+        active_agg.join(active_ranges_df, on="ModelID", how="left")
+        .with_columns(
+            IsActiveLast30Days=pl.lit(True),
+            AUC_ActiveRange_CI_Available=pl.col("AUC_ActiveRange_CI_Available").fill_null(False),
+            AUC_ActiveRange_CI_Reason=pl.col("AUC_ActiveRange_CI_Reason").fill_null("analysis_error"),
+        )
+        .with_columns(
+            CI_Width=(pl.col("AUC_ActiveRange_CI_Upper") - pl.col("AUC_ActiveRange_CI_Lower")),
+            PositivesSegment=pl.when(pl.col("Positives") > positives_maturity_threshold)
+            .then(pl.lit(f">{positives_maturity_threshold}"))
+            .otherwise(pl.lit(f"<={positives_maturity_threshold}")),
+            MaturitySegmentAboveThreshold=pl.col("Positives") > positives_maturity_threshold,
+        )
     )
 
     metrics = {}


### PR DESCRIPTION
## Summary

Investigates whether the current `ResponseCount`-weighted AUC roll-up
(used e.g. in `Aggregates.model_summary`) is statistically well-founded,
per docs/plans/adm/auc-rollup-weighting.md.

- Adds `compute_auc_rollup_comparison` to `scripts/batch_healthcheck.py`:
  compares five AUC aggregation methods per model `Configuration` (naive
  mean, current `ResponseCount`-weighted, `Positives*Negatives`-weighted,
  `Positives`-only-weighted, and DeLong inverse-variance-weighted), plus
  two `*_PositivesOnly` diagnostic variants.
- Writes results to `auc_rollup_comparison.csv`, prints a per-dataset
  comparison table, and adds an agreement table + Bland-Altman plot
  against the DeLong reference (`print_auc_rollup_agreement_table`,
  `generate_auc_rollup_bland_altman_plot`).
- Adds a constrained `1/sqrt(Positives)` power-law fit to the existing
  CI-width plots to empirically estimate the CI-vs-Positives relationship.
- Updates `compute_auc_rollup_comparison` to use the pooled
  configuration-level DeLong CI for AGB (from PR #948's
  `AUC_ActiveRange_CI_Scope`) instead of re-pooling it per segment row,
  which would double-count evidence.
- No changes to `python/pdstools` library code.

## Conclusions (see plan doc for full detail)

Run across the full private customer corpus: `PosNeg`- and
`Positives`-only-weighted roll-ups track the DeLong (statistically
correct) reference far more closely than the current `ResponseCount`
weighting, and are feasible drop-in replacements requiring no
classifier/predictor bin data. However, **the library default is not
being changed as part of this PR** -- see the plan doc's "Decision: keep
the current `ResponseCount`-weighted default for now" section for the
reasoning (AGB not yet empirically validated; the two weightings answer
different questions).

